### PR TITLE
Verify button call to action

### DIFF
--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -441,7 +441,8 @@
     "verify4": "If your organization has not been verified yet, or if you're a freelancer, <a target=\"_blank\" href=\"https://www.muckrock.com/assignment/request-account-verification-377/form/\">request verification here</a>. Requests usually take two business days to process.",
     "uploadFirst": "Upload your first document",
     "upload1": "Upload a document file to get started using DocumentCloud. You can drag the file into this window, or click on the blue “Upload” button above.",
-    "upload2": "Once you upload a file, DocumentCloud will process the document and extract its contents. It may take a few minutes for this to complete, but once it’s done your document will be optimized for analysis and sharing on the web."
+    "upload2": "Once you upload a file, DocumentCloud will process the document and extract its contents. It may take a few minutes for this to complete, but once it’s done your document will be optimized for analysis and sharing on the web.",
+    "requestVerificationAction": "Request Verification to Upload"
   },
   "paginator": {
     "of": "of",

--- a/src/pages/app/Documents.svelte
+++ b/src/pages/app/Documents.svelte
@@ -276,7 +276,13 @@
               >+ {$_("documents.upload")}</Button
             >
           {/if}
+          {#if $orgsAndUsers.loggedIn && !$orgsAndUsers.isVerified}
+          <a href="https://www.muckrock.com/assignment/request-account-verification-377/form/" target="_new">
+            <Button>{$_("noDocuments.requestVerificationAction")}</Button>
+          </a>
+          {/if}
         {/if}
+        
       </div>
       {#if !embed}
         <ActionBar />


### PR DESCRIPTION
An unverified user sees a new call to action button: 
![image](https://user-images.githubusercontent.com/283343/152819908-3c2088ea-0d59-4532-8993-90e9917f941d.png)

It opens a new tab to: https://www.muckrock.com/assignment/request-account-verification-377/form/
Should this string of this URL be localized?

A verified user doesn't see any change: <img width="1079" alt="image" src="https://user-images.githubusercontent.com/283343/152819746-7a5e9c2f-37da-4156-beb8-8c098820e9f3.png">
