### PR TITLE
Fix API calls for add-on pagination

### DIFF
--- a/src/api/addon.js
+++ b/src/api/addon.js
@@ -16,12 +16,12 @@ export async function getActiveAddons() {
   return results.map((result) => new Addon(result));
 }
 
-export async function getAddons(
+export async function getAddons({
   query = "",
   filters = {},
   per_page = 5,
   url = null,
-) {
+} = {}) {
   // Use the URL from the next or previous url in the response
   if (!url) {
     url = apiUrl(queryBuilder("addons/", { ...filters, query, per_page }));

--- a/src/common/dialog/AddonBrowserDialog.svelte
+++ b/src/common/dialog/AddonBrowserDialog.svelte
@@ -16,11 +16,11 @@
   });
 
   const handleInput = debounce((e) => {
-    getBrowserAddons(e.target.value);
+    getBrowserAddons({ query: e.target.value });
   }, 300);
 
   function changePage(url) {
-    getBrowserAddons("", url);
+    getBrowserAddons({ url });
     // scroll to top of modal
     document.getElementsByClassName("modal")[0].scroll({ top: 0 });
   }

--- a/src/manager/addons.js
+++ b/src/manager/addons.js
@@ -76,13 +76,13 @@ export function removeRun(uuid) {
   addons.runs = addons.runs.filter((addon) => addon.uuid != uuid);
 }
 
-export async function getBrowserAddons(
+export async function getBrowserAddons({
   query = "",
   filters = {},
   per_page = 5,
   url = null,
-) {
-  const newAddons = await getAddons(query, filters, per_page, url);
+} = {}) {
+  const newAddons = await getAddons({ query, filters, per_page, url });
   [addons.browserAddons, addons.browserNext, addons.browserPrev] = newAddons;
 }
 
@@ -94,7 +94,10 @@ export async function getBrowserAddons(
  * @returns import('../structure/addon').Addon
  */
 export async function getAddonByRepository(repository = "") {
-  const [addons, next, previous] = await getAddons("", { repository }, 1);
+  const [addons, next, previous] = await getAddons({
+    filters: { repository },
+    per_page: 1,
+  });
   return addons[0] || null; // there should be only one, or nothing
 }
 


### PR DESCRIPTION
Made API methods with more than two arguments take destructured objects instead of positional arguments, and fixed calls as needed. 