### PR TITLE
Set text fields null when blank and filter out nulls

### DIFF
--- a/src/addons/dispatch/Form.svelte
+++ b/src/addons/dispatch/Form.svelte
@@ -13,6 +13,7 @@
 <script lang="ts">
   import Ajv from "ajv";
   import addFormats from "ajv-formats";
+  import { beforeUpdate } from "svelte";
   import { _ } from "svelte-i18n";
 
   // todo: figure out how to use a real path
@@ -46,9 +47,22 @@
   }
 
   export function validate() {
+    $values = noNulls($values);
     const valid = validator($values);
 
     return { valid, errors: validator.errors };
+  }
+
+  function noNulls(values) {
+    return Object.entries(values).reduce(
+      (m, [k, v]) => {
+        if (v !== null) {
+          m[k] = v;
+        }
+        return m;
+      },
+      { event: "disabled", selection: null },
+    );
   }
 </script>
 

--- a/src/addons/dispatch/fields/Text.svelte
+++ b/src/addons/dispatch/fields/Text.svelte
@@ -4,7 +4,7 @@
   export let title: string;
   export let name: string;
   export let defaultValue: string = "";
-  export let value: string = defaultValue;
+  export let value: string = defaultValue || null;
   export let required: boolean = false;
   export let placeholder: string = "";
   export let description: string = "";


### PR DESCRIPTION
Text fields were defaulting to an empty string, and that was tripping up validation. This should fix that issue.

TODO: Show validation errors on non-required fields.