### PR TITLE
Add robots meta tag if the document has hideFromGoogle set.

### DIFF
--- a/src/pages/viewer/Viewer.svelte
+++ b/src/pages/viewer/Viewer.svelte
@@ -85,6 +85,9 @@
     <!-- Insert canonical URL -->
     <link rel="canonical" href={$viewer.document.canonicalUrl} />
 
+    {#if $viewer.document && $viewer.document.hideFromGoogle}
+      <meta name="robots" content="noindex">
+    {/if}
     <!-- Social cards -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="og:url" content={$viewer.document.canonicalUrl} />


### PR DESCRIPTION
This is the first part of the implementation of the de-indexing feature. Adding this tag when rendering documents with this flag set should let Google know not to index this. This goes along with a corresponding PR in the backend.