### PR TITLE
Update Makefile to use docker<space>compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,39 @@
 install:
-	docker volume create nodemodules && docker-compose -f local.builder.yml run --rm install
+	docker volume create nodemodules && docker compose -f local.builder.yml run --rm install
 
 install-ci:
-	docker volume create nodemodules && docker-compose -f local.builder.yml run --rm install-ci
+	docker volume create nodemodules && docker compose -f local.builder.yml run --rm install-ci
 
 
 npmlist:
-	docker-compose -f local.builder.yml run --rm npmlist
+	docker compose -f local.builder.yml run --rm npmlist
 
 build:
-	docker-compose -f local.builder.yml run --rm build
+	docker compose -f local.builder.yml run --rm build
 
 build-staging:
-	docker-compose -f local.builder.yml run --rm build_staging
+	docker compose -f local.builder.yml run --rm build_staging
 
 dev:
-	docker-compose -f local.yml up documentcloud_frontend
+	docker compose -f local.yml up documentcloud_frontend
 
 dev-app:
-	docker-compose -f local.yml up documentcloud_frontend_app
+	docker compose -f local.yml up documentcloud_frontend_app
 
 dev-embed:
-	docker-compose -f local.yml up documentcloud_frontend_embed
+	docker compose -f local.yml up documentcloud_frontend_embed
 
 build-serve:
-	docker-compose -f local.yml up documentcloud_frontend_build
+	docker compose -f local.yml up documentcloud_frontend_build
 
 build-analyze:
-	docker-compose -f local.yml up documentcloud_frontend_analyze
+	docker compose -f local.yml up documentcloud_frontend_analyze
 
 test:
-	docker-compose -f local.builder.yml run --rm test
+	docker compose -f local.builder.yml run --rm test
 
 test-watch:
-	docker-compose -f local.builder.yml run --rm test-watch
+	docker compose -f local.builder.yml run --rm test-watch
 
 prettier-check:
 	prettier --check --plugin-search-dir=. src	


### PR DESCRIPTION
Update Makefile to use docker<space>compose because docker<dash>compose is deprecated. `docker-compose` is thus difficult (impossible?) to update now, and if you have a `docker-compose` too old to run the local.yaml, you're in a tough spot.