### PR TITLE
Add plausible to App and Viewer for logged-in users

### DIFF
--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -5,6 +5,7 @@
 
   import { layout } from "@/manager/layout";
   import { documents } from "@/manager/documents";
+  import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
 
   let sidebar = null;
 
@@ -15,6 +16,11 @@
 
 <svelte:head>
   <title>{$_("common.documentCloud")}</title>
+
+  {#if $orgsAndUsers.me !== null}<script
+      defer
+      data-domain="documentcloud.org"
+      src="https://plausible.io/js/script.js"></script>{/if}
 </svelte:head>
 
 <div>

--- a/src/pages/app/sidebar/OrgUsers.svelte
+++ b/src/pages/app/sidebar/OrgUsers.svelte
@@ -1,8 +1,7 @@
 <script>
-  import Title from "@/common/Title";
-  import Link from "@/router/Link";
-  import { orgsAndUsers } from "@/manager/orgsAndUsers";
-  import { userUrl, orgUrl } from "@/search/search";
+  import Link from "@/router/Link.svelte";
+  import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
+  import { userUrl, orgUrl } from "@/search/search.js";
 
   import { _ } from "svelte-i18n";
 </script>

--- a/src/pages/viewer/Viewer.svelte
+++ b/src/pages/viewer/Viewer.svelte
@@ -79,7 +79,9 @@
       }
     }
 
-    initOrgsAndUsers();
+    if (!$viewer.embed) {
+      initOrgsAndUsers().then(console.log);
+    }
   });
 </script>
 

--- a/src/pages/viewer/Viewer.svelte
+++ b/src/pages/viewer/Viewer.svelte
@@ -11,6 +11,7 @@
   import Progress from "@/common/Progress";
   import Button from "@/common/Button";
   import { embedUrl } from "@/api/embed";
+  import { orgsAndUsers, initOrgsAndUsers } from "@/manager/orgsAndUsers.js";
   import { _ } from "svelte-i18n";
 
   // Dialogs
@@ -77,6 +78,8 @@
         return;
       }
     }
+
+    initOrgsAndUsers();
   });
 </script>
 
@@ -86,7 +89,7 @@
     <link rel="canonical" href={$viewer.document.canonicalUrl} />
 
     {#if $viewer.document && $viewer.document.noindex}
-      <meta name="robots" content="noindex">
+      <meta name="robots" content="noindex" />
     {/if}
     <!-- Social cards -->
     <meta property="twitter:card" content="summary_large_image" />
@@ -108,6 +111,11 @@
       content={pageImageUrl($viewer.document, 0, 700, 1)}
     />
   {/if}
+
+  {#if !$viewer.embed && $orgsAndUsers.me !== null}<script
+      defer
+      data-domain="documentcloud.org"
+      src="https://plausible.io/js/script.js"></script>{/if}
 </svelte:head>
 
 {#if $layout.error}


### PR DESCRIPTION
Does what it says on the tin.

I'm adding our Plausible script tag in <svelte:head> wrapped in a login check. This just sends pageviews right now. Will add event tracking if we like this approach.

We don't load the script if you're not logged in, or if you're in an embed.