### PR TITLE
explicitly turn highlighting on in frontend

### DIFF
--- a/src/api/document.js
+++ b/src/api/document.js
@@ -47,7 +47,7 @@ export async function searchDocuments(
 ) {
   // Return documents with the specified parameters
   const url = apiUrl(
-    queryBuilder("documents/search/", { q: query, expand, page: page + 1 })
+    queryBuilder("documents/search/", { q: query, expand, page: page + 1, hl: "true" })
   );
   const { data } = await session.get(url);
   data.results = data.results.map(doc => new Document(doc));


### PR DESCRIPTION
I want to turn highlighting off by default so API users aren't using it by default, making things quicker.  This just turns highlighting on explicitly for the frontend.