### PR TITLE
Use that new API filter

### DIFF
--- a/src/api/addon.js
+++ b/src/api/addon.js
@@ -16,10 +16,15 @@ export async function getActiveAddons() {
   return results.map((result) => new Addon(result));
 }
 
-export async function getAddons(query = "", url = null) {
+export async function getAddons(
+  query = "",
+  filters = {},
+  per_page = 5,
+  url = null,
+) {
   // Use the URL from the next or previous url in the response
   if (!url) {
-    url = apiUrl(queryBuilder(`addons/`, { query, per_page: 5 }));
+    url = apiUrl(queryBuilder("addons/", { ...filters, query, per_page }));
   }
   const { data } = await session.get(url);
   const results = data.results.map((result) => new Addon(result));

--- a/src/common/dialog/AddonDispatchTsDialog.svelte
+++ b/src/common/dialog/AddonDispatchTsDialog.svelte
@@ -10,7 +10,7 @@
   import AddonRun from "@/common/AddonRun.svelte";
 
   import { setHash } from "@/router/router.js";
-  import { addons, dispatchAddon } from "@/manager/addons.js";
+  import { addons, dispatchAddon, getBrowserAddons } from "@/manager/addons.js";
   import {
     createAddonEvent,
     getAddonEvents,
@@ -124,7 +124,7 @@
   // generate a hash URL for each addon event
   function eventUrl(event) {
     const id = event.addonEvent.addon;
-    const addon = addons.addonsById[id];
+    const addon = layout.addonDispatchOpen;
 
     return `#add-ons/${addon.repository}/${id}`;
   }

--- a/src/manager/addons.js
+++ b/src/manager/addons.js
@@ -24,13 +24,11 @@ export const addons = new Svue({
     };
   },
   computed: {
-    addonsById(activeAddons) {
-      const results = {};
-      for (let i = 0; i < activeAddons.length; i++) {
-        const addon = activeAddons[i];
-        results[addon.id] = addon;
-      }
-      return results;
+    addonsById(browserAddons) {
+      return browserAddons.reduce((m, addon) => {
+        m[addon.id] = addon;
+        return m;
+      }, {});
     },
     addonsByRepo(browserAddons) {
       return browserAddons.reduce((m, addon) => {
@@ -78,9 +76,26 @@ export function removeRun(uuid) {
   addons.runs = addons.runs.filter((addon) => addon.uuid != uuid);
 }
 
-export async function getBrowserAddons(query = "", url = null) {
-  const newAddons = await getAddons(query, url);
+export async function getBrowserAddons(
+  query = "",
+  filters = {},
+  per_page = 5,
+  url = null,
+) {
+  const newAddons = await getAddons(query, filters, per_page, url);
   [addons.browserAddons, addons.browserNext, addons.browserPrev] = newAddons;
+}
+
+/**
+ * Fetch a single Add-On based on repository name, like Muckrock/Klaxon
+ *
+ * @export
+ * @param {string} [repo=""]
+ * @returns import('../structure/addon').Addon
+ */
+export async function getAddonByRepository(repository = "") {
+  const [addons, next, previous] = await getAddons("", { repository }, 1);
+  return addons[0] || null; // there should be only one, or nothing
 }
 
 export async function toggleActiveAddon(addon) {

--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -6,7 +6,11 @@
   import MainContainer from "./MainContainer.svelte";
 
   import { layout } from "@/manager/layout.js";
-  import { addons, getBrowserAddons } from "@/manager/addons.js";
+  import {
+    addons,
+    getBrowserAddons,
+    getAddonByRepository,
+  } from "@/manager/addons.js";
   import { documents } from "@/manager/documents.js";
   import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
 
@@ -33,15 +37,14 @@
     [
       /^#add-ons\/([-\w]+)\/([-\w]+)$/,
       async (match) => {
-        await getBrowserAddons();
-
         const [org, name] = match.slice(1, 3);
-        const addon = addons.addonsByRepo[`${org}/${name}`];
+        const repo = `${org}/${name}`;
+        const addon = await getAddonByRepository(repo);
         if (addon) {
           layout.addonDispatchOpen = addon;
           layout.params.addOnEvent = null;
         } else {
-          console.error("Add-on not found: %s", `${org}/${name}`);
+          console.error("Add-on not found: %s", repo);
         }
       },
     ],
@@ -50,15 +53,14 @@
     [
       /^#add-ons\/(?<org>[-\w]+)\/(?<name>[-\w]+)\/(?<id>\d+)$/,
       async (match) => {
-        await getBrowserAddons();
-
         const [org, name, id] = match.slice(1, 4);
-        const addon = addons.addonsByRepo[`${org}/${name}`];
+        const repo = `${org}/${name}`;
+        const addon = await getAddonByRepository(repo);
         if (addon) {
           layout.addonDispatchOpen = addon;
           layout.params.addOnEvent = +id;
         } else {
-          console.error("Add-on not found: %s", `${org}/${name}`);
+          console.error("Add-on not found: %s", repo);
         }
       },
     ],


### PR DESCRIPTION
This uses the `repository` filter to fetch one, and only one, add-on in the dispatch dialog. No more looping through.