### PR TITLE
Load initial add-on dispatch values from querystring

### DIFF
--- a/src/common/dialog/AddonDispatchTsDialog.svelte
+++ b/src/common/dialog/AddonDispatchTsDialog.svelte
@@ -25,7 +25,7 @@
   import { layout } from "@/manager/layout.js";
   import { components } from "./DCDefaultFormComponents.ts";
 
-  let form;
+  let container;
   let schema = structuredClone(layout.addonDispatchOpen.parameters);
 
   // The bind value for the event select drop down
@@ -83,12 +83,9 @@
     eventSelect = "0";
     schema = structuredClone(layout.addonDispatchOpen.parameters);
 
-    const marker = document.getElementById("form");
-    const form = marker && marker.closest("form");
+    const form = container && container.querySelector("form");
     if (form) {
       form.reset();
-    } else {
-      console.error("form not found");
     }
 
     layout.params.addOnEvent = null;
@@ -105,7 +102,8 @@
     for (const param in event.parameters) {
       schema.properties[param].default = event.parameters[param];
     }
-    document.getElementById("form").closest("form").reset();
+    const form = container && container.querySelector("form");
+    if (form) form.reset();
     // set the event select widget
     eventSelect = event.event;
     // reset runs
@@ -194,14 +192,14 @@
   }
 </script>
 
-<style lang="scss">
+<style>
   #repository-detail {
     font-size: 16px;
     font-weight: normal;
+  }
 
-    a {
-      text-decoration: underline;
-    }
+  a {
+    text-decoration: underline;
   }
 
   table {
@@ -240,19 +238,17 @@
   .notice :global(a),
   .markdown :global(a) {
     text-decoration: underline;
-    color: $primary;
+    color: var(--primary, #4294f0);
   }
 
-  .eventSelect {
-    label {
-      font-size: 16px;
-      padding-right: 5px;
-    }
+  .eventSelect label {
+    font-size: 16px;
+    padding-right: 5px;
   }
 
   .runs {
     background: #eff7ff;
-    border-radius: $radius;
+    border-radius: var(--radius, 3px);
     padding: 0;
     margin: 20px 0;
   }
@@ -260,13 +256,14 @@
   .events a {
     text-decoration: underline;
     color: #5a76a0;
-    &:hover {
-      filter: brightness(85%);
-    }
+  }
+
+  .events a:hover {
+    filter: brightness(85%);
   }
 </style>
 
-<div class="mcontent">
+<div class="mcontent" bind:this={container}>
   {#if schema}
     <h2>
       {$_("addonsMenu.addon")}: {layout.addonDispatchOpen.name}
@@ -344,7 +341,6 @@
       {components}
       {value}
       {validator}
-      bind:this={form}
       on:submit={(e) => {
         if (activeEvent) {
           updateAddonEvent(activeEvent.id, e.detail, eventSelect);
@@ -366,7 +362,6 @@
         emit.dismiss();
       }}
     >
-      <a id="form" />
       {#if !eventActive}
         {#if notice}
           <div class="notice">{@html notice}</div>

--- a/src/common/dialog/AddonDispatchTsDialog.svelte
+++ b/src/common/dialog/AddonDispatchTsDialog.svelte
@@ -49,16 +49,27 @@
   ];
   let eventSelectOptions = [];
   if (schema.eventOptions && schema.eventOptions.events) {
-    eventSelectOptions = availableOptions.filter(
-      ([value, label]) =>
-        schema.eventOptions.events.indexOf(label.toLowerCase()) > -1,
+    eventSelectOptions = availableOptions.filter(([value, label]) =>
+      schema.eventOptions.events.includes(label.toLowerCase()),
     );
   }
   let showEventInfo = eventSelectOptions.length > 0;
 
   onMount(async () => {
     events = await getAddonEvents(layout.addonDispatchOpen.id);
+
+    // load initial value from querystring
+    value = valuesFromQS();
   });
+
+  // extract initial form values from querystring
+  function valuesFromQS() {
+    let qs = new URLSearchParams(window.location.search);
+
+    // only accept values in properties
+    qs = Array.from(qs).filter(([k, v]) => schema.properties.hasOwnProperty(k));
+    return Object.fromEntries(qs);
+  }
 
   async function showRuns(e) {
     e.preventDefault();
@@ -128,6 +139,7 @@
   const validator = createAjvValidator(ajv);
 
   let value;
+  let addonForm;
 
   const emit = emitter({
     dismiss() {},
@@ -339,8 +351,9 @@
     <Form
       {schema}
       {components}
-      {value}
       {validator}
+      {value}
+      bind:this={addonForm}
       on:submit={(e) => {
         if (activeEvent) {
           updateAddonEvent(activeEvent.id, e.detail, eventSelect);

--- a/src/manager/layout.js
+++ b/src/manager/layout.js
@@ -25,7 +25,6 @@ export const layout = new Svue({
 
       // Custom dialogs
       addonDispatchOpen: null,
-      addOnEvent: null,
       addonBrowserOpen: false,
       metaOpen: null,
       documentInfoOpen: false,
@@ -37,6 +36,11 @@ export const layout = new Svue({
       searchTipsOpen: false,
       diagnosticsOpen: false,
       mailkeyOpen: false,
+
+      // nest any captured URL params here
+      params: {
+        addOnEvent: null,
+      },
 
       // Data
       dataDocuments: [],

--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -39,6 +39,7 @@
         const addon = addons.addonsByRepo[`${org}/${name}`];
         if (addon) {
           layout.addonDispatchOpen = addon;
+          layout.params.addOnEvent = null;
         } else {
           console.error("Add-on not found: %s", `${org}/${name}`);
         }
@@ -55,7 +56,7 @@
         const addon = addons.addonsByRepo[`${org}/${name}`];
         if (addon) {
           layout.addonDispatchOpen = addon;
-          layout.addOnEvent = +id;
+          layout.params.addOnEvent = +id;
         } else {
           console.error("Add-on not found: %s", `${org}/${name}`);
         }


### PR DESCRIPTION
Load this URL locally: https://www.dev.documentcloud.org/app?q=%2Buser%3Achris-100000%20&site=https://www.muckrock.com/&selector=*#add-ons/MuckRock/Klaxon

That will load the app with the Add-On dispatch open to Klaxon, with the `site` and `selector` fields pre-populated. Any fields defined in `schema.properties` can be pre-filled. Anything else gets filtered out.

<img width="988" alt="Screenshot 2023-05-01 at 9 00 36 PM" src="https://user-images.githubusercontent.com/25778/235557424-6faca7bb-2644-41df-a60f-a9e31f867fe1.png">
