### PR TITLE
Don't load Sentry on embeds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,33 +1,40 @@
-import * as Sentry from "@sentry/svelte";
+// import * as Sentry from "@sentry/svelte";
 import Main from "./Main.svelte";
 
 const SENTRY_DSN = process.env.SENTRY_DSN;
+const IS_EMBED =
+  typeof window !== "undefined" &&
+  (window.location.hostname === "embed.documentcloud.org" ||
+    new URLSearchParams(window.location.search).has("embed"));
 
 // init sentry first
-if (SENTRY_DSN) {
-  Sentry.init({
-    dsn: SENTRY_DSN,
-    integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+if (!IS_EMBED && SENTRY_DSN) {
+  import("@sentry/svelte").then((Sentry) => {
+    Sentry.init({
+      dsn: SENTRY_DSN,
+      integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
 
-    // Set tracesSampleRate to 1.0 to capture 100%
-    // of transactions for performance monitoring.
-    // We recommend adjusting this value in production
-    tracesSampleRate: 1.0,
+      // Set tracesSampleRate to 1.0 to capture 100%
+      // of transactions for performance monitoring.
+      // We recommend adjusting this value in production
+      tracesSampleRate: 1.0,
 
-    // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
-    tracePropagationTargets: [
-      "http://www.dev.documentcloud.org",
-      "https://www.staging.documentcloud.org",
-      "https://www.documentcloud.org",
-    ],
+      // Set `tracePropagationTargets` to control for which URLs distributed tracing should be enabled
+      tracePropagationTargets: [
+        "http://www.dev.documentcloud.org",
+        "https://www.staging.documentcloud.org",
+        "https://www.documentcloud.org",
+      ],
 
-    // Capture Replay for 10% of all sessions,
-    // plus for 100% of sessions with an error
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
+      // Capture Replay for 10% of all sessions,
+      // plus for 100% of sessions with an error
+      replaysSessionSampleRate: 0.1,
+      replaysOnErrorSampleRate: 1.0,
+    });
   });
 } else {
-  console.log("Sentry is not configured. Set SENTRY_DSN to enable.");
+  if (!IS_EMBED)
+    console.log("Sentry is not configured. Set SENTRY_DSN to enable.");
 }
 
 // Imports to get persistent app functionality working

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,3 @@
-// import * as Sentry from "@sentry/svelte";
 import Main from "./Main.svelte";
 
 const SENTRY_DSN = process.env.SENTRY_DSN;


### PR DESCRIPTION
Switched to a dynamic import so we don't have any Sentry code on embeds.