### PR TITLE
Trim search params to avoid encoding errors

### DIFF
--- a/src/router/router.js
+++ b/src/router/router.js
@@ -126,7 +126,7 @@ export function setQS(qs, keep = []) {
 
   url.search = "";
   [...keys, ...qs].forEach(([k, v]) => {
-    url.searchParams.set(k, v);
+    url.searchParams.set(k, String(v).trim());
   });
 
   pushUrl(url.pathname + url.search + url.hash);


### PR DESCRIPTION
This was causing search errors when the modal closed.