### PR TITLE
Add raw flag to svg imports

### DIFF
--- a/src/addons/progress/AddonRun.svelte
+++ b/src/addons/progress/AddonRun.svelte
@@ -190,7 +190,7 @@
           <span class="info processingText message comment" class:compact>
             {#if run.comment === ""}
               <input
-                placeholder={$_("addonProgres.feedback")}
+                placeholder={$_("addonProgress.feedback")}
                 maxlength="255"
                 bind:value={comment}
               />

--- a/src/api/document.js
+++ b/src/api/document.js
@@ -6,7 +6,7 @@ import session from "./session.js";
 import { apiUrl } from "./base.js";
 import { timeout } from "@/util/timeout.js";
 import { queryBuilder } from "@/util/url.js";
-import { DEFAULT_ORDERING, DEFAULT_EXPAND } from "./common.js";
+import { DEFAULT_EXPAND } from "./common.js";
 import { Results } from "@/structure/results.js";
 import { batchDelay } from "@/util/batchDelay.js";
 import { StorageManager } from "@/util/storageManager.js";
@@ -97,7 +97,7 @@ export async function searchDocument(query, docId) {
 export async function getDocument(id, expand = DEFAULT_EXPAND) {
   // Get a single document with the specified id
   const { data } = await session.get(
-    apiUrl(queryBuilder(`documents/${id}/`, { expand })),
+    apiUrl(queryBuilder(`documents/${id}.json`, { expand })),
   );
   return new Document(data);
 }

--- a/src/assets/close.svg
+++ b/src/assets/close.svg
@@ -1,4 +1,0 @@
-<svg class="close" width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="9.48682" cy="9.83179" r="8.13172" stroke="black" stroke-opacity="0.51" stroke-width="1.73656"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M9.4868 10.8959L12.7966 14.2057L13.8611 13.1412L10.5513 9.83138L13.8607 6.52196L12.7962 5.45744L9.4868 8.76686L6.17722 5.45728L5.1127 6.5218L8.42228 9.83138L5.1123 13.1414L6.17683 14.2059L9.4868 10.8959Z" fill="black" fill-opacity="0.51"/>
-</svg>

--- a/src/common/AccessIcon.svelte
+++ b/src/common/AccessIcon.svelte
@@ -8,9 +8,9 @@
   import { viewer } from "@/viewer/viewer.js";
 
   // SVG assets
-  import privateIconSvg from "@/assets/private_icon.svg";
-  import publicIconSvg from "@/assets/public_icon.svg";
-  import organizationIconSvg from "@/assets/organization_icon.svg";
+  import privateIconSvg from "@/assets/private_icon.svg?raw";
+  import publicIconSvg from "@/assets/public_icon.svg?raw";
+  import organizationIconSvg from "@/assets/organization_icon.svg?raw";
 
   export let document;
   export let showText = false;

--- a/src/common/AccessToggle.svelte
+++ b/src/common/AccessToggle.svelte
@@ -1,8 +1,8 @@
 <script>
   // SVG assets
-  import privateIconSvg from "@/assets/private_icon.svg";
-  import publicIconSvg from "@/assets/public_icon.svg";
-  import organizationIconSvg from "@/assets/organization_icon.svg";
+  import privateIconSvg from "@/assets/private_icon.svg?raw";
+  import publicIconSvg from "@/assets/public_icon.svg?raw";
+  import organizationIconSvg from "@/assets/organization_icon.svg?raw";
   import { _ } from "svelte-i18n";
 
   export let access = "private";

--- a/src/common/Calendar.svelte
+++ b/src/common/Calendar.svelte
@@ -3,8 +3,8 @@
   import { lpad } from "@/util/string.js";
 
   // SVG assets
-  import CalendarLeft from "@/assets/calendar_left.svg";
-  import CalendarRight from "@/assets/calendar_right.svg";
+  import CalendarLeft from "@/assets/calendar_left.svg?raw";
+  import CalendarRight from "@/assets/calendar_right.svg?raw";
 
   $: months = [
     $_("calendar.jan"),

--- a/src/common/Logo.svelte
+++ b/src/common/Logo.svelte
@@ -5,7 +5,7 @@
   import { getPath } from "@/router/router.js";
 
   // Svg assets
-  import dcLogo from "@/assets/dc_logo.svg";
+  import dcLogo from "@/assets/dc_logo.svg?raw";
 
   export let newPage = false;
   export let nopadding = false;

--- a/src/common/Modal.svelte
+++ b/src/common/Modal.svelte
@@ -6,7 +6,7 @@
   import emitter from "@/emit.js";
 
   // SVG assets
-  import closeSvg from "@/assets/close.svg";
+  import { XCircle24 } from "svelte-octicons";
 
   const emit = emitter({
     close() {},
@@ -46,7 +46,7 @@
 <style lang="scss">
   .shim {
     background: #051d38b5;
-    z-index: $modalShimZ;
+    z-index: var(--modalShimZ, 20);
     position: fixed;
     left: 0;
     right: 0;
@@ -55,7 +55,7 @@
   }
 
   .modalcontainer {
-    z-index: $modalContainerZ;
+    z-index: var(--modalContainerZ, 21);
     position: fixed;
     top: 10vh;
     left: 20vw;
@@ -90,10 +90,10 @@
     box-sizing: border-box;
     overflow-y: auto;
     background: white;
-    border-radius: $radius;
+    border-radius: var(--radius, 3px);
     color: black;
     padding: 0;
-    box-shadow: $overlay-shadow;
+    box-shadow: var(--overlay-shadow, 2px 2px 4px rgba(0, 0, 0, 0.25));
     position: relative;
     max-height: 80vh;
     max-width: 766px;
@@ -113,7 +113,7 @@
     }
 
     :global(.mcontent) {
-      padding: 0 $modal-horiz-padding;
+      padding: 0 var(--modal-horiz-padding, 42px);
     }
 
     :global(.buttonpadded) {
@@ -146,23 +146,22 @@
     position: sticky;
     position: -webkit-sticky;
     top: 0;
-    height: $modal-vert-padding;
+    height: var(--modal-vert-padding, 44px);
     margin-bottom: 2px;
-    z-index: $modalHeaderZ;
+    z-index: var(--modalHeaderZ, 22);
   }
 
-  :global(.close) {
-    @include buttonLike;
-
+  .dismiss :global(svg) {
     user-select: none;
-    margin-left: $closePadding;
-    margin-top: $closePadding;
+    margin-left: var(--closePadding, 12px);
+    margin-top: var(--closePadding, 12px);
   }
 
   button.dismiss {
     background: none;
-    padding: none;
+    padding: 0;
     border: none;
+    cursor: pointer;
   }
 </style>
 
@@ -175,8 +174,8 @@
       <div bind:this={modal} class="modal">
         <div class="header">
           {#if dismissable}
-            <button class="dismiss" on:click={dismiss}>
-              {@html closeSvg}
+            <button class="dismiss buttonLike" on:click={dismiss}>
+              <XCircle24 />
             </button>
           {/if}
         </div>

--- a/src/common/ShareOptions.svelte
+++ b/src/common/ShareOptions.svelte
@@ -5,9 +5,9 @@
   import { _ } from "svelte-i18n";
 
   // SVG assets
-  import embedSvg from "@/assets/embed.svg";
-  import linkSvg from "@/assets/link.svg";
-  import twitterSvg from "@/assets/twitter.svg";
+  import embedSvg from "@/assets/embed.svg?raw";
+  import linkSvg from "@/assets/link.svg?raw";
+  import twitterSvg from "@/assets/twitter.svg?raw";
 
   export let shareOption = "embed";
   export let embedDescription;

--- a/src/common/dialog/AccessDialog.svelte
+++ b/src/common/dialog/AccessDialog.svelte
@@ -15,8 +15,8 @@
   import { _ } from "svelte-i18n";
 
   // SVG assets
-  import InfoSvg from "@/assets/info.svg";
-  import CalendarSvg from "@/assets/calendar.svg";
+  import InfoSvg from "@/assets/info.svg?raw";
+  import CalendarSvg from "@/assets/calendar.svg?raw";
 
   const emit = emitter({
     dismiss() {},

--- a/src/common/dialog/CollaboratorDialog.svelte
+++ b/src/common/dialog/CollaboratorDialog.svelte
@@ -26,7 +26,7 @@
   import { _ } from "svelte-i18n";
 
   // SVG assets
-  import pencilSvg from "@/assets/pencil.svg";
+  import pencilSvg from "@/assets/pencil.svg?raw";
 
   const emit = emitter({
     dismiss() {},

--- a/src/common/dialog/DataDialog.svelte
+++ b/src/common/dialog/DataDialog.svelte
@@ -21,7 +21,7 @@
   import { _ } from "svelte-i18n";
 
   // SVG assets
-  import pencilSvg from "@/assets/pencil.svg";
+  import pencilSvg from "@/assets/pencil.svg?raw";
 
   const emit = emitter({
     dismiss() {},

--- a/src/common/dialog/EditSectionsDialog.svelte
+++ b/src/common/dialog/EditSectionsDialog.svelte
@@ -11,8 +11,8 @@
   import { _ } from "svelte-i18n";
 
   // SVG assets
-  import pencilSvg from "@/assets/pencil.svg";
-  import closeSimpleSvg from "@/assets/close_simple.svg";
+  import pencilSvg from "@/assets/pencil.svg?raw";
+  import closeSimpleSvg from "@/assets/close_simple.svg?raw";
 
   import { writable } from "svelte/store";
 

--- a/src/common/dialog/EmbedDialog.svelte
+++ b/src/common/dialog/EmbedDialog.svelte
@@ -16,10 +16,10 @@
   import { writable } from "svelte/store";
 
   // SVG assets
-  import errorIconSvg from "@/assets/error_icon.svg";
-  import shareDocumentSvg from "@/assets/share_document.svg";
-  import sharePageSvg from "@/assets/share_page.svg";
-  import shareNoteSvg from "@/assets/share_note.svg";
+  import errorIconSvg from "@/assets/error_icon.svg?raw";
+  import shareDocumentSvg from "@/assets/share_document.svg?raw";
+  import sharePageSvg from "@/assets/share_page.svg?raw";
+  import shareNoteSvg from "@/assets/share_note.svg?raw";
 
   let loading = writable(false);
   let skipPublic = false;

--- a/src/pages/FlatPage.svelte
+++ b/src/pages/FlatPage.svelte
@@ -10,7 +10,7 @@
   import { inIframe } from "../util/iframe.js";
 
   // SVG assets
-  import mastLogoSvg from "@/assets/mastlogo.svg";
+  import mastLogoSvg from "@/assets/mastlogo.svg?raw";
 
   export let content = "";
   export let title = "";

--- a/src/pages/app/Anonymous.svelte
+++ b/src/pages/app/Anonymous.svelte
@@ -5,8 +5,8 @@
   import { fade } from "svelte/transition";
 
   // SVG assets
-  import documentSilhouetteSvg from "@/assets/document_silhouette.svg";
-  import closeSvg from "@/assets/close.svg";
+  import { XCircle24 } from "svelte-octicons";
+  import documentSilhouetteSvg from "@/assets/document_silhouette.svg?raw";
 
   export let closed = false;
 
@@ -18,7 +18,7 @@
 <style lang="scss">
   .container {
     margin: 1em 1.5em;
-    background: $fyi;
+    background: var(--fyi);
     padding: 1em;
     border-radius: 10px;
   }
@@ -42,10 +42,9 @@
     margin: 0 2em 1em 2em;
 
     :global(a) {
-      color: $primary;
+      color: var(--primary);
     }
 
-    li,
     p {
       font-size: 15px;
       line-height: 22px;
@@ -58,22 +57,22 @@
   }
 
   :global(.close) {
-    @include buttonLike;
-
     user-select: none;
-    margin-left: $closePadding;
-    margin-top: $closePadding;
+    margin-left: var(--closePadding);
+    margin-top: var(--closePadding);
   }
+
   button.dismiss {
     background: none;
     padding: none;
     border: none;
+    cursor: pointer;
   }
 </style>
 
 <div class="container" out:fade>
   <button class="dismiss" on:click={dismiss}>
-    {@html closeSvg}
+    <XCircle24 />
   </button>
   <h2>{$_("anonymous.title")}</h2>
   <div class="img">

--- a/src/pages/app/Document.svelte
+++ b/src/pages/app/Document.svelte
@@ -17,8 +17,8 @@
   import { projectUrl, dataUrl } from "@/search/search.js";
   import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
 
-  import closeSimpleSvg from "@/assets/close_inline.svg";
-  import pencilSvg from "@/assets/pencil.svg";
+  import closeSimpleSvg from "@/assets/close_inline.svg?raw";
+  import pencilSvg from "@/assets/pencil.svg?raw";
 
   import { pageImageUrl } from "@/api/viewer.js";
 

--- a/src/pages/app/DocumentThumbnail.svelte
+++ b/src/pages/app/DocumentThumbnail.svelte
@@ -8,10 +8,10 @@
   import { _ } from "svelte-i18n";
 
   // SVG assets
-  import errorIconSvg from "@/assets/error_icon.svg";
-  import publicTagSvg from "@/assets/public_tag.svg";
-  import organizationTagSvg from "@/assets/organization_tag.svg";
-  import privateTagSvg from "@/assets/private_tag.svg";
+  import errorIconSvg from "@/assets/error_icon.svg?raw";
+  import publicTagSvg from "@/assets/public_tag.svg?raw";
+  import organizationTagSvg from "@/assets/organization_tag.svg?raw";
+  import privateTagSvg from "@/assets/private_tag.svg?raw";
 
   export let document;
   export let embed = false;

--- a/src/pages/app/File.svelte
+++ b/src/pages/app/File.svelte
@@ -5,8 +5,8 @@
   import { _ } from "svelte-i18n";
 
   // SVG assets
-  import documentIconSvg from "@/assets/document_icon.svg";
-  import closeInlineSvg from "@/assets/close_inline.svg";
+  import documentIconSvg from "@/assets/document_icon.svg?raw";
+  import closeInlineSvg from "@/assets/close_inline.svg?raw";
 
   const emit = emitter({
     name() {},

--- a/src/pages/app/NoDocuments.svelte
+++ b/src/pages/app/NoDocuments.svelte
@@ -4,8 +4,8 @@
   import { _ } from "svelte-i18n";
 
   // SVG assets
-  import documentSilhouetteSvg from "@/assets/document_silhouette.svg";
-  import emptyResultsSvg from "@/assets/empty_results.svg";
+  import documentSilhouetteSvg from "@/assets/document_silhouette.svg?raw";
+  import emptyResultsSvg from "@/assets/empty_results.svg?raw";
 </script>
 
 <style lang="scss">

--- a/src/pages/app/Paginator.svelte
+++ b/src/pages/app/Paginator.svelte
@@ -3,8 +3,8 @@
   import { _ } from "svelte-i18n";
 
   // SVG assets
-  import leftPaginatorSvg from "@/assets/page_arrow_left.svg";
-  import rightPaginatorSvg from "@/assets/page_arrow_right.svg";
+  import leftPaginatorSvg from "@/assets/page_arrow_left.svg?raw";
+  import rightPaginatorSvg from "@/assets/page_arrow_right.svg?raw";
 </script>
 
 <style lang="scss">

--- a/src/pages/app/SearchInput.svelte
+++ b/src/pages/app/SearchInput.svelte
@@ -19,8 +19,8 @@
   import { timeoutify } from "@/util/closure.js";
 
   // SVG assets
-  import searchIconSvg from "@/assets/search_icon.svg";
-  import closeInlineSvg from "@/assets/close_inline.svg";
+  import searchIconSvg from "@/assets/search_icon.svg?raw";
+  import closeInlineSvg from "@/assets/close_inline.svg?raw";
 
   const fieldAliases = {
     projects: "project",

--- a/src/pages/app/SearchLink.svelte
+++ b/src/pages/app/SearchLink.svelte
@@ -1,7 +1,7 @@
 <script>
   import { _ } from "svelte-i18n";
   // SVG assets
-  import SearchIconSvg from "@/assets/search_icon.svg";
+  import SearchIconSvg from "@/assets/search_icon.svg?raw";
 
   export let link = "";
 </script>

--- a/src/pages/app/sidebar/Project.svelte
+++ b/src/pages/app/sidebar/Project.svelte
@@ -4,7 +4,7 @@
   import { projectUrl } from "@/search/search.js";
 
   // SVG assets
-  import pencilSvg from "@/assets/pencil.svg";
+  import pencilSvg from "@/assets/pencil.svg?raw";
 
   export let project;
 </script>

--- a/src/pages/entities/Entities.svelte
+++ b/src/pages/entities/Entities.svelte
@@ -13,7 +13,7 @@
   import { entities, getE } from "@/entities/entities.js";
   import { updateInCollection } from "@/manager/documents.js";
 
-  import closeSvg from "@/assets/close_inline.svg";
+  import closeSvg from "@/assets/close_inline.svg?raw";
 
   const CONTACT = process.env.SPECIAL_CONTACT;
 

--- a/src/pages/home/HomeTemplate.svelte
+++ b/src/pages/home/HomeTemplate.svelte
@@ -7,9 +7,9 @@
   import { orgsAndUsers } from "../../manager/orgsAndUsers.js";
 
   // SVG assets
-  import mastLogoSvg from "@/assets/mastlogo.svg";
-  import mastheadSvg from "@/assets/masthead.svg";
-  import mastheadResponsiveSvg from "@/assets/masthead_responsive.svg";
+  import mastLogoSvg from "@/assets/mastlogo.svg?raw";
+  import mastheadSvg from "@/assets/masthead.svg?raw";
+  import mastheadResponsiveSvg from "@/assets/masthead_responsive.svg?raw";
 
   // Authentication
   import {

--- a/src/pages/viewer/Annotation.svelte
+++ b/src/pages/viewer/Annotation.svelte
@@ -22,9 +22,9 @@
   import emitter from "@/emit.js";
 
   // SVG assets
-  import closeInlineSvg from "@/assets/close_inline.svg";
-  import simpleLinkSvg from "@/assets/simplelink.svg";
-  import pencilSvg from "@/assets/pencil.svg";
+  import closeInlineSvg from "@/assets/close_inline.svg?raw";
+  import simpleLinkSvg from "@/assets/simplelink.svg?raw";
+  import pencilSvg from "@/assets/pencil.svg?raw";
 
   // Asynchronously load dompurify
   import { loadDompurify } from "@/util/domPurify.js";

--- a/src/pages/viewer/ContentItem.svelte
+++ b/src/pages/viewer/ContentItem.svelte
@@ -9,7 +9,7 @@
   import { restorePosition, showAnnotation } from "@/viewer/document.js";
 
   // SVG assets
-  import smallCircleSvg from "@/assets/small_circle.svg";
+  import smallCircleSvg from "@/assets/small_circle.svg?raw";
 
   export let sectionOrNote;
 

--- a/src/pages/viewer/InternalPage.svelte
+++ b/src/pages/viewer/InternalPage.svelte
@@ -31,9 +31,9 @@
   let annotationChanger = 0;
 
   // SVG assets
-  import publicTagSvg from "@/assets/public_tag.svg";
-  import organizationTagSvg from "@/assets/organization_tag.svg";
-  import privateTagSvg from "@/assets/private_tag.svg";
+  import publicTagSvg from "@/assets/public_tag.svg?raw";
+  import organizationTagSvg from "@/assets/organization_tag.svg?raw";
+  import privateTagSvg from "@/assets/private_tag.svg?raw";
 
   const svgMap = {
     public: publicTagSvg,

--- a/src/pages/viewer/controls/FullScreen.svelte
+++ b/src/pages/viewer/controls/FullScreen.svelte
@@ -2,7 +2,7 @@
   import { viewer } from "@/viewer/viewer.js";
 
   // SVG assets
-  import fullScreenSvg from "@/assets/fullscreen.svg";
+  import fullScreenSvg from "@/assets/fullscreen.svg?raw";
 </script>
 
 <style lang="scss">

--- a/src/pages/viewer/controls/Hamburger.svelte
+++ b/src/pages/viewer/controls/Hamburger.svelte
@@ -2,7 +2,7 @@
   import { toggleSidebar } from "@/viewer/document.js";
 
   // SVG assets
-  import viewerHamburgerSvg from "@/assets/viewer_hamburger.svg";
+  import viewerHamburgerSvg from "@/assets/viewer_hamburger.svg?raw";
 </script>
 
 <style lang="scss">

--- a/src/pages/viewer/controls/Paginator.svelte
+++ b/src/pages/viewer/controls/Paginator.svelte
@@ -5,8 +5,8 @@
   import { viewer } from "@/viewer/viewer.js";
 
   // SVG assets
-  import leftPaginator from "@/assets/left_paginator.svg";
-  import rightPaginator from "@/assets/right_paginator.svg";
+  import leftPaginator from "@/assets/left_paginator.svg?raw";
+  import rightPaginator from "@/assets/right_paginator.svg?raw";
 
   let input;
   let customPage = "1";

--- a/src/pages/viewer/controls/Search.svelte
+++ b/src/pages/viewer/controls/Search.svelte
@@ -5,9 +5,9 @@
   import { _ } from "svelte-i18n";
 
   // SVG assets
-  import viewerSearchIconSvg from "@/assets/viewer_search_icon.svg";
-  import searchIconSvg from "@/assets/search_icon.svg";
-  import closeInlineSvg from "@/assets/close_inline.svg";
+  import viewerSearchIconSvg from "@/assets/viewer_search_icon.svg?raw";
+  import searchIconSvg from "@/assets/search_icon.svg?raw";
+  import closeInlineSvg from "@/assets/close_inline.svg?raw";
 
   let query = "";
   let searchElem = null;

--- a/src/pages/viewer/controls/Zoom.svelte
+++ b/src/pages/viewer/controls/Zoom.svelte
@@ -4,8 +4,8 @@
   import { doc, zoomBreakpoints } from "@/viewer/document.js";
 
   // SVG assets
-  import plusSvg from "@/assets/viewer_plus.svg";
-  import minusSvg from "@/assets/viewer_minus.svg";
+  import plusSvg from "@/assets/viewer_plus.svg?raw";
+  import minusSvg from "@/assets/viewer_minus.svg?raw";
 
   let select;
 

--- a/src/pages/viewer/header/TitleHeader.svelte
+++ b/src/pages/viewer/header/TitleHeader.svelte
@@ -11,7 +11,7 @@
   import { layout } from "@/viewer/layout.js";
 
   // SVG assets
-  import backArrowSvg from "@/assets/back_arrow.svg";
+  import backArrowSvg from "@/assets/back_arrow.svg?raw";
 </script>
 
 <style>

--- a/src/pages/viewer/pane/ActionPane.svelte
+++ b/src/pages/viewer/pane/ActionPane.svelte
@@ -8,7 +8,7 @@
   import { cancelActions } from "@/viewer/document.js";
 
   // SVG assets
-  import closeSvg from "@/assets/close.svg";
+  import { XCircle24 } from "svelte-octicons";
 
   export let actionHeight;
 
@@ -68,7 +68,7 @@
   >
     <div class="actionclose">
       <button class="buttonLike" on:click={cancelActions}>
-        {@html closeSvg}
+        <XCircle24 />
       </button>
     </div>
     <div class="actioncontent">


### PR DESCRIPTION
Another big find-and-replace to get us ready for Vite. This adds `?raw` to all of our SVG imports, which tells Vite to import the raw string, rather than a filename. Webpack ignores this, so it's functionally a no-op until we switch.