### PR TITLE
Production push: Add-on deep linking

### DIFF
--- a/src/Main.svelte
+++ b/src/Main.svelte
@@ -27,6 +27,9 @@
         window.location.href,
       );
     }
+
+    // debug
+    window.router = router;
   });
 
   function handleBackNav(e) {
@@ -36,7 +39,8 @@
 </script>
 
 <style lang="scss">
-  :global(input), :global(select) {
+  :global(input),
+  :global(select) {
     padding: 4px 10px;
     font-family: inherit;
     font-size: 16px;

--- a/src/api/addon.js
+++ b/src/api/addon.js
@@ -57,7 +57,11 @@ export async function postAddonDispatch(
   return new AddonRun(data);
 }
 
-export async function getAddonRuns(event = null, dismissed = false, expand = "addon") {
+export async function getAddonRuns(
+  event = null,
+  dismissed = false,
+  expand = "addon",
+) {
   // Returns all add-on runs
   const results = await grabAllPages(
     apiUrl(queryBuilder(`addon_runs/`, { expand, dismissed, event })),
@@ -98,7 +102,10 @@ export async function updateAddonEvent(eventId, parameters, event) {
 }
 
 export async function updateAddonRun(run, parameters) {
-  const { data } = await session.patch(apiUrl(`addon_runs/${run.uuid}/`), parameters);
+  const { data } = await session.patch(
+    apiUrl(`addon_runs/${run.uuid}/`),
+    parameters,
+  );
   // Cannot expand addon in patch call, use previous expanded addon info
   data.addon = run.addonRun.addon;
   return new AddonRun(data);

--- a/src/api/addon.js
+++ b/src/api/addon.js
@@ -16,10 +16,15 @@ export async function getActiveAddons() {
   return results.map((result) => new Addon(result));
 }
 
-export async function getAddons(query = "", url = null) {
+export async function getAddons(
+  query = "",
+  filters = {},
+  per_page = 5,
+  url = null,
+) {
   // Use the URL from the next or previous url in the response
   if (!url) {
-    url = apiUrl(queryBuilder(`addons/`, { query, per_page: 5 }));
+    url = apiUrl(queryBuilder("addons/", { ...filters, query, per_page }));
   }
   const { data } = await session.get(url);
   const results = data.results.map((result) => new Addon(result));

--- a/src/common/AddonRun.svelte
+++ b/src/common/AddonRun.svelte
@@ -17,7 +17,7 @@
 
   function getStatus(status) {
     if (status === "cancelled") {
-      return "Timed Out"
+      return "Timed Out";
     }
     return status
       .split("_")
@@ -45,13 +45,12 @@
 
   function rate(val) {
     const newVal = run.rating === val ? 0 : val;
-    editAddonRun(run, {rating: newVal});
+    editAddonRun(run, { rating: newVal });
   }
 
   function submitFeedback() {
-    editAddonRun(run, {comment});
+    editAddonRun(run, { comment });
   }
-
 </script>
 
 <style lang="scss">
@@ -90,7 +89,8 @@
     border-top: 1px solid rgba(128, 128, 128, 0.15);
   }
 
-  .failure, .cancelled {
+  .failure,
+  .cancelled {
     background: $errorbg;
     .info {
       color: $caution;
@@ -137,17 +137,10 @@
     </span>
     {#if done(run)}
       <span class="rate">
-        <Button
-          small={true}
-          on:click={thumbsUp}
-          secondary={run.rating !== 1}
-          >
+        <Button small={true} on:click={thumbsUp} secondary={run.rating !== 1}>
           &#x1F44D;
         </Button>
-        <Button
-          small={true}
-          on:click={thumbsDown}
-          secondary={run.rating !== -1}
+        <Button small={true} on:click={thumbsDown} secondary={run.rating !== -1}
           >&#x1F44E;
         </Button>
 
@@ -158,7 +151,7 @@
                 placeholder="Feedback on this AddOn Run"
                 maxlength="255"
                 bind:value={comment}
-                >
+              />
               <Button small={true} on:click={submitFeedback}>Submit</Button>
             {:else}
               <span>Thanks for the feedback!</span>
@@ -166,22 +159,14 @@
           </span>
         {/if}
       </span>
-    {:else} 
+    {:else}
       <span class="cancel">
         {#if cancelled.includes(run.uuid)}
-          <Button
-            small={true}
-            danger={true}
-            disabled={true}
-            >
+          <Button small={true} danger={true} disabled={true}>
             {$_("dialog.cancelling")}
           </Button>
         {:else}
-          <Button
-            small={true}
-            on:click={() => cancel(run.uuid)}
-            danger={true}
-            >
+          <Button small={true} on:click={() => cancel(run.uuid)} danger={true}>
             {$_("dialog.cancel")}
           </Button>
         {/if}

--- a/src/common/Dropdown.svelte
+++ b/src/common/Dropdown.svelte
@@ -12,8 +12,8 @@
   const MENU_OFFSET = 1; // vert offset for menu
 
   export let name = undefined; // for analytics
-  export let table;
-  export let bordered;
+  export let table = false;
+  export let bordered = false;
   export let fixed = false;
 
   let active = false;

--- a/src/common/dialog/AddonBrowserDialog.svelte
+++ b/src/common/dialog/AddonBrowserDialog.svelte
@@ -1,4 +1,8 @@
 <script>
+  import SvelteMarkdown from "svelte-markdown";
+  import { _ } from "svelte-i18n";
+  import debounce from "lodash/debounce";
+
   import Button from "@/common/Button.svelte";
   import {
     addons,
@@ -6,10 +10,6 @@
     getBrowserAddons,
   } from "@/manager/addons.js";
   import emitter from "@/emit.js";
-
-  import SvelteMarkdown from "svelte-markdown";
-  import { _ } from "svelte-i18n";
-  import debounce from "lodash/debounce";
 
   const emit = emitter({
     dismiss() {},

--- a/src/common/dialog/AddonBrowserDialog.svelte
+++ b/src/common/dialog/AddonBrowserDialog.svelte
@@ -1,51 +1,49 @@
 <script>
-  import Button from "@/common/Button";
-  import { activateAddon } from "@/api/addon";
+  import Button from "@/common/Button.svelte";
   import {
     addons,
     toggleActiveAddon,
     getBrowserAddons,
-  } from "@/manager/addons";
+  } from "@/manager/addons.js";
+  import emitter from "@/emit.js";
+
   import SvelteMarkdown from "svelte-markdown";
   import { _ } from "svelte-i18n";
-  import emitter from "@/emit";
-  import { layout } from "@/manager/layout";
-
-  import debounce from 'lodash/debounce';
+  import debounce from "lodash/debounce";
 
   const emit = emitter({
     dismiss() {},
   });
 
-  const handleInput = debounce(e => { getBrowserAddons(e.target.value); }, 300);
+  const handleInput = debounce((e) => {
+    getBrowserAddons(e.target.value);
+  }, 300);
 
   function changePage(url) {
     getBrowserAddons("", url);
     // scroll to top of modal
-    document.getElementsByClassName("modal")[0].scroll({top: 0});
+    document.getElementsByClassName("modal")[0].scroll({ top: 0 });
   }
-
 </script>
 
-<style lang="scss">
+<style>
   .repository-detail {
     font-size: 16px;
     font-weight: normal;
+  }
 
-    a {
-      text-decoration: underline;
-    }
+  .repository-detail a {
+    text-decoration: underline;
   }
 
   .markdown :global(a) {
     text-decoration: underline;
-    color: $primary;
+    color: var(--primary, #4294f0);
   }
-
 </style>
 
 <div class="mcontent">
-  <h1>Browse Add Ons</h1>
+  <h2>{$_("addonBrowserDialog.browseAll")}</h2>
   <div>
     <input
       type="text"
@@ -56,22 +54,29 @@
   <div class="addons">
     <hr />
     {#each $addons.browserAddons as addon}
-      <h2>
+      <h3>
         {addon.name}
         <span class="repository-detail">
           by {addon.repository.split("/")[0]}
-          <a target="_blank" href="https://www.github.com/{addon.repository}">
-            (View Source)
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.github.com/{addon.repository}"
+          >
+            ({$_("addonBrowserDialog.viewsource")})
           </a>
         </span>
-      </h2>
+      </h3>
       <div class="markdown">
         <SvelteMarkdown
           source={addon.parameters.description}
           renderers={{ html: null }}
         />
       </div>
-      <Button secondary={!addon.active} on:click={() => toggleActiveAddon(addon)}>
+      <Button
+        secondary={!addon.active}
+        on:click={() => toggleActiveAddon(addon)}
+      >
         {#if addon.active}
           {$_("addonBrowserDialog.active")}
         {:else}

--- a/src/common/dialog/AddonDispatchTsDialog.svelte
+++ b/src/common/dialog/AddonDispatchTsDialog.svelte
@@ -25,7 +25,7 @@
   import { layout } from "@/manager/layout.js";
   import { components } from "./DCDefaultFormComponents.ts";
 
-  let form;
+  let container;
   let schema = structuredClone(layout.addonDispatchOpen.parameters);
 
   // The bind value for the event select drop down
@@ -83,12 +83,9 @@
     eventSelect = "0";
     schema = structuredClone(layout.addonDispatchOpen.parameters);
 
-    const marker = document.getElementById("form");
-    const form = marker && marker.closest("form");
+    const form = container && container.querySelector("form");
     if (form) {
       form.reset();
-    } else {
-      console.error("form not found");
     }
 
     layout.params.addOnEvent = null;
@@ -105,7 +102,8 @@
     for (const param in event.parameters) {
       schema.properties[param].default = event.parameters[param];
     }
-    document.getElementById("form").closest("form").reset();
+    const form = container && container.querySelector("form");
+    if (form) form.reset();
     // set the event select widget
     eventSelect = event.event;
     // reset runs
@@ -194,14 +192,14 @@
   }
 </script>
 
-<style lang="scss">
+<style>
   #repository-detail {
     font-size: 16px;
     font-weight: normal;
+  }
 
-    a {
-      text-decoration: underline;
-    }
+  a {
+    text-decoration: underline;
   }
 
   table {
@@ -240,19 +238,17 @@
   .notice :global(a),
   .markdown :global(a) {
     text-decoration: underline;
-    color: $primary;
+    color: var(--primary, #4294f0);
   }
 
-  .eventSelect {
-    label {
-      font-size: 16px;
-      padding-right: 5px;
-    }
+  .eventSelect label {
+    font-size: 16px;
+    padding-right: 5px;
   }
 
   .runs {
     background: #eff7ff;
-    border-radius: $radius;
+    border-radius: var(--radius, 3px);
     padding: 0;
     margin: 20px 0;
   }
@@ -260,13 +256,14 @@
   .events a {
     text-decoration: underline;
     color: #5a76a0;
-    &:hover {
-      filter: brightness(85%);
-    }
+  }
+
+  .events a:hover {
+    filter: brightness(85%);
   }
 </style>
 
-<div class="mcontent">
+<div class="mcontent" bind:this={container}>
   {#if schema}
     <h2>
       {$_("addonsMenu.addon")}: {layout.addonDispatchOpen.name}
@@ -344,7 +341,6 @@
       {components}
       {value}
       {validator}
-      bind:this={form}
       on:submit={(e) => {
         if (activeEvent) {
           updateAddonEvent(activeEvent.id, e.detail, eventSelect);
@@ -366,7 +362,6 @@
         emit.dismiss();
       }}
     >
-      <a id="form" />
       {#if !eventActive}
         {#if notice}
           <div class="notice">{@html notice}</div>

--- a/src/common/dialog/AddonDispatchTsDialog.svelte
+++ b/src/common/dialog/AddonDispatchTsDialog.svelte
@@ -54,13 +54,12 @@
   }
   let showEventInfo = eventSelectOptions.length > 0;
 
-  // debug
-  $: console.log(events);
-
   onMount(async () => {
     events = await getAddonEvents(layout.addonDispatchOpen.id);
     if (layout.addOnEvent) {
       eventSelect = layout.addOnEvent;
+      activeEvent = events.find((e) => e.id === layout.addOnEvent);
+      loadEvent(activeEvent);
     }
   });
 
@@ -105,7 +104,6 @@
 
   // generate a hash URL for each addon event
   function eventUrl(event) {
-    console.log(event);
     const id = event.addonEvent.addon;
     const addon = addons.addonsById[id];
 

--- a/src/common/dialog/AddonDispatchTsDialog.svelte
+++ b/src/common/dialog/AddonDispatchTsDialog.svelte
@@ -10,13 +10,15 @@
   import AddonRun from "@/common/AddonRun.svelte";
 
   import { setHash } from "@/router/router.js";
-  import { addons, dispatchAddon, getBrowserAddons } from "@/manager/addons.js";
+  import { dispatchAddon } from "@/manager/addons.js";
+  import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
   import {
     createAddonEvent,
     getAddonEvents,
     getAddonRuns,
     updateAddonEvent,
   } from "@/api/addon.js";
+  import { SIGN_IN_URL } from "@/api/auth.js";
   import { search } from "@/search/search.js";
   import { viewer } from "@/viewer/viewer.js";
   import emitter from "@/emit.js";
@@ -456,12 +458,16 @@
 
       <div class="buttonpadded">
         <!-- disable button when invalid, maybe -->
-        <Button type="submit">
-          {eventActive ? $_("dialog.save") : $_("dialog.dispatch")}
-        </Button>
-        <Button secondary={true} on:click={emit.dismiss}>
-          {$_("dialog.cancel")}
-        </Button>
+        {#if $orgsAndUsers.me}
+          <Button type="submit">
+            {eventActive ? $_("dialog.save") : $_("dialog.dispatch")}
+          </Button>
+          <Button secondary={true} on:click={emit.dismiss}>
+            {$_("dialog.cancel")}
+          </Button>
+        {:else}
+          <p><a href={SIGN_IN_URL}>{$_("addonDispatchDialog.signIn")}</a></p>
+        {/if}
       </div>
     </Form>
   {/if}

--- a/src/common/dialog/AddonDispatchTsDialog.svelte
+++ b/src/common/dialog/AddonDispatchTsDialog.svelte
@@ -49,16 +49,27 @@
   ];
   let eventSelectOptions = [];
   if (schema.eventOptions && schema.eventOptions.events) {
-    eventSelectOptions = availableOptions.filter(
-      ([value, label]) =>
-        schema.eventOptions.events.indexOf(label.toLowerCase()) > -1,
+    eventSelectOptions = availableOptions.filter(([value, label]) =>
+      schema.eventOptions.events.includes(label.toLowerCase()),
     );
   }
   let showEventInfo = eventSelectOptions.length > 0;
 
   onMount(async () => {
     events = await getAddonEvents(layout.addonDispatchOpen.id);
+
+    // load initial value from querystring
+    value = valuesFromQS();
   });
+
+  // extract initial form values from querystring
+  function valuesFromQS() {
+    let qs = new URLSearchParams(window.location.search);
+
+    // only accept values in properties
+    qs = Array.from(qs).filter(([k, v]) => schema.properties.hasOwnProperty(k));
+    return Object.fromEntries(qs);
+  }
 
   async function showRuns(e) {
     e.preventDefault();
@@ -128,6 +139,7 @@
   const validator = createAjvValidator(ajv);
 
   let value;
+  let addonForm;
 
   const emit = emitter({
     dismiss() {},
@@ -339,8 +351,9 @@
     <Form
       {schema}
       {components}
-      {value}
       {validator}
+      {value}
+      bind:this={addonForm}
       on:submit={(e) => {
         if (activeEvent) {
           updateAddonEvent(activeEvent.id, e.detail, eventSelect);

--- a/src/common/dialog/AddonDispatchTsDialog.svelte
+++ b/src/common/dialog/AddonDispatchTsDialog.svelte
@@ -28,7 +28,7 @@
   import { components } from "./DCDefaultFormComponents.ts";
 
   let container;
-  let schema = structuredClone(layout.addonDispatchOpen.parameters);
+  let schema = deepcopy(layout.addonDispatchOpen.parameters);
 
   // The bind value for the event select drop down
   let eventSelect = 0;
@@ -94,7 +94,7 @@
     runs = [];
     activeEvent = null;
     eventSelect = "0";
-    schema = structuredClone(layout.addonDispatchOpen.parameters);
+    schema = deepcopy(layout.addonDispatchOpen.parameters);
 
     const form = container && container.querySelector("form");
     if (form) {
@@ -129,6 +129,10 @@
     const addon = layout.addonDispatchOpen;
 
     return `#add-ons/${addon.repository}/${id}`;
+  }
+
+  function deepcopy(obj) {
+    return JSON.parse(JSON.stringify(obj));
   }
 
   const ajv = new Ajv({

--- a/src/common/dialog/AddonDispatchTsDialog.svelte
+++ b/src/common/dialog/AddonDispatchTsDialog.svelte
@@ -10,7 +10,7 @@
   import AddonRun from "@/common/AddonRun.svelte";
 
   import { setHash } from "@/router/router.js";
-  import { addons, dispatchAddon } from "@/manager/addons.js";
+  import { addons, dispatchAddon, getBrowserAddons } from "@/manager/addons.js";
   import {
     createAddonEvent,
     getAddonEvents,
@@ -124,7 +124,7 @@
   // generate a hash URL for each addon event
   function eventUrl(event) {
     const id = event.addonEvent.addon;
-    const addon = addons.addonsById[id];
+    const addon = layout.addonDispatchOpen;
 
     return `#add-ons/${addon.repository}/${id}`;
   }

--- a/src/common/dialog/DiagnosticDialog.svelte
+++ b/src/common/dialog/DiagnosticDialog.svelte
@@ -2,7 +2,6 @@
   import Button from "@/common/Button";
   import emitter from "@/emit";
   import { layout } from "@/manager/layout";
-  import { nameSingularNumberPlural } from "@/util/string";
   import DocumentThumbnail from "@/pages/app/DocumentThumbnail";
   import { apiUrl } from "@/api/base";
   import { _ } from "svelte-i18n";

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -702,7 +702,8 @@
     "hideRuns": "Hide Runs",
     "showAddons": "Show Scheduled Add-Ons ({n})",
     "runSchedule": "Run on a schedule:",
-    "disable": "Disable"
+    "disable": "Disable",
+    "signIn": "Sign in to use Add-Ons"
   },
   "addonBrowserDialog": {
     "browseAll": "Browse All Add-Ons",

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -705,11 +705,13 @@
     "disable": "Disable"
   },
   "addonBrowserDialog": {
+    "browseAll": "Browse All Add-Ons",
     "searchPlaceholder": "Search...",
     "active": "Active",
     "inactive": "Inactive",
     "next": "Next",
-    "previous": "Previous"
+    "previous": "Previous",
+    "viewsource": "View Source"
   },
   "uploadEmailDialog": {
     "uploadEmailAddress": "Upload via email",

--- a/src/manager/addons.js
+++ b/src/manager/addons.js
@@ -24,13 +24,11 @@ export const addons = new Svue({
     };
   },
   computed: {
-    addonsById(activeAddons) {
-      const results = {};
-      for (let i = 0; i < activeAddons.length; i++) {
-        const addon = activeAddons[i];
-        results[addon.id] = addon;
-      }
-      return results;
+    addonsById(browserAddons) {
+      return browserAddons.reduce((m, addon) => {
+        m[addon.id] = addon;
+        return m;
+      }, {});
     },
     addonsByRepo(browserAddons) {
       return browserAddons.reduce((m, addon) => {
@@ -78,9 +76,26 @@ export function removeRun(uuid) {
   addons.runs = addons.runs.filter((addon) => addon.uuid != uuid);
 }
 
-export async function getBrowserAddons(query = "", url = null) {
-  const newAddons = await getAddons(query, url);
+export async function getBrowserAddons(
+  query = "",
+  filters = {},
+  per_page = 5,
+  url = null,
+) {
+  const newAddons = await getAddons(query, filters, per_page, url);
   [addons.browserAddons, addons.browserNext, addons.browserPrev] = newAddons;
+}
+
+/**
+ * Fetch a single Add-On based on repository name, like Muckrock/Klaxon
+ *
+ * @export
+ * @param {string} [repo=""]
+ * @returns import('../structure/addon').Addon
+ */
+export async function getAddonByRepository(repository = "") {
+  const [addons, next, previous] = await getAddons("", { repository }, 1);
+  return addons[0] || null; // there should be only one, or nothing
 }
 
 export async function toggleActiveAddon(addon) {

--- a/src/manager/addons.js
+++ b/src/manager/addons.js
@@ -6,9 +6,7 @@ import {
   getAddonRuns,
   activateAddon,
   updateAddonRun,
-} from "@/api/addon";
-import { AddonRun } from "@/structure/addon";
-import { layout } from "@/manager/layout";
+} from "@/api/addon.js";
 
 export function done(run) {
   return run.status != "queued" && run.status != "in_progress";
@@ -89,10 +87,12 @@ export async function toggleActiveAddon(addon) {
     addons.activeAddons = addons.activeAddons.filter((a) => a.id != addon.id);
   }
   // then update the state in the browser list
-  addons.browserAddons = addons.browserAddons.map((a) => (a == addon) ? newAddon : a);
+  addons.browserAddons = addons.browserAddons.map((a) =>
+    a == addon ? newAddon : a,
+  );
 }
 
 export async function editAddonRun(run, data) {
   const newRun = await updateAddonRun(run, data);
-  addons.runs = addons.runs.map((r) => r.uuid === newRun.uuid ? newRun : r);
+  addons.runs = addons.runs.map((r) => (r.uuid === newRun.uuid ? newRun : r));
 }

--- a/src/manager/addons.js
+++ b/src/manager/addons.js
@@ -32,6 +32,12 @@ export const addons = new Svue({
       }
       return results;
     },
+    addonsByRepo(browserAddons) {
+      return browserAddons.reduce((m, addon) => {
+        m[addon.repository] = addon;
+        return m;
+      }, {});
+    },
     pollEvents(runs) {
       if (runs.filter((x) => !done(x)).length === 0) return [];
       return [updateRuns];

--- a/src/manager/documents.js
+++ b/src/manager/documents.js
@@ -365,7 +365,12 @@ export async function markAsDirty(docIds) {
   }
 }
 
-export async function reprocessDocuments(documents, forceOcr, ocrEngine, language) {
+export async function reprocessDocuments(
+  documents,
+  forceOcr,
+  ocrEngine,
+  language,
+) {
   await wrapLoad(layout, async () => {
     const ids = documents.map((doc) => doc.id);
     await editMetadata(

--- a/src/manager/layout.js
+++ b/src/manager/layout.js
@@ -25,7 +25,6 @@ export const layout = new Svue({
 
       // Custom dialogs
       addonDispatchOpen: null,
-      addOnEvent: null,
       addonBrowserOpen: false,
       metaOpen: null,
       documentInfoOpen: false,
@@ -37,6 +36,11 @@ export const layout = new Svue({
       searchTipsOpen: false,
       diagnosticsOpen: false,
       mailkeyOpen: false,
+
+      // nest any captured URL params here
+      params: {
+        addOnEvent: null,
+      },
 
       // Data
       dataDocuments: [],

--- a/src/manager/layout.js
+++ b/src/manager/layout.js
@@ -194,7 +194,6 @@ export function openAddonBrowser() {
   layout.addonBrowserOpen = true;
 }
 export function hideAddonBrowser() {
-  console.log("hide addon browser");
   setHash("");
   setQS(new URLSearchParams(), ["q"]); // clear query params
   layout.addonBrowserOpen = false;

--- a/src/manager/layout.js
+++ b/src/manager/layout.js
@@ -1,7 +1,7 @@
 import { Svue } from "svue";
-import { router } from "@/router/router";
-import { truthyParamValue } from "@/util/url";
-import { sameProp } from "@/util/array";
+import { router, setHash } from "@/router/router.js";
+import { truthyParamValue } from "@/util/url.js";
+import { sameProp } from "@/util/array.js";
 
 // Used to calculate the most restricted level of access
 // in a group of documents
@@ -24,7 +24,8 @@ export const layout = new Svue({
       selectedMap: {},
 
       // Custom dialogs
-      addonDispatchOpen: false,
+      addonDispatchOpen: null,
+      addOnEvent: null,
       addonBrowserOpen: false,
       metaOpen: null,
       documentInfoOpen: false,
@@ -166,16 +167,29 @@ export function unselectDocument(document) {
 
 // Dialogs
 export function openDispatchAddon(addon) {
+  const { repository } = addon.addon;
+  setHash(`add-ons/${repository}`);
   layout.addonDispatchOpen = addon;
 }
+
+export function showAddonEvent(addon, eventId) {
+  const { repository } = addon.addon;
+  setHash(`add-ons/${repository}/${eventId}`);
+  layout.addonDispatchOpen = addon;
+  layout.addOnEvent = eventId;
+}
+
 export function hideAddonDispatch() {
-  layout.addonDispatchOpen = false;
+  setHash("");
+  layout.addonDispatchOpen = null;
 }
 
 export function openAddonBrowser() {
+  setHash("add-ons");
   layout.addonBrowserOpen = true;
 }
 export function hideAddonBrowser() {
+  setHash("");
   layout.addonBrowserOpen = false;
 }
 

--- a/src/manager/layout.js
+++ b/src/manager/layout.js
@@ -1,5 +1,5 @@
 import { Svue } from "svue";
-import { router, setHash } from "@/router/router.js";
+import { router, setHash, setQS } from "@/router/router.js";
 import { truthyParamValue } from "@/util/url.js";
 import { sameProp } from "@/util/array.js";
 
@@ -185,6 +185,7 @@ export function showAddonEvent(addon, eventId) {
 
 export function hideAddonDispatch() {
   setHash("");
+  setQS(new URLSearchParams(), ["q"]); // clear query params
   layout.addonDispatchOpen = null;
 }
 
@@ -193,7 +194,9 @@ export function openAddonBrowser() {
   layout.addonBrowserOpen = true;
 }
 export function hideAddonBrowser() {
+  console.log("hide addon browser");
   setHash("");
+  setQS(new URLSearchParams(), ["q"]); // clear query params
   layout.addonBrowserOpen = false;
 }
 

--- a/src/pages/app/AddonStatus.svelte
+++ b/src/pages/app/AddonStatus.svelte
@@ -1,22 +1,22 @@
 <script>
-  import AddonRun from "@/common/AddonRun";
-  import { addons } from "@/manager/addons";
+  import AddonRun from "@/common/AddonRun.svelte";
+  import { addons } from "@/manager/addons.js";
 </script>
 
-<style lang="scss">
+<style>
   .addonStatus {
     background: #eff7ff;
-    border-radius: $radius;
+    border-radius: var(--radius, 3px);
     padding: 0;
     margin: 20px 0;
+  }
 
-    .title {
-      font-weight: bold;
-      display: inline-block;
-      vertical-align: middle;
-      font-size: 18px;
-      padding: 8px 20px;
-    }
+  .addonStatus .title {
+    font-weight: bold;
+    display: inline-block;
+    vertical-align: middle;
+    font-size: 18px;
+    padding: 8px 20px;
   }
 </style>
 

--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -39,6 +39,7 @@
         const addon = addons.addonsByRepo[`${org}/${name}`];
         if (addon) {
           layout.addonDispatchOpen = addon;
+          layout.params.addOnEvent = null;
         } else {
           console.error("Add-on not found: %s", `${org}/${name}`);
         }
@@ -55,7 +56,7 @@
         const addon = addons.addonsByRepo[`${org}/${name}`];
         if (addon) {
           layout.addonDispatchOpen = addon;
-          layout.addOnEvent = +id;
+          layout.params.addOnEvent = +id;
         } else {
           console.error("Add-on not found: %s", `${org}/${name}`);
         }

--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -6,7 +6,11 @@
   import MainContainer from "./MainContainer.svelte";
 
   import { layout } from "@/manager/layout.js";
-  import { addons, getBrowserAddons } from "@/manager/addons.js";
+  import {
+    addons,
+    getBrowserAddons,
+    getAddonByRepository,
+  } from "@/manager/addons.js";
   import { documents } from "@/manager/documents.js";
   import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
 
@@ -33,15 +37,14 @@
     [
       /^#add-ons\/([-\w]+)\/([-\w]+)$/,
       async (match) => {
-        await getBrowserAddons();
-
         const [org, name] = match.slice(1, 3);
-        const addon = addons.addonsByRepo[`${org}/${name}`];
+        const repo = `${org}/${name}`;
+        const addon = await getAddonByRepository(repo);
         if (addon) {
           layout.addonDispatchOpen = addon;
           layout.params.addOnEvent = null;
         } else {
-          console.error("Add-on not found: %s", `${org}/${name}`);
+          console.error("Add-on not found: %s", repo);
         }
       },
     ],
@@ -50,15 +53,14 @@
     [
       /^#add-ons\/(?<org>[-\w]+)\/(?<name>[-\w]+)\/(?<id>\d+)$/,
       async (match) => {
-        await getBrowserAddons();
-
         const [org, name, id] = match.slice(1, 4);
-        const addon = addons.addonsByRepo[`${org}/${name}`];
+        const repo = `${org}/${name}`;
+        const addon = await getAddonByRepository(repo);
         if (addon) {
           layout.addonDispatchOpen = addon;
           layout.params.addOnEvent = +id;
         } else {
-          console.error("Add-on not found: %s", `${org}/${name}`);
+          console.error("Add-on not found: %s", repo);
         }
       },
     ],

--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -1,12 +1,68 @@
 <script>
   import { onMount } from "svelte";
-  import Sidebar from "./sidebar/Sidebar";
-  import MainContainer from "./MainContainer";
   import { _ } from "svelte-i18n";
 
-  import { layout } from "@/manager/layout";
-  import { documents } from "@/manager/documents";
+  import Sidebar from "./sidebar/Sidebar.svelte";
+  import MainContainer from "./MainContainer.svelte";
+
+  import { layout } from "@/manager/layout.js";
+  import { addons, getBrowserAddons } from "@/manager/addons.js";
+  import { documents } from "@/manager/documents.js";
   import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
+
+  // hash routing, like in Viewer.svelte
+  // [regexp, callback]
+  const navHandlers = [
+    [
+      /^#$/,
+      (match) => {
+        layout.addonBrowserOpen = false;
+      },
+    ],
+
+    // list add-ons
+    [
+      /^#add-ons$/,
+      async (match) => {
+        await getBrowserAddons();
+        layout.addonBrowserOpen = true;
+      },
+    ],
+
+    // initial add-on view
+    [
+      /^#add-ons\/([-\w]+)\/([-\w]+)$/,
+      async (match) => {
+        await getBrowserAddons();
+
+        const [org, name] = match.slice(1, 3);
+        const addon = addons.addonsByRepo[`${org}/${name}`];
+        if (addon) {
+          layout.addonDispatchOpen = addon;
+        } else {
+          console.error("Add-on not found: %s", `${org}/${name}`);
+        }
+      },
+    ],
+
+    // configured add-on
+    [
+      /^#add-ons\/(?<org>[-\w]+)\/(?<name>[-\w]+)\/(?<id>\d+)$/,
+      async (match) => {
+        console.log(match);
+        await getBrowserAddons();
+
+        const [org, name, id] = match.slice(1, 4);
+        const addon = addons.addonsByRepo[`${org}/${name}`];
+        if (addon) {
+          layout.addonDispatchOpen = addon;
+          layout.addOnEvent = id;
+        } else {
+          console.error("Add-on not found: %s", `${org}/${name}`);
+        }
+      },
+    ],
+  ];
 
   let sidebar = null;
 
@@ -18,6 +74,22 @@
     }
   }
 
+  function hashRoute() {
+    const hash = window.location.hash;
+    if (hash === "") {
+      const callback = navHandlers[0][1];
+      return callback();
+    }
+
+    navHandlers.find(([route, callback]) => {
+      const match = route.exec(hash);
+      if (match) {
+        callback(match);
+        return true; // stop the loop
+      }
+    });
+  }
+
   onMount(() => {
     window.plausible =
       window.plausible ||
@@ -26,8 +98,15 @@
       };
 
     plausible("pageview");
+    hashRoute();
+
+    // debug
+    window.layout = layout;
+    window.addons = addons;
   });
 </script>
+
+<svelte:window on:hashchange={hashRoute} />
 
 <svelte:head>
   <title>{$_("common.documentCloud")}</title>

--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -49,14 +49,13 @@
     [
       /^#add-ons\/(?<org>[-\w]+)\/(?<name>[-\w]+)\/(?<id>\d+)$/,
       async (match) => {
-        console.log(match);
         await getBrowserAddons();
 
         const [org, name, id] = match.slice(1, 4);
         const addon = addons.addonsByRepo[`${org}/${name}`];
         if (addon) {
           layout.addonDispatchOpen = addon;
-          layout.addOnEvent = id;
+          layout.addOnEvent = +id;
         } else {
           console.error("Add-on not found: %s", `${org}/${name}`);
         }

--- a/src/pages/app/menus/AddonsMenu.svelte
+++ b/src/pages/app/menus/AddonsMenu.svelte
@@ -1,12 +1,14 @@
 <script>
   import { onMount } from "svelte";
-  import Menu from "@/common/Menu";
-  import MenuItem from "@/common/MenuItem";
-  import AddonMenuItem from "./AddonMenuItem";
-
-  import { openAddonBrowser } from "@/manager/layout";
-  import { addons, getBrowserAddons } from "@/manager/addons";
   import { _ } from "svelte-i18n";
+
+  import Menu from "@/common/Menu.svelte";
+  import MenuItem from "@/common/MenuItem.svelte";
+  import AddonMenuItem from "./AddonMenuItem.svelte";
+
+  import { openAddonBrowser } from "@/manager/layout.js";
+  import { addons, getBrowserAddons } from "@/manager/addons.js";
+  import { setHash } from "@/router/router.js";
 
   function sort(addons) {
     if (addons == null) return [];
@@ -21,7 +23,7 @@
   async function openBrowser() {
     await getBrowserAddons();
     openAddonBrowser();
-
+    setHash("add-ons");
     plausible("app-add-ons", { props: { target: "browser" } });
   }
 
@@ -34,11 +36,11 @@
   });
 </script>
 
-<style lang="scss">
+<style>
   .promo {
-    color: $darkgray;
+    color: var(--darkgray, rgba(0, 0, 0, 0.8));
     font-style: italic;
-    font-size: $normal;
+    font-size: var(--normal, 16px);
   }
 </style>
 

--- a/src/pages/app/sidebar/Sidebar.svelte
+++ b/src/pages/app/sidebar/Sidebar.svelte
@@ -1,9 +1,9 @@
 <script>
-  import emitter from "@/emit";
+  import emitter from "@/emit.js";
 
   // Components
-  import Hamburger from "@/common/Hamburger";
-  import Logo from "@/common/Logo";
+  import Hamburger from "@/common/Hamburger.svelte";
+  import Logo from "@/common/Logo.svelte";
 
   import ProjectFilters from "./ProjectFilters.svelte";
   import Projects from "./Projects.svelte";

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -1,7 +1,7 @@
 import rlite from "rlite-router";
 import { Svue } from "svue";
 import Empty from "@/pages/home/Empty.svelte"; // explicit extension for tests
-import { lazyComponent } from "@/util/lazyComponent";
+import { lazyComponent } from "@/util/lazyComponent.js";
 
 const endings = [".html", ".html"];
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -111,6 +111,26 @@ export function setHash(hash) {
   url.hash = hash;
   pushUrl(url.pathname + url.search + url.hash);
 }
+/**
+ * Set (and overwrite) the URL search
+ *
+ * @export
+ * @param {URLSearchParams} qs Query args to set
+ * @param {Array<String>} keep Keys to preserve
+ */
+export function setQS(qs, keep = []) {
+  const url = new URL(router.currentUrl, window.location.href);
+  const keys = Array.from(url.searchParams).filter(([k, v]) =>
+    keep.includes(k),
+  );
+
+  url.search = "";
+  [...keys, ...qs].forEach(([k, v]) => {
+    url.searchParams.set(k, v);
+  });
+
+  pushUrl(url.pathname + url.search + url.hash);
+}
 
 export function goBack(fallback = FALLBACK_URL) {
   if (router.pastUrl != null) {

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -126,7 +126,7 @@ export function setQS(qs, keep = []) {
 
   url.search = "";
   [...keys, ...qs].forEach(([k, v]) => {
-    url.searchParams.set(k, v);
+    url.searchParams.set(k, String(v).trim());
   });
 
   pushUrl(url.pathname + url.search + url.hash);

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -105,6 +105,13 @@ export function pushUrl(url) {
   );
 }
 
+// for hash routing in App.svelte and Viewer.svelte
+export function setHash(hash) {
+  const url = new URL(router.currentUrl, window.location.href);
+  url.hash = hash;
+  pushUrl(url.pathname + url.search + url.hash);
+}
+
 export function goBack(fallback = FALLBACK_URL) {
   if (router.pastUrl != null) {
     window.history.back();

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,4 +1,4 @@
-import NotFound from "@/pages/NotFound";
+import NotFound from "@/pages/NotFound.svelte";
 import {
   loadDefault,
   loadHome,
@@ -9,7 +9,7 @@ import {
   loadProject,
   loadLegacyRedirect,
   loadEntities,
-} from "@/util/lazyComponent";
+} from "@/util/lazyComponent.js";
 
 export const routes = [
   NotFound,
@@ -29,6 +29,23 @@ export const routes = [
       component: lazyComponent.app,
       get: loadApp,
     },
+
+    addonList: {
+      path: "/app/add-ons",
+      component: lazyComponent.app,
+      get: loadApp,
+    },
+    addonDetail: {
+      path: "/app/add-ons/:org/:name",
+      component: lazyComponent.app,
+      get: loadApp,
+    },
+    addonEvent: {
+      path: "/app/add-ons/:org/:name/:id",
+      component: lazyComponent.app,
+      get: loadApp,
+    },
+
     viewer: {
       path: "/documents/:id",
       component: lazyComponent.viewer,

--- a/src/structure/addon.js
+++ b/src/structure/addon.js
@@ -68,7 +68,7 @@ export class AddonRun extends Svue {
           return addonRun.status;
         },
         failure(status) {
-          return (status === "failure" || status === "cancelled");
+          return status === "failure" || status === "cancelled";
         },
         progress(addonRun) {
           return addonRun.progress;
@@ -107,7 +107,6 @@ export class AddonRun extends Svue {
   }
 }
 
-
 export class AddonEvent extends Svue {
   constructor(rawAddonEvent, structure = {}) {
     const computed = structure.computed == null ? {} : structure.computed;
@@ -135,4 +134,3 @@ export class AddonEvent extends Svue {
     });
   }
 }
-


### PR DESCRIPTION
Lots happening here:
- Formatting and cleanup some unused imports
- Hash URLs mostly working
- loading events
- Maybe finally getting state right
- un-sass
- Load initial values from querystring
- Use that new API filter
- Handle anonymous users linking to add-ons
- Cleanup URL on close
- remove a console.log
- Trim params
- structuredClone isn't available on older firefox

See it working on staging: https://www.staging.documentcloud.org/app?q=%2Buser%3Afreeuser-100013&site=https://www.muckrock.com#add-ons/MuckRock/documentcloud-scraper-addon

That will open the Add-On dispatch dialog with the `site` field pre-filled. Any add-on properties present in the querystring become initial values in the form, so this will help with Klaxon and probably other add-ons. When you close the modal, we clean up the querystring.
