### PR TITLE
Production: Obscure document slugs in analytics for privacy

### DIFF
--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -24,6 +24,8 @@
       function () {
         (window.plausible.q = window.plausible.q || []).push(arguments);
       };
+
+    plausible("pageview");
   });
 </script>
 
@@ -33,7 +35,7 @@
   {#if $orgsAndUsers.me !== null}<script
       defer
       data-domain="documentcloud.org"
-      src="https://plausible.io/js/script.tagged-events.js"></script>{/if}
+      src="https://plausible.io/js/script.manual.tagged-events.js"></script>{/if}
 </svelte:head>
 
 <div>

--- a/src/pages/viewer/Viewer.svelte
+++ b/src/pages/viewer/Viewer.svelte
@@ -68,7 +68,7 @@
     ],
   ];
 
-  onMount(() => {
+  onMount(async () => {
     const hash = window.location.hash;
     for (let i = 0; i < navHandlers.length; i++) {
       const [regex, handler] = navHandlers[i];
@@ -80,9 +80,27 @@
     }
 
     if (!$viewer.embed) {
-      initOrgsAndUsers();
+      await initOrgsAndUsers();
+
+      plausible("pageview", { u: obscureURL() });
     }
   });
+
+  // create a URL that won't leak the document slug
+  function obscureURL() {
+    const u = new URL(window.location);
+    const path_re = /documents\/(\d+)-(.+)/;
+
+    // if we're somehow not on a normal doc URL
+    if (!path_re.test(u.pathname)) {
+      return u.href;
+    }
+
+    const [p, id, slug] = path_re.exec(u.pathname);
+    u.pathname = u.pathname.replace(slug, "obscure");
+
+    return u.toString();
+  }
 </script>
 
 <svelte:head>
@@ -117,7 +135,7 @@
   {#if !$viewer.embed && $orgsAndUsers.me !== null}<script
       defer
       data-domain="documentcloud.org"
-      src="https://plausible.io/js/script.tagged-events.js"></script>{/if}
+      src="https://plausible.io/js/script.manual.tagged-events.js"></script>{/if}
 </svelte:head>
 
 {#if $layout.error}


### PR DESCRIPTION
This replaces the slug in a document URL with `obscure`, so `/documents/23702579-boston_covid-19_vaccination_report_10may2021` looks like `/documents/23702579-obscure` in the analytics dashboard.
