### PR TITLE
Fix global selectors on FlatPage.svelte

### DIFF
--- a/src/pages/FlatPage.svelte
+++ b/src/pages/FlatPage.svelte
@@ -250,7 +250,8 @@
         }
       }
 
-      :global(h5, h6) {
+      :global(h5),
+      :global(h6) {
         font-weight: bold;
       }
 
@@ -298,7 +299,8 @@
         border-collapse: collapse;
       }
 
-      :global(td, th) {
+      :global(td),
+      :global(th) {
         border: solid 1px #d1d6dc;
         padding: 6px 12px;
         vertical-align: middle;


### PR DESCRIPTION
Updated Svelte doesn't allow selectors like `:global(h5, h6)`, so this splits them.