### PR TITLE
add on routing

### DIFF
--- a/src/Main.svelte
+++ b/src/Main.svelte
@@ -27,6 +27,9 @@
         window.location.href,
       );
     }
+
+    // debug
+    window.router = router;
   });
 
   function handleBackNav(e) {
@@ -36,7 +39,8 @@
 </script>
 
 <style lang="scss">
-  :global(input), :global(select) {
+  :global(input),
+  :global(select) {
     padding: 4px 10px;
     font-family: inherit;
     font-size: 16px;

--- a/src/common/dialog/AddonBrowserDialog.svelte
+++ b/src/common/dialog/AddonBrowserDialog.svelte
@@ -1,4 +1,8 @@
 <script>
+  import SvelteMarkdown from "svelte-markdown";
+  import { _ } from "svelte-i18n";
+  import debounce from "lodash/debounce";
+
   import Button from "@/common/Button.svelte";
   import {
     addons,
@@ -6,10 +10,6 @@
     getBrowserAddons,
   } from "@/manager/addons.js";
   import emitter from "@/emit.js";
-
-  import SvelteMarkdown from "svelte-markdown";
-  import { _ } from "svelte-i18n";
-  import debounce from "lodash/debounce";
 
   const emit = emitter({
     dismiss() {},

--- a/src/common/dialog/AddonDispatchTsDialog.svelte
+++ b/src/common/dialog/AddonDispatchTsDialog.svelte
@@ -54,13 +54,12 @@
   }
   let showEventInfo = eventSelectOptions.length > 0;
 
-  // debug
-  $: console.log(events);
-
   onMount(async () => {
     events = await getAddonEvents(layout.addonDispatchOpen.id);
     if (layout.addOnEvent) {
       eventSelect = layout.addOnEvent;
+      activeEvent = events.find((e) => e.id === layout.addOnEvent);
+      loadEvent(activeEvent);
     }
   });
 
@@ -105,7 +104,6 @@
 
   // generate a hash URL for each addon event
   function eventUrl(event) {
-    console.log(event);
     const id = event.addonEvent.addon;
     const addon = addons.addonsById[id];
 

--- a/src/manager/addons.js
+++ b/src/manager/addons.js
@@ -32,6 +32,12 @@ export const addons = new Svue({
       }
       return results;
     },
+    addonsByRepo(browserAddons) {
+      return browserAddons.reduce((m, addon) => {
+        m[addon.repository] = addon;
+        return m;
+      }, {});
+    },
     pollEvents(runs) {
       if (runs.filter((x) => !done(x)).length === 0) return [];
       return [updateRuns];

--- a/src/manager/layout.js
+++ b/src/manager/layout.js
@@ -1,7 +1,7 @@
 import { Svue } from "svue";
-import { router } from "@/router/router";
-import { truthyParamValue } from "@/util/url";
-import { sameProp } from "@/util/array";
+import { router, setHash } from "@/router/router.js";
+import { truthyParamValue } from "@/util/url.js";
+import { sameProp } from "@/util/array.js";
 
 // Used to calculate the most restricted level of access
 // in a group of documents
@@ -24,7 +24,8 @@ export const layout = new Svue({
       selectedMap: {},
 
       // Custom dialogs
-      addonDispatchOpen: false,
+      addonDispatchOpen: null,
+      addOnEvent: null,
       addonBrowserOpen: false,
       metaOpen: null,
       documentInfoOpen: false,
@@ -166,16 +167,29 @@ export function unselectDocument(document) {
 
 // Dialogs
 export function openDispatchAddon(addon) {
+  const { repository } = addon.addon;
+  setHash(`add-ons/${repository}`);
   layout.addonDispatchOpen = addon;
 }
+
+export function showAddonEvent(addon, eventId) {
+  const { repository } = addon.addon;
+  setHash(`add-ons/${repository}/${eventId}`);
+  layout.addonDispatchOpen = addon;
+  layout.addOnEvent = eventId;
+}
+
 export function hideAddonDispatch() {
-  layout.addonDispatchOpen = false;
+  setHash("");
+  layout.addonDispatchOpen = null;
 }
 
 export function openAddonBrowser() {
+  setHash("add-ons");
   layout.addonBrowserOpen = true;
 }
 export function hideAddonBrowser() {
+  setHash("");
   layout.addonBrowserOpen = false;
 }
 

--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -1,12 +1,68 @@
 <script>
   import { onMount } from "svelte";
-  import Sidebar from "./sidebar/Sidebar";
-  import MainContainer from "./MainContainer";
   import { _ } from "svelte-i18n";
 
-  import { layout } from "@/manager/layout";
-  import { documents } from "@/manager/documents";
+  import Sidebar from "./sidebar/Sidebar.svelte";
+  import MainContainer from "./MainContainer.svelte";
+
+  import { layout } from "@/manager/layout.js";
+  import { addons, getBrowserAddons } from "@/manager/addons.js";
+  import { documents } from "@/manager/documents.js";
   import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
+
+  // hash routing, like in Viewer.svelte
+  // [regexp, callback]
+  const navHandlers = [
+    [
+      /^#$/,
+      (match) => {
+        layout.addonBrowserOpen = false;
+      },
+    ],
+
+    // list add-ons
+    [
+      /^#add-ons$/,
+      async (match) => {
+        await getBrowserAddons();
+        layout.addonBrowserOpen = true;
+      },
+    ],
+
+    // initial add-on view
+    [
+      /^#add-ons\/([-\w]+)\/([-\w]+)$/,
+      async (match) => {
+        await getBrowserAddons();
+
+        const [org, name] = match.slice(1, 3);
+        const addon = addons.addonsByRepo[`${org}/${name}`];
+        if (addon) {
+          layout.addonDispatchOpen = addon;
+        } else {
+          console.error("Add-on not found: %s", `${org}/${name}`);
+        }
+      },
+    ],
+
+    // configured add-on
+    [
+      /^#add-ons\/(?<org>[-\w]+)\/(?<name>[-\w]+)\/(?<id>\d+)$/,
+      async (match) => {
+        console.log(match);
+        await getBrowserAddons();
+
+        const [org, name, id] = match.slice(1, 4);
+        const addon = addons.addonsByRepo[`${org}/${name}`];
+        if (addon) {
+          layout.addonDispatchOpen = addon;
+          layout.addOnEvent = id;
+        } else {
+          console.error("Add-on not found: %s", `${org}/${name}`);
+        }
+      },
+    ],
+  ];
 
   let sidebar = null;
 
@@ -18,6 +74,22 @@
     }
   }
 
+  function hashRoute() {
+    const hash = window.location.hash;
+    if (hash === "") {
+      const callback = navHandlers[0][1];
+      return callback();
+    }
+
+    navHandlers.find(([route, callback]) => {
+      const match = route.exec(hash);
+      if (match) {
+        callback(match);
+        return true; // stop the loop
+      }
+    });
+  }
+
   onMount(() => {
     window.plausible =
       window.plausible ||
@@ -26,8 +98,15 @@
       };
 
     plausible("pageview");
+    hashRoute();
+
+    // debug
+    window.layout = layout;
+    window.addons = addons;
   });
 </script>
+
+<svelte:window on:hashchange={hashRoute} />
 
 <svelte:head>
   <title>{$_("common.documentCloud")}</title>

--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -49,14 +49,13 @@
     [
       /^#add-ons\/(?<org>[-\w]+)\/(?<name>[-\w]+)\/(?<id>\d+)$/,
       async (match) => {
-        console.log(match);
         await getBrowserAddons();
 
         const [org, name, id] = match.slice(1, 4);
         const addon = addons.addonsByRepo[`${org}/${name}`];
         if (addon) {
           layout.addonDispatchOpen = addon;
-          layout.addOnEvent = id;
+          layout.addOnEvent = +id;
         } else {
           console.error("Add-on not found: %s", `${org}/${name}`);
         }

--- a/src/pages/app/menus/AddonsMenu.svelte
+++ b/src/pages/app/menus/AddonsMenu.svelte
@@ -1,12 +1,14 @@
 <script>
   import { onMount } from "svelte";
-  import Menu from "@/common/Menu";
-  import MenuItem from "@/common/MenuItem";
-  import AddonMenuItem from "./AddonMenuItem";
-
-  import { openAddonBrowser } from "@/manager/layout";
-  import { addons, getBrowserAddons } from "@/manager/addons";
   import { _ } from "svelte-i18n";
+
+  import Menu from "@/common/Menu.svelte";
+  import MenuItem from "@/common/MenuItem.svelte";
+  import AddonMenuItem from "./AddonMenuItem.svelte";
+
+  import { openAddonBrowser } from "@/manager/layout.js";
+  import { addons, getBrowserAddons } from "@/manager/addons.js";
+  import { setHash } from "@/router/router.js";
 
   function sort(addons) {
     if (addons == null) return [];
@@ -21,7 +23,7 @@
   async function openBrowser() {
     await getBrowserAddons();
     openAddonBrowser();
-
+    setHash("add-ons");
     plausible("app-add-ons", { props: { target: "browser" } });
   }
 
@@ -34,11 +36,11 @@
   });
 </script>
 
-<style lang="scss">
+<style>
   .promo {
-    color: $darkgray;
+    color: var(--darkgray, rgba(0, 0, 0, 0.8));
     font-style: italic;
-    font-size: $normal;
+    font-size: var(--normal, 16px);
   }
 </style>
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -105,6 +105,13 @@ export function pushUrl(url) {
   );
 }
 
+// for hash routing in App.svelte and Viewer.svelte
+export function setHash(hash) {
+  const url = new URL(router.currentUrl, window.location.href);
+  url.hash = hash;
+  pushUrl(url.pathname + url.search + url.hash);
+}
+
 export function goBack(fallback = FALLBACK_URL) {
   if (router.pastUrl != null) {
     window.history.back();

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,4 +1,4 @@
-import NotFound from "@/pages/NotFound";
+import NotFound from "@/pages/NotFound.svelte";
 import {
   loadDefault,
   loadHome,
@@ -9,7 +9,7 @@ import {
   loadProject,
   loadLegacyRedirect,
   loadEntities,
-} from "@/util/lazyComponent";
+} from "@/util/lazyComponent.js";
 
 export const routes = [
   NotFound,
@@ -29,6 +29,23 @@ export const routes = [
       component: lazyComponent.app,
       get: loadApp,
     },
+
+    addonList: {
+      path: "/app/add-ons",
+      component: lazyComponent.app,
+      get: loadApp,
+    },
+    addonDetail: {
+      path: "/app/add-ons/:org/:name",
+      component: lazyComponent.app,
+      get: loadApp,
+    },
+    addonEvent: {
+      path: "/app/add-ons/:org/:name/:id",
+      component: lazyComponent.app,
+      get: loadApp,
+    },
+
     viewer: {
       path: "/documents/:id",
       component: lazyComponent.viewer,

--- a/src/structure/addon.js
+++ b/src/structure/addon.js
@@ -68,7 +68,7 @@ export class AddonRun extends Svue {
           return addonRun.status;
         },
         failure(status) {
-          return (status === "failure" || status === "cancelled");
+          return status === "failure" || status === "cancelled";
         },
         progress(addonRun) {
           return addonRun.progress;
@@ -107,7 +107,6 @@ export class AddonRun extends Svue {
   }
 }
 
-
 export class AddonEvent extends Svue {
   constructor(rawAddonEvent, structure = {}) {
     const computed = structure.computed == null ? {} : structure.computed;
@@ -135,4 +134,3 @@ export class AddonEvent extends Svue {
     });
   }
 }
-


### PR DESCRIPTION
Adds hash URLs to `App.svelte`, based on this plan: https://www.notion.so/muckrock/Add-On-deep-linking-fe36e206f06146c4aa1a340f23d33ec3

Still to do: Pre-filling the add-on dispatch form based on query params, but that'll be next.

Try locally:

- https://www.dev.documentcloud.org/app#add-ons/MuckRock/Klaxon/1
- https://www.dev.documentcloud.org/app#add-ons/MuckRock/Klaxon
- https://www.dev.documentcloud.org/app#add-ons

