### PR TITLE
Env fixes

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -7,7 +7,7 @@ services:
       - nodemodules:/app/node_modules
       - .:/app
     working_dir: /app
-    command: npm run dev
+    command: npm run watch
     networks:
       default:
         aliases:

--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
     "dev-app": "cross-env NODE_ENV=development SUPPRESS_WARNINGS=1 webpack serve --config webpack.app.config.js",
     "dev-embed": "cross-env NODE_ENV=development webpack --config webpack.embed.config.js",
     "test": "jest",
-    "watch": "cross-env NODE_ENV=development webpack watch --config webpack.app.config.js",
+    "serve": "serve public -l 80 --single",
+    "watch-app": "cross-env NODE_ENV=development webpack watch --config webpack.app.config.js",
+    "watch": "concurrently npm:dev-embed npm:watch-app npm:serve",
     "test-watch": "jest --watchAll",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -102,7 +102,10 @@ module.exports = wrap({
     new MiniCssExtractPlugin({
       filename: "[name].[contenthash].css",
     }),
-    new DotEnv(),
+    new DotEnv({
+      path: prod ? `.env.${environment}` : ".env",
+      defaults: ".env",
+    }),
     new CircularDependencyPlugin({
       // exclude detection of files based on a RegExp
       exclude: /node_modules/,


### PR DESCRIPTION
Configure `webpack-dotenv` to always load `.env` and sometimes load `.env.staging` or `.env.production` as appropriate.