### PR TITLE
Fix draggable so no highlight when unverified

### DIFF
--- a/src/pages/app/Documents.svelte
+++ b/src/pages/app/Documents.svelte
@@ -288,7 +288,7 @@
     <div class="docscontainer">
       <Draggable
         on:files={showUploadModal}
-        disabled={embed || !$orgsAndUsers.loggedIn}
+        disabled={embed || !$orgsAndUsers.loggedIn || !$orgsAndUsers.isVerified}
       >
         {#each $documents.documents as document (document.id)}
           <div class:inlinecard={embed} animate:flip={{ duration: 400 }}>


### PR DESCRIPTION
The front login page now checks if you have the verified journalist tag on your account needed for upload before showing a draggable highlight in the drop area. This should draw the user's attention to the warning there of what they can do.