### PR TITLE
Production push: addon sidebar

### DIFF
--- a/src/Main.svelte
+++ b/src/Main.svelte
@@ -7,13 +7,13 @@
 
   import Empty from "./pages/home/Empty.svelte";
 
-  import { router } from "@/router/router.js";
-  import { routes } from "@/routes.js";
-  import { currentUrl } from "@/util/url.js";
-  import "@/langs/i18n.js";
+  import { router } from "./router/router.js";
+  import { routes } from "./routes.js";
+  import { currentUrl } from "./util/url.js";
+  import "./langs/i18n.js";
 
   // Patch poll events
-  import "@/ticker/ticker.js";
+  import "./ticker/ticker.js";
 
   // Set up routes
   router.notFound = routes[0];

--- a/src/addons/browser/AddOnList.svelte
+++ b/src/addons/browser/AddOnList.svelte
@@ -20,6 +20,7 @@
   export let loading: boolean;
   export let error: string | undefined;
   export let reload: () => void | undefined;
+
   $: empty = !(items && items.length > 0);
 </script>
 
@@ -80,8 +81,8 @@
     <p>{$_("addonBrowserDialog.empty")}</p>
   {:else}
     <ul>
-      {#each items as addOn (addOn.id)}
-        <li><ListItem {...addOn} /></li>
+      {#each items as addon (addon.id)}
+        <li><ListItem {addon} /></li>
       {/each}
     </ul>
   {/if}

--- a/src/addons/browser/AddOnList.svelte
+++ b/src/addons/browser/AddOnList.svelte
@@ -10,11 +10,12 @@
 
 <script lang="ts">
   import { _ } from "svelte-i18n";
-  import Loader from "../../common/Loader.svelte";
-  import Error from "../../common/icons/Error.svelte";
-  import ListItem from "./AddOnListItem.svelte";
-  import EmptyResults from "../../common/icons/EmptyResults.svelte";
   import Button from "../../common/Button.svelte";
+  import EmptyResults from "../../common/icons/EmptyResults.svelte";
+  import Error from "../../common/icons/Error.svelte";
+  import Loader from "../../common/Loader.svelte";
+
+  import ListItem from "./AddOnListItem.svelte";
 
   export let items: AddOnListItem[];
   export let loading: boolean;

--- a/src/addons/browser/AddOnListItem.svelte
+++ b/src/addons/browser/AddOnListItem.svelte
@@ -72,6 +72,11 @@
       addon.active = !addon.active;
       console.error(`Problem updating add-on: ${resp.statusText}`);
     }
+
+    // now that we've updated, set $pinned
+    $pinned = addon.active
+      ? [...$pinned, addon]
+      : $pinned.filter((a) => a.id !== addon.id);
   }
 </script>
 

--- a/src/addons/browser/AddOnListItem.svelte
+++ b/src/addons/browser/AddOnListItem.svelte
@@ -1,4 +1,6 @@
 <script lang="ts" context="module">
+  import { writable, type Writable } from "svelte/store";
+
   interface Author {
     name?: string;
     avatar?: string;
@@ -19,6 +21,8 @@
     featured: boolean;
     default: boolean;
   }
+
+  export const pinned: Writable<AddOnListItem[]> = writable([]);
 </script>
 
 <script lang="ts">
@@ -29,26 +33,15 @@
   import Pin from "../../common/Pin.svelte";
   import AddOnPopularity from "../Popularity.svelte";
 
-  export let id: number = undefined;
-  export let active = false;
-  export let name: string = undefined;
-  export let repository: string = undefined;
-  export let parameters: any = {};
+  export let addon: AddOnListItem;
 
-  export let description: string = undefined;
-  export let author: Author = {
-    name: undefined,
-    avatar: undefined,
-  };
-  export let usage: number = undefined;
-
-  $: endpoint = new URL(`/api/addons/${id}/`, baseApiUrl);
-  $: description = parameters?.description;
-  $: if (!author.name) {
-    author.name = repository.split("/")[0];
+  $: endpoint = new URL(`/api/addons/${addon.id}/`, baseApiUrl);
+  $: description = addon.parameters?.description;
+  $: if (!addon?.author) {
+    addon.author = { name: addon?.repository?.split("/")[0] };
   }
 
-  $: url = `#add-ons/${repository}`;
+  $: url = `#add-ons/${addon.repository}`;
 
   async function toggle(event) {
     event.preventDefault();
@@ -61,14 +54,13 @@
     };
 
     // optimistic update
-    active = !active;
-    console.log(`${active ? "Pinning" : "Unpinning"} ${id}...`);
+    addon.active = !addon.active;
 
     const resp = await fetch(endpoint, {
       ...options,
-      body: JSON.stringify({ active }),
+      body: JSON.stringify({ active: addon.active }),
     }).catch((err) => {
-      active = !active;
+      addon.active = !addon.active;
       return {
         ok: false,
         statusText: String(err),
@@ -77,7 +69,7 @@
 
     if (!resp.ok) {
       // reset active state
-      active = !active;
+      addon.active = !addon.active;
       console.error(`Problem updating add-on: ${resp.statusText}`);
     }
   }
@@ -146,27 +138,27 @@
 </style>
 
 <a class="addon-link" href={url}>
-  <div class="container" id={repository}>
+  <div class="container" id={addon.repository}>
     <div class="top-row">
       <div class="center-self">
-        <Pin {active} on:click={toggle} />
+        <Pin active={addon.active} on:click={toggle} />
       </div>
       <div class="stretch">
-        <h3 class="addon-name">{name}</h3>
+        <h3 class="addon-name">{addon.name}</h3>
       </div>
       <div class="metadata">
-        {#if author && author.name}
+        {#if addon?.author?.name}
           <p class="author">
             <a
-              href="http://github.com/{repository}"
+              href="http://github.com/{addon.repository}"
               target="_blank"
               rel="noopener noreferrer"
-              title={$_("addonBrowserDialog.viewsource")}>{author.name}</a
+              title={$_("addonBrowserDialog.viewsource")}>{addon.author.name}</a
             >
           </p>
         {/if}
-        {#if usage}
-          <AddOnPopularity useCount={usage} />
+        {#if addon.usage}
+          <AddOnPopularity useCount={addon.usage} />
         {/if}
       </div>
     </div>

--- a/src/addons/browser/stories/AddOnListItem.stories.svelte
+++ b/src/addons/browser/stories/AddOnListItem.stories.svelte
@@ -4,7 +4,7 @@
 
   import AddOnListItem from "../AddOnListItem.svelte";
 
-  const args = {
+  const addon = {
     active: false,
     name: "Scraper",
     repository: "MuckRock/documentcloud-scraper-addon",
@@ -14,6 +14,8 @@
         "This add-on will scrape and optionally crawl a given site for documents to upload to DocumentCloud. It can also alert you of given keywords appearing in those documents.",
     },
   };
+
+  const args = { addon };
 
   const onClick = action("Click");
 </script>
@@ -38,15 +40,17 @@
 </Template>
 
 <Story name="Default" {args} />
-<Story name="Pinned" args={{ ...args, active: true }} />
+<Story name="Pinned" args={{ addon: { ...addon, active: true } }} />
 <Story
   name="Long Description"
   args={{
-    ...args,
-    name: "SideKick",
-    parameters: {
-      description:
-        "SideKick is machine learning tool designed to help you quickly test ways to categorize large documents sets, apply machine learning to try to sort documents into one set or another, and get feedback on how well the model works. We're working on launching an improved, real-time graphical categorization tool, but in the meantime, this Add-On will let you get started. # Step 1: Select a project on the left-hand sidebar before running this Add-On. If you need to, click *Cancel*, select a project, and start SideKick again. # Step 2: Use DocumentCloud's *Edit->Edit Document Data* feature to add a key value pair with the category you want, with about five examples of documents that match a category and five that don't. For example, you might add a key of *Email* with five documents set to *True* and five set to *False*. Since *Email* is the value you're training on, set it as the *Value to Train* below. SideKick is a binary classifier — it will try to rank all documents on a spectrum from -1 to 1 based on how likely it believe the document is to be that value.",
+    addon: {
+      ...args,
+      name: "SideKick",
+      parameters: {
+        description:
+          "SideKick is machine learning tool designed to help you quickly test ways to categorize large documents sets, apply machine learning to try to sort documents into one set or another, and get feedback on how well the model works. We're working on launching an improved, real-time graphical categorization tool, but in the meantime, this Add-On will let you get started. # Step 1: Select a project on the left-hand sidebar before running this Add-On. If you need to, click *Cancel*, select a project, and start SideKick again. # Step 2: Use DocumentCloud's *Edit->Edit Document Data* feature to add a key value pair with the category you want, with about five examples of documents that match a category and five that don't. For example, you might add a key of *Email* with five documents set to *True* and five set to *False*. Since *Email* is the value you're training on, set it as the *Value to Train* below. SideKick is a binary classifier — it will try to rank all documents on a spectrum from -1 to 1 based on how likely it believe the document is to be that value.",
+      },
     },
   }}
 />

--- a/src/addons/browser/stories/Browser.stories.svelte
+++ b/src/addons/browser/stories/Browser.stories.svelte
@@ -4,7 +4,7 @@
 
   import Browser from "../Browser.svelte";
   import listFixture from "../../fixtures/addon-list.json";
-  import { baseApiUrl } from "../../../api/base";
+  import { baseApiUrl } from "../../../api/base.js";
 
   const args = { visible: true };
   const mockUrl = new URL(`addons/`, baseApiUrl).toString();

--- a/src/addons/dispatch/Dispatch.svelte
+++ b/src/addons/dispatch/Dispatch.svelte
@@ -13,7 +13,7 @@
   import Header from "./Header.svelte";
   import Selection from "./Selection.svelte";
   import ScheduledInset from "./ScheduledInset.svelte";
-  import { schedules } from "../runs/ScheduledEvent.svelte";
+  import { eventValues, schedules } from "../runs/ScheduledEvent.svelte";
 
   import { baseApiUrl } from "../../api/base.js";
   import { getCsrfToken } from "../../api/session.js";
@@ -23,14 +23,6 @@
   export let visible: boolean = false;
   export let addon: AddOnListItem;
   export let event: Event;
-
-  const eventValues = {
-    disabled: 0,
-    hourly: 1,
-    daily: 2,
-    weekly: 3,
-    upload: 4,
-  };
 
   let error: Error | null;
 

--- a/src/addons/fixtures/addons-active.json
+++ b/src/addons/fixtures/addons-active.json
@@ -1,0 +1,251 @@
+{
+  "count": 6,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 480,
+      "user": 100000,
+      "organization": 10001,
+      "access": "public",
+      "name": "Empty Page Deleter",
+      "repository": "duckduckgrayduck/Empty-Page-Deletion",
+      "parameters": {
+        "type": "object",
+        "title": "Empty Page Deleter",
+        "required": ["project_id"],
+        "documents": ["selected", "query"],
+        "categories": ["file"],
+        "properties": {
+          "project_id": {
+            "type": "integer",
+            "title": "Project ID of the project you would like the documents uploaded to (required)"
+          }
+        },
+        "description": "<p>This Add-On detects pages with no text in a document, deletes the pages, and re-uploads the document with those pages removed.</p>"
+      },
+      "created_at": "2023-07-19T19:59:18.092909Z",
+      "updated_at": "2023-07-27T14:06:16.815280Z",
+      "active": true,
+      "default": false,
+      "featured": true
+    },
+    {
+      "id": 462,
+      "user": 100000,
+      "organization": 10001,
+      "access": "public",
+      "name": "Entity Export",
+      "repository": "MuckRock/documentcloud-entity-export-addon",
+      "parameters": {
+        "type": "object",
+        "title": "Entity Export",
+        "documents": ["query", "selected"],
+        "categories": ["ai"],
+        "properties": {},
+        "description": "<p>Export a CSV of the entities in your documents</p>"
+      },
+      "created_at": "2023-07-19T19:59:18.090336Z",
+      "updated_at": "2023-08-16T00:33:33.432959Z",
+      "active": true,
+      "default": false,
+      "featured": false
+    },
+    {
+      "id": 461,
+      "user": 100000,
+      "organization": 10001,
+      "access": "public",
+      "name": "Google Cloud Entity Extractor",
+      "repository": "MuckRock/documentcloud-google-entity-extractor-addon",
+      "parameters": {
+        "type": "object",
+        "title": "Google Cloud Entity Extractor",
+        "documents": ["selected"],
+        "categories": ["ai"],
+        "properties": {},
+        "description": "<p>Extract entities using Google Cloud&rsquo;s natural language API</p>"
+      },
+      "created_at": "2023-07-19T19:59:18.089005Z",
+      "updated_at": "2023-07-21T15:38:06.493007Z",
+      "active": true,
+      "default": false,
+      "featured": false
+    },
+    {
+      "id": 436,
+      "user": 100000,
+      "organization": 10001,
+      "access": "public",
+      "name": "Klaxon Site Monitor",
+      "repository": "MuckRock/Klaxon",
+      "parameters": {
+        "type": "object",
+        "title": "Klaxon Site Monitor",
+        "required": ["site", "selector"],
+        "categories": ["monitor"],
+        "properties": {
+          "site": {
+            "type": "string",
+            "title": "Site",
+            "format": "uri"
+          },
+          "selector": {
+            "type": "string",
+            "title": "Selector",
+            "description": "CSS Selector on the page you would like to monitor."
+          },
+          "slack_webhook": {
+            "type": "string",
+            "title": "Slack Webhook",
+            "format": "uri",
+            "description": "Enter a slack webhook to enable Slack notifications"
+          }
+        },
+        "description": "<p>Klaxon enables reporters and editors to monitor scores of sites and files on the web for newsworthy changes. \nGet email notifications when something changes. Provide an optional CSS selector to only monitor \nportions of a page you are interested in. To get started, copy the bookmarklet <a href=\"javascript:(function(){document.body.appendChild(document.createElement('script')).src='https://documentcloud-klaxon.s3.amazonaws.com/inject.js';})();\">Add to Klaxon</a> to your bookmarks, \nvisit a page you are looking to monitor, and then click on the bookmark to activate Klaxon. </p>",
+        "eventOptions": {
+          "name": "site",
+          "events": ["hourly", "daily", "weekly"]
+        }
+      },
+      "created_at": "2023-07-19T19:59:18.068046Z",
+      "updated_at": "2023-07-27T14:06:29.899202Z",
+      "active": true,
+      "default": false,
+      "featured": true
+    },
+    {
+      "id": 372,
+      "user": 100000,
+      "organization": 10001,
+      "access": "public",
+      "name": "PII Detector",
+      "repository": "MuckRock/PII-Detector",
+      "parameters": {
+        "type": "object",
+        "title": "PII Detector",
+        "documents": ["query", "selected"],
+        "categories": ["extraction", "monitor"],
+        "properties": {
+          "ssn": {
+            "type": "boolean",
+            "title": "Detect SSNs"
+          },
+          "zip": {
+            "type": "boolean",
+            "title": "Detect zipcodes"
+          },
+          "alert": {
+            "type": "boolean",
+            "title": "Notify by email when PII is detected in a document"
+          },
+          "email": {
+            "type": "boolean",
+            "title": "Detect emails"
+          },
+          "phone": {
+            "type": "boolean",
+            "title": "Detect phone numbers"
+          },
+          "access": {
+            "type": "string",
+            "title": "Access level of the annotations (public, private, organization)",
+            "default": "private"
+          },
+          "address": {
+            "type": "boolean",
+            "title": "Detect addresses"
+          },
+          "project_id": {
+            "type": "integer",
+            "title": "If you'd like to add documents where PII is detected to a project, provide the Project ID Here."
+          },
+          "credit_card": {
+            "type": "boolean",
+            "title": "Detect credit cards"
+          }
+        },
+        "description": "<p>This add-on will detect PII in a document, annotate where, and automatically e-mail you when sensitive PII is detected if you choose that option.</p>",
+        "eventOptions": {
+          "events": ["upload"]
+        }
+      },
+      "created_at": "2023-07-19T19:59:18.062382Z",
+      "updated_at": "2023-08-03T14:47:38.148954Z",
+      "active": true,
+      "default": false,
+      "featured": false
+    },
+    {
+      "id": 105,
+      "user": 100000,
+      "organization": 10001,
+      "access": "public",
+      "name": "Scraper",
+      "repository": "MuckRock/documentcloud-scraper-addon",
+      "parameters": {
+        "type": "object",
+        "title": "Scraper",
+        "required": ["site", "project"],
+        "categories": ["monitor"],
+        "properties": {
+          "site": {
+            "type": "string",
+            "title": "Site",
+            "format": "uri",
+            "description": "The URL of the site to start scraping"
+          },
+          "project": {
+            "type": "string",
+            "title": "Project",
+            "description": "The DocumentCloud project title or ID of the project the documents should be uploaded to.  If the project title does not exist, it will be created."
+          },
+          "filecoin": {
+            "type": "boolean",
+            "title": "Push to IPFS/Filecoin",
+            "description": "WARNING: This will push all scraped files to IPFS and Filecoin.   There is no way to remove files from these storage systems."
+          },
+          "keywords": {
+            "type": "string",
+            "title": "Keywords",
+            "description": "Keywords to search and notify on (comma separated)"
+          },
+          "notify_all": {
+            "type": "boolean",
+            "title": "Notify on all new documents"
+          },
+          "crawl_depth": {
+            "type": "integer",
+            "title": "Crawl Depth",
+            "default": 0,
+            "maximum": 2,
+            "minimum": 0,
+            "description": "Recursively scrape same-domain links found on the page (Must be between 0 and 2)"
+          },
+          "access_level": {
+            "type": "string",
+            "title": "Access Level",
+            "default": "public",
+            "description": "Access level (public, private, or organization) of documents scraped."
+          },
+          "slack_webhook": {
+            "type": "string",
+            "title": "Slack Webhook",
+            "format": "uri",
+            "description": "Enter a slack webhook to enable Slack notifications"
+          }
+        },
+        "description": "<p>This add-on will scrape and optionally crawl a given site for documents to upload to DocumentCloud.  It can also alert you of given keywords appearing in those documents.</p>",
+        "eventOptions": {
+          "name": "site",
+          "events": ["hourly", "daily", "weekly"]
+        }
+      },
+      "created_at": "2023-07-19T19:59:18.027007Z",
+      "updated_at": "2023-07-24T20:28:25.669788Z",
+      "active": true,
+      "default": true,
+      "featured": false
+    }
+  ]
+}

--- a/src/addons/runs/ScheduledEvent.svelte
+++ b/src/addons/runs/ScheduledEvent.svelte
@@ -12,7 +12,15 @@
     updated_at: string;
   }
 
+  // schedules and eventValues are the inverse of each other, so store them together
   export const schedules = ["disabled", "hourly", "daily", "weekly", "upload"];
+  export const eventValues = {
+    disabled: 0,
+    hourly: 1,
+    daily: 2,
+    weekly: 3,
+    upload: 4,
+  };
 </script>
 
 <script lang="ts">

--- a/src/addons/sidebar/AddonListItem.svelte
+++ b/src/addons/sidebar/AddonListItem.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { AddOnListItem } from "../browser/AddOnListItem.svelte";
+  import Pin from "../../common/icons/Pin.svelte";
+  import ListItem from "./ListItem.svelte";
+
+  export let addon: AddOnListItem;
+
+  $: href = `#add-ons/${addon.repository}`;
+  $: label = addon.name;
+</script>
+
+<style>
+  .icon {
+    fill: var(--highlight-orange);
+  }
+</style>
+
+<ListItem {href} {label}>
+  <div slot="icon" class="icon"><Pin title={label} /></div>
+</ListItem>

--- a/src/addons/sidebar/ListItem.svelte
+++ b/src/addons/sidebar/ListItem.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { AddOnListItem } from "../browser/AddOnListItem.svelte";
+  import Pin from "../../common/Pin.svelte";
+
+  export let addon: AddOnListItem;
+
+  $: url = `#add-ons/${addon.repository}`;
+</script>
+
+<style>
+  .addon {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  h4 {
+    margin: 0em auto 1em 0.5em;
+  }
+</style>
+
+<div class="addon">
+  <a href={url}><Pin active={addon.active} /></a>
+  <h4>
+    <a href={url}>{addon.name}</a>
+  </h4>
+</div>

--- a/src/addons/sidebar/ListItem.svelte
+++ b/src/addons/sidebar/ListItem.svelte
@@ -1,34 +1,33 @@
 <script lang="ts">
-  import type { AddOnListItem } from "../browser/AddOnListItem.svelte";
-  import Pin from "../../common/icons/Pin.svelte";
-
-  export let addon: AddOnListItem;
-
-  $: url = `#add-ons/${addon.repository}`;
+  export let href: string;
+  export let label: string;
 </script>
 
 <style>
-  .addon {
+  .list-item {
     display: flex;
-    align-items: flex-start;
     justify-content: flex-start;
+    gap: 0.5em;
+    padding: 0.25em 0.5em;
+    border-radius: var(--radius);
+    overflow: hidden;
+  }
+
+  .list-item:hover {
+    background-color: var(--menuBg);
+  }
+
+  .icon {
+    margin-top: 0.15em;
   }
 
   h4 {
-    margin: 0em auto 1em 0.5em;
-  }
-
-  .addon a {
-    fill: var(--highlight-orange);
+    margin: 0;
+    font-weight: 600;
   }
 </style>
 
-<div class="addon">
-  <a href={url}>
-    <Pin title={addon.name} />
-  </a>
-
-  <h4>
-    <a href={url}> {addon.name}</a>
-  </h4>
-</div>
+<a class="list-item" {href}>
+  {#if $$slots.icon}<div class="icon"><slot name="icon" /></div>{/if}
+  <h4>{label}</h4>
+</a>

--- a/src/addons/sidebar/ListItem.svelte
+++ b/src/addons/sidebar/ListItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { AddOnListItem } from "../browser/AddOnListItem.svelte";
-  import Pin from "../../common/Pin.svelte";
+  import Pin from "../../common/icons/Pin.svelte";
 
   export let addon: AddOnListItem;
 
@@ -17,11 +17,18 @@
   h4 {
     margin: 0em auto 1em 0.5em;
   }
+
+  .addon a {
+    fill: var(--highlight-orange);
+  }
 </style>
 
 <div class="addon">
-  <a href={url}><Pin active={addon.active} /></a>
+  <a href={url}>
+    <Pin title={addon.name} />
+  </a>
+
   <h4>
-    <a href={url}>{addon.name}</a>
+    <a href={url}> {addon.name}</a>
   </h4>
 </div>

--- a/src/addons/sidebar/Sidebar.svelte
+++ b/src/addons/sidebar/Sidebar.svelte
@@ -37,7 +37,7 @@
 
 <style>
   .addon-sidebar {
-    padding: 0 24px;
+    padding: 0 1.5rem;
   }
 
   h4 a {

--- a/src/addons/sidebar/Sidebar.svelte
+++ b/src/addons/sidebar/Sidebar.svelte
@@ -5,6 +5,7 @@
 
   import { pinned, type AddOnListItem } from "../browser/AddOnListItem.svelte";
   import ListItem from "./ListItem.svelte";
+  import AddonListItem from "./AddonListItem.svelte";
   import { baseApiUrl } from "../../api/base.js";
 
   $: console.log($pinned);
@@ -40,24 +41,48 @@
     padding: 0 1.5rem;
   }
 
-  h4 a {
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-start;
-    gap: 0.5em;
+  .section-title {
+    margin: 0 0 0.5rem;
+    border-radius: var(--radius);
+    overflow: hidden;
+  }
+
+  .section-title a {
+    display: block;
+    padding: 0.25em 0.5em;
+  }
+
+  .section-title a:hover {
+    background-color: var(--menuBg);
+  }
+
+  .runs-icon {
+    fill: var(--gray);
+  }
+
+  ul {
+    margin: 0.5rem 0 0;
+    padding: 0;
+    list-style-type: none;
+  }
+
+  li {
+    margin: 0.25em 0;
   }
 </style>
 
 <div class="addon-sidebar">
-  <h3><a href="#add-ons">{$_("addonSidebar.title")}</a></h3>
-  <h4>
-    <a href="#add-ons/runs">
-      <ClockFill16 />
-      <span>{$_("addonSidebar.runs")}</span>
-    </a>
-  </h4>
-
-  {#each sort($pinned) as addon (addon.id)}
-    <ListItem {addon} />
-  {/each}
+  <h3 class="section-title">
+    <a href="#add-ons">{$_("addonSidebar.title")}</a>
+  </h3>
+  <ListItem href="#add-ons/runs" label={$_("addonSidebar.runs")}>
+    <span slot="icon" class="runs-icon"><ClockFill16 /></span>
+  </ListItem>
+  {#if $pinned.length}
+    <ul class="addons">
+      {#each sort($pinned) as addon (addon.id)}
+        <li><AddonListItem {addon} /></li>
+      {/each}
+    </ul>
+  {/if}
 </div>

--- a/src/addons/sidebar/Sidebar.svelte
+++ b/src/addons/sidebar/Sidebar.svelte
@@ -44,10 +44,7 @@
     display: flex;
     align-items: flex-start;
     justify-content: flex-start;
-  }
-
-  h4 a span {
-    margin: 0em 0.5em;
+    gap: 0.5em;
   }
 </style>
 

--- a/src/addons/sidebar/Sidebar.svelte
+++ b/src/addons/sidebar/Sidebar.svelte
@@ -3,13 +3,13 @@
   import { _ } from "svelte-i18n";
   import { ClockFill16 } from "svelte-octicons";
 
-  import { pinned } from "../browser/AddOnListItem.svelte";
+  import { pinned, type AddOnListItem } from "../browser/AddOnListItem.svelte";
   import ListItem from "./ListItem.svelte";
   import { baseApiUrl } from "../../api/base.js";
 
   $: console.log($pinned);
 
-  const endpoint = new URL("/api/addons/?active=true", baseApiUrl);
+  const endpoint = new URL("/api/addons/?active=true&per_page=100", baseApiUrl);
   const options: RequestInit = {
     credentials: "include",
   };
@@ -24,6 +24,10 @@
       });
 
     $pinned = res.results;
+  }
+
+  function sort(addons: AddOnListItem[]) {
+    return addons.sort((a, b) => a.name.localeCompare(b.name));
   }
 
   onMount(async () => {
@@ -48,7 +52,7 @@
 </style>
 
 <div class="addon-sidebar">
-  <h3>{$_("addonSidebar.title")}</h3>
+  <h3><a href="#add-ons">{$_("addonSidebar.title")}</a></h3>
   <h4>
     <a href="#add-ons/runs">
       <ClockFill16 />
@@ -56,7 +60,7 @@
     </a>
   </h4>
 
-  {#each $pinned as addon (addon.id)}
+  {#each sort($pinned) as addon (addon.id)}
     <ListItem {addon} />
   {/each}
 </div>

--- a/src/addons/sidebar/Sidebar.svelte
+++ b/src/addons/sidebar/Sidebar.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { _ } from "svelte-i18n";
+  import { ClockFill16 } from "svelte-octicons";
+
+  import { pinned } from "../browser/AddOnListItem.svelte";
+  import ListItem from "./ListItem.svelte";
+  import { baseApiUrl } from "../../api/base.js";
+
+  $: console.log($pinned);
+
+  const endpoint = new URL("/api/addons/?active=true", baseApiUrl);
+  const options: RequestInit = {
+    credentials: "include",
+  };
+
+  async function load() {
+    console.log("Loading pinned add-ons");
+    const res = await fetch(endpoint, options)
+      .then((r) => r.json())
+      .catch((err) => {
+        console.error(err);
+        return { results: [] };
+      });
+
+    $pinned = res.results;
+  }
+
+  onMount(async () => {
+    await load();
+  });
+</script>
+
+<style>
+  .addon-sidebar {
+    padding: 0 24px;
+  }
+
+  h4 a {
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  h4 a span {
+    margin: 0em 0.5em;
+  }
+</style>
+
+<div class="addon-sidebar">
+  <h3>{$_("addonSidebar.title")}</h3>
+  <h4>
+    <a href="#add-ons/runs">
+      <ClockFill16 />
+      <span>{$_("addonSidebar.runs")}</span>
+    </a>
+  </h4>
+
+  {#each $pinned as addon (addon.id)}
+    <ListItem {addon} />
+  {/each}
+</div>

--- a/src/addons/sidebar/stories/ListItem.stories.svelte
+++ b/src/addons/sidebar/stories/ListItem.stories.svelte
@@ -1,0 +1,38 @@
+<script>
+  import { Meta, Story, Template } from "@storybook/addon-svelte-csf";
+  import ListItem from "../ListItem.svelte";
+  import Pin from "../../../common/icons/Pin.svelte";
+</script>
+
+<style>
+  .sidebar {
+    width: var(--sidebar-width);
+    background-color: var(--sidebar);
+  }
+  .icon {
+    fill: var(--highlight-orange);
+  }
+</style>
+
+<Meta
+  title="Add-Ons / Sidebar / List Item"
+  tags={["autodocs"]}
+  parameters={{ layout: "centered" }}
+  component={ListItem}
+/>
+
+<Template let:args>
+  <div class="sidebar">
+    <ListItem {...args}>
+      <span slot="icon" class="icon"><Pin /></span>
+    </ListItem>
+  </div>
+</Template>
+
+<Story
+  name="ListItem"
+  args={{
+    href: "#addon/duckduckgrayduck/Empty-Page-Deletion",
+    label: "Empty Page Deleter",
+  }}
+/>

--- a/src/addons/sidebar/stories/Sidebar.stories.svelte
+++ b/src/addons/sidebar/stories/Sidebar.stories.svelte
@@ -2,10 +2,9 @@
   import { rest } from "msw";
   import { Meta, Story, Template } from "@storybook/addon-svelte-csf";
 
-  import { baseApiUrl } from "../../api/base.js";
-  import activeAddons from "../fixtures/addons-active.json";
-
-  import Sidebar from "../sidebar/Sidebar.svelte";
+  import { baseApiUrl } from "../../../api/base.js";
+  import activeAddons from "../../fixtures/addons-active.json";
+  import Sidebar from "../Sidebar.svelte";
 
   const mockUrl = new URL(`addons/`, baseApiUrl).toString();
 
@@ -17,6 +16,7 @@
 
 <style>
   .sidebar {
+    padding: 1.5rem 0;
     width: var(--sidebar-width);
     background-color: var(--sidebar);
   }
@@ -25,7 +25,7 @@
 <Meta
   title="Add-Ons / Sidebar"
   tags={["autodocs"]}
-  parameters={{ layout: "fullscreen" }}
+  parameters={{ layout: "centered" }}
   component={Sidebar}
 />
 

--- a/src/addons/stories/Sidebar.stories.svelte
+++ b/src/addons/stories/Sidebar.stories.svelte
@@ -1,0 +1,38 @@
+<script>
+  import { rest } from "msw";
+  import { Meta, Story, Template } from "@storybook/addon-svelte-csf";
+
+  import { baseApiUrl } from "../../api/base.js";
+  import activeAddons from "../fixtures/addons-active.json";
+
+  import Sidebar from "../sidebar/Sidebar.svelte";
+
+  const mockUrl = new URL(`addons/`, baseApiUrl).toString();
+
+  /* Mock Request Handlers */
+  const data = rest.get(mockUrl, (req, res, ctx) =>
+    res(ctx.json(activeAddons)),
+  );
+</script>
+
+<style>
+  .sidebar {
+    width: var(--sidebar-width);
+    background-color: var(--sidebar);
+  }
+</style>
+
+<Meta
+  title="Add-Ons / Sidebar"
+  tags={["autodocs"]}
+  parameters={{ layout: "fullscreen" }}
+  component={Sidebar}
+/>
+
+<Template>
+  <div class="sidebar">
+    <Sidebar />
+  </div>
+</Template>
+
+<Story name="Sidebar" parameters={{ msw: { handlers: [data] } }} />

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -767,6 +767,10 @@
     "thanks": "Thanks for the feedback!",
     "download": "Download file"
   },
+  "addonSidebar": {
+    "title": "Add-Ons",
+    "runs": "Schedule & history"
+  },
   "uploadEmailDialog": {
     "uploadEmailAddress": "Upload via email",
     "bodyText": "You can upload documents to your account by sending them to to a special email address as attachments.  For security reasons, this email is only shown to you once. Please copy it to a secure location: It will accept attachments from any email account. You can generate a new upload address at any time (which will disable the old one) or turn off this feature entirely. Documents are uploaded as private.<br><br>We’d love your feedback and to hear about creative use cases at <a href=\"mailto:info@documentcloud.org\" target=\"_blank\">info@documentcloud.org</a>.",

--- a/src/pages/app/sidebar/Project.svelte
+++ b/src/pages/app/sidebar/Project.svelte
@@ -9,43 +9,40 @@
   export let project;
 </script>
 
-<style lang="scss">
+<style>
   .project {
-    @include buttonLike;
-    padding: 11px 25px;
+    padding: 11px 25px 11px 0;
     display: table;
     width: 100%;
     box-sizing: border-box;
+  }
 
-    @media screen and (max-width: $mobileBreak) {
-      padding: 11px 25px 11px (25px + $sidebarAdd);
-    }
+  .project:hover {
+    background: rgba(0, 0, 0, 0.03);
+  }
 
-    &:hover {
-      background: rgba(0, 0, 0, 0.03);
-    }
+  .project > * {
+    display: table-cell;
+    vertical-align: top;
+  }
 
-    > * {
-      display: table-cell;
-      vertical-align: top;
-    }
+  .project .edit {
+    background: none;
+    border: none;
+    cursor: pointer;
+    float: right;
 
-    .edit {
-      float: right;
-      @include buttonLike;
+    padding-right: 5px;
+    padding-top: 3px;
+    width: 15px;
+  }
 
-      padding-right: 5px;
-      padding-top: 3px;
-      width: 15px;
-
-      &:hover {
-        filter: brightness(0.3);
-      }
-    }
+  .project .edit:hover {
+    filter: brightness(0.3);
   }
 
   .title {
-    font-size: $normal;
+    font-size: var(--normal);
     user-select: none;
     word-break: break-word;
   }
@@ -55,12 +52,12 @@
   <div class="project">
     <span class="title">{project.title}</span>
     {#if project.editAccess}
-      <span
+      <button
         class="edit"
         on:click|stopPropagation|preventDefault={() => editProject(project)}
       >
         {@html pencilSvg}
-      </span>
+      </button>
     {/if}
   </div>
 </Link>

--- a/src/pages/app/sidebar/Projects.svelte
+++ b/src/pages/app/sidebar/Projects.svelte
@@ -1,15 +1,16 @@
 <script>
-  import Button from "@/common/Button";
-  import Title from "@/common/Title";
-  import Project from "./Project";
-
-  import { projects } from "@/manager/projects";
-  import { newProject } from "@/manager/layout";
-  import { orgsAndUsers } from "@/manager/orgsAndUsers";
   import { _ } from "svelte-i18n";
 
+  import Button from "@/common/Button.svelte";
+  import Title from "@/common/Title.svelte";
+  import Project from "./Project.svelte";
+
+  import { projects } from "@/manager/projects.js";
+  import { newProject } from "@/manager/layout.js";
+  import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
+
   function sort(projects) {
-    if (projects == null) return [];
+    if (projects === null) return [];
     try {
       projects.sort((a, b) => a.title.localeCompare(b.title));
     } catch (e) {}
@@ -19,39 +20,40 @@
   $: alphabetizedProjects = sort($projects.projects);
 </script>
 
-<style lang="scss">
+<style>
   .projects {
-    padding: 20px 0;
+    padding: 20px 25px;
+  }
 
+  .titlesection {
+    display: inline-block;
+  }
+
+  @media only screen and (max-width: 720px) {
     .titlesection {
-      padding: 0 25px;
-
-      @media screen and (max-width: $mobileBreak) {
-        padding: 0 25px 0 (25px + $sidebarAdd);
-      }
-    }
-
-    .projectcontainer {
-      padding: 16px 0;
+      padding: 0 25px 0 0;
     }
   }
 
+  .projects .projectcontainer {
+    padding: 16px 0;
+  }
+
   .sticky {
-    background: $sidebar;
-    z-index: $sidebarStickyZ;
+    background: var(--sidebar);
+    z-index: var(--sidebarStickyZ);
   }
 
   small {
     font-size: 13px;
-    color: $gray;
+    color: var(--gray);
     margin: 0 24px;
     display: block;
   }
-
 </style>
 
-<div class="projects">
-  <div class="sticky">
+<details class="projects">
+  <summary class="sticky">
     {#if $orgsAndUsers.loggedIn}
       <div class="titlesection">
         <Title small={true}>{$_("projects.header")}</Title>
@@ -60,7 +62,7 @@
         >
       </div>
     {/if}
-  </div>
+  </summary>
   {#if $orgsAndUsers.loggedIn}
     <div class="projectcontainer">
       {#if alphabetizedProjects.length > 0}
@@ -72,4 +74,4 @@
       {/if}
     </div>
   {/if}
-</div>
+</details>

--- a/src/pages/app/sidebar/Sidebar.svelte
+++ b/src/pages/app/sidebar/Sidebar.svelte
@@ -16,15 +16,14 @@
   });
 </script>
 
-<style lang="scss" scoped>
+<style>
   .sidebar {
     position: absolute;
     top: 0;
     left: 0;
     bottom: 0;
     overflow: auto;
-    width: $sidebar-width;
-    // z-index: $sidebarZ;
+    width: var(--sidebar-width, 272px);
     -webkit-overflow-scrolling: touch;
   }
 
@@ -33,9 +32,9 @@
     top: 0;
     left: 0;
     bottom: 0;
-    z-index: $sidebarBg;
-    width: $sidebar-width;
-    background: $sidebar;
+    z-index: var(--sidebarBg);
+    width: var(--sidebar-width, 272px);
+    background: var(--sidebar, #edeeef);
     box-shadow: 2px 0px 4px rgba(0, 0, 0, 0.12);
   }
 
@@ -43,7 +42,7 @@
     padding: 20px 0;
   }
 
-  @media only screen and (max-width: $mobileBreak) {
+  @media only screen and (max-width: 720px) {
     .sidebar {
       display: none;
       width: 100vw;

--- a/src/pages/app/sidebar/Sidebar.svelte
+++ b/src/pages/app/sidebar/Sidebar.svelte
@@ -9,6 +9,8 @@
   import Projects from "./Projects.svelte";
   import OrgUsers from "./OrgUsers.svelte";
 
+  import AddonSidebar from "../../../addons/sidebar/Sidebar.svelte";
+
   export let expanded;
 
   const emit = emitter({
@@ -71,6 +73,8 @@
   <ProjectFilters />
   <OrgUsers />
   <Projects on:retractSidebar={emit.retractSidebar} />
+
+  <AddonSidebar />
 
   <!-- todo get rid of this -->
   <div class="sidebarbg" />


### PR DESCRIPTION
See it on staging: https://www.staging.documentcloud.org/app?q=

- Make projects in sidebar collapsible to accomodate pinned add-ons
- Use a single addon property for AddOnListItem, like everything else
- Populate the addon sidebar
- Coordinate between sidebar and browser
- Update src/addons/sidebar/Sidebar.svelte
- Update src/addons/sidebar/Sidebar.svelte
- Use icon instead of full pin component
- Styling for sidebar

<img width="809" alt="Screenshot 2023-08-17 at 4 38 39 PM" src="https://github.com/MuckRock/documentcloud-frontend/assets/25778/42f39cb9-e777-484d-accc-88543222985c">
