### PR TITLE
Correct command require privilege escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ make dev
 Set up your hosts:
 
 ```bash
-sudo echo "127.0.0.1 www.dev.documentcloud.org" >> /etc/hosts
+echo "127.0.0.1 www.dev.documentcloud.org" | sudo tee -a /etc/hosts
 ```
 
 Once everything is up and running, you should be able to see the website live at [www.dev.documentcloud.org](http://www.dev.documentcloud.org/).


### PR DESCRIPTION
Because output redirection is a service offered by the command-line
interpreter, the `sudo` utility has no effect on its permissions. Use
the `pipe` utility (available on by default on GNU/Linux and macOS
systems) to guarantee that the "write" operation described by this
instruction runs with administrative privileges.