### PR TITLE
Adds Pin controller to Add-On Detail page

### DIFF
--- a/src/addons/AddOnPin.svelte
+++ b/src/addons/AddOnPin.svelte
@@ -1,0 +1,55 @@
+<script lang="ts" context="module">
+  import { writable, type Writable } from "svelte/store";
+  import type { AddOnListItem } from "./types.ts";
+
+  export const pinned: Writable<AddOnListItem[]> = writable([]);
+</script>
+
+<script lang="ts">
+  import { getCsrfToken } from "../api/session.js";
+  import { baseApiUrl } from "../api/base.js";
+  import Pin from "../common/Pin.svelte";
+
+  export let addon: AddOnListItem;
+  export let size = 1;
+
+  $: endpoint = new URL(`/api/addons/${addon.id}/`, baseApiUrl);
+
+  async function toggle(event) {
+    event.preventDefault();
+
+    const csrftoken = getCsrfToken();
+    const options: RequestInit = {
+      credentials: "include",
+      method: "PATCH", // this component can only update whether an addon is active or not
+      headers: { "X-CSRFToken": csrftoken, "Content-type": "application/json" },
+    };
+
+    // optimistic update
+    addon.active = !addon.active;
+
+    const resp = await fetch(endpoint, {
+      ...options,
+      body: JSON.stringify({ active: addon.active }),
+    }).catch((err) => {
+      addon.active = !addon.active;
+      return {
+        ok: false,
+        statusText: String(err),
+      };
+    });
+
+    if (!resp.ok) {
+      // reset active state
+      addon.active = !addon.active;
+      console.error(`Problem updating add-on: ${resp.statusText}`);
+    }
+
+    // now that we've updated, set $pinned
+    $pinned = addon.active
+      ? [...$pinned, addon]
+      : $pinned.filter((a) => a.id !== addon.id);
+  }
+</script>
+
+<Pin active={addon.active} on:click={toggle} {size} />

--- a/src/addons/browser/AddOnList.svelte
+++ b/src/addons/browser/AddOnList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" context="module">
-  import type { AddOnListItem } from "./AddOnListItem.svelte";
+  import type { AddOnListItem } from "../types.ts";
 
   export interface AddOnList {
     items?: AddOnListItem[];

--- a/src/addons/browser/AddOnListItem.svelte
+++ b/src/addons/browser/AddOnListItem.svelte
@@ -1,83 +1,18 @@
-<script lang="ts" context="module">
-  import { writable, type Writable } from "svelte/store";
-
-  interface Author {
-    name?: string;
-    avatar?: string;
-  }
-
-  // API endpoint https://api.www.documentcloud.org/api/addons/
-  export interface AddOnListItem {
-    id: number;
-    name: string;
-    repository: string;
-    parameters: any;
-    description?: string;
-    author?: Author;
-    usage?: number;
-    categories: string[];
-    documents: string[];
-    active: boolean;
-    featured: boolean;
-    default: boolean;
-  }
-
-  export const pinned: Writable<AddOnListItem[]> = writable([]);
-</script>
-
 <script lang="ts">
   import { _ } from "svelte-i18n";
-  import { baseApiUrl } from "../../api/base.js";
-  import { getCsrfToken } from "../../api/session.js";
 
-  import Pin from "../../common/Pin.svelte";
+  import AddOnPin from "../AddOnPin.svelte";
   import AddOnPopularity from "../Popularity.svelte";
+  import type { AddOnListItem } from "../types.js";
 
   export let addon: AddOnListItem;
 
-  $: endpoint = new URL(`/api/addons/${addon.id}/`, baseApiUrl);
   $: description = addon.parameters?.description;
   $: if (!addon?.author) {
     addon.author = { name: addon?.repository?.split("/")[0] };
   }
 
   $: url = `#add-ons/${addon.repository}`;
-
-  async function toggle(event) {
-    event.preventDefault();
-
-    const csrftoken = getCsrfToken();
-    const options: RequestInit = {
-      credentials: "include",
-      method: "PATCH", // this component can only update whether an addon is active or not
-      headers: { "X-CSRFToken": csrftoken, "Content-type": "application/json" },
-    };
-
-    // optimistic update
-    addon.active = !addon.active;
-
-    const resp = await fetch(endpoint, {
-      ...options,
-      body: JSON.stringify({ active: addon.active }),
-    }).catch((err) => {
-      addon.active = !addon.active;
-      return {
-        ok: false,
-        statusText: String(err),
-      };
-    });
-
-    if (!resp.ok) {
-      // reset active state
-      addon.active = !addon.active;
-      console.error(`Problem updating add-on: ${resp.statusText}`);
-    }
-
-    // now that we've updated, set $pinned
-    $pinned = addon.active
-      ? [...$pinned, addon]
-      : $pinned.filter((a) => a.id !== addon.id);
-  }
 </script>
 
 <style>
@@ -146,7 +81,7 @@
   <div class="container" id={addon.repository}>
     <div class="top-row">
       <div class="center-self">
-        <Pin active={addon.active} on:click={toggle} />
+        <AddOnPin {addon} />
       </div>
       <div class="stretch">
         <h3 class="addon-name">{addon.name}</h3>

--- a/src/addons/browser/Browser.svelte
+++ b/src/addons/browser/Browser.svelte
@@ -4,7 +4,7 @@
   import { _ } from "svelte-i18n";
   import { baseApiUrl } from "../../api/base.js";
   import AddOnList from "./AddOnList.svelte";
-  import type { AddOnListItem } from "./AddOnListItem.svelte";
+  import type { AddOnListItem } from "../types.ts";
   import Drawer from "../Drawer.svelte";
   import Paginator from "../Paginator.svelte";
   import Search, { query } from "./SearchInput.svelte";

--- a/src/addons/dispatch/Dispatch.svelte
+++ b/src/addons/dispatch/Dispatch.svelte
@@ -4,7 +4,7 @@
   import { onMount, tick } from "svelte";
   import { _ } from "svelte-i18n";
 
-  import type { AddOnListItem } from "../browser/AddOnListItem.svelte";
+  import type { AddOnListItem } from "../types.ts";
   import type { Event } from "../runs/ScheduledEvent.svelte";
 
   import Button from "../../common/Button.svelte";

--- a/src/addons/dispatch/Header.svelte
+++ b/src/addons/dispatch/Header.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
 
-  import type { AddOnListItem } from "../browser/AddOnListItem.svelte";
+  import type { AddOnListItem } from "../types.ts";
   import BackArrow from "../../common/icons/BackArrow.svelte";
   import Button from "../../common/Button.svelte";
   import GitHubIcon from "svelte-octicons/lib/MarkGithub16.svelte";
   import ShareIcon from "svelte-octicons/lib/Share16.svelte";
 
   import { pushToast } from "../../common/Toast.svelte";
+  import AddOnPin from "../AddOnPin.svelte";
 
   export let addon: AddOnListItem;
 
@@ -52,6 +53,14 @@
   }
   .name {
     flex: 1 1 100%;
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  .pin {
+    flex: 0 1 auto;
+  }
+  .name h2 {
     margin: 0;
   }
   .metadata {
@@ -104,7 +113,10 @@
     {$_("addonDispatchDialog.backButton")}
   </Button>
 
-  <h2 class="name">{addon.name}</h2>
+  <div class="name">
+    <span class="pin"><AddOnPin {addon} size={1.25} /></span>
+    <h2>{addon.name}</h2>
+  </div>
 
   <dl class="metadata">
     <div class="author">

--- a/src/addons/dispatch/ScheduledInset.svelte
+++ b/src/addons/dispatch/ScheduledInset.svelte
@@ -2,7 +2,7 @@
   import { _ } from "svelte-i18n";
   import { onMount } from "svelte";
 
-  import type { AddOnListItem } from "../browser/AddOnListItem.svelte";
+  import type { AddOnListItem } from "../types.ts";
   import ScheduledEvent, { type Event } from "../runs/ScheduledEvent.svelte";
 
   import { baseApiUrl } from "../../api/base.js";

--- a/src/addons/dispatch/stories/Dispatch.stories.svelte
+++ b/src/addons/dispatch/stories/Dispatch.stories.svelte
@@ -34,6 +34,15 @@
     res(ctx.status(400, "Something went wrong")),
   );
 
+  const mockPinUrl = new URL("/api/addons/:id", baseApiUrl).toString();
+  const pinSuccess = rest.all(mockPinUrl, (req, res, ctx) => res(ctx.json({})));
+  const pinLoading = rest.all(mockPinUrl, (req, res, ctx) =>
+    res(ctx.delay("infinite")),
+  );
+  const pinError = rest.all(mockPinUrl, (req, res, ctx) =>
+    res(ctx.status(400, "Something went wrong")),
+  );
+
   let args = {
     visible: true,
     addon: null,
@@ -54,17 +63,17 @@
 <Story
   name="Success"
   args={{ visible: true, addon: klaxon, event }}
-  parameters={{ msw: { handlers: [scheduleSuccess, sendSuccess] } }}
+  parameters={{ msw: { handlers: [scheduleSuccess, sendSuccess, pinSuccess] } }}
 />
 <Story
   name="Error"
   args={{ visible: true, addon: klaxon, event }}
-  parameters={{ msw: { handlers: [scheduleError, sendError] } }}
+  parameters={{ msw: { handlers: [scheduleError, sendError, pinError] } }}
 />
 <Story
   name="Loading"
   args={{ visible: true, addon: klaxon, event }}
-  parameters={{ msw: { handlers: [scheduleLoading, sendLoading] } }}
+  parameters={{ msw: { handlers: [scheduleLoading, sendLoading, pinLoading] } }}
 />
 
 <Story name="Klaxon" args={{ visible: true, addon: klaxon, event }} />

--- a/src/addons/runs/HistoryEvent.svelte
+++ b/src/addons/runs/HistoryEvent.svelte
@@ -1,6 +1,6 @@
 <script context="module" lang="ts">
   import Button from "../../common/Button.svelte";
-  import type { AddOnListItem } from "../browser/AddOnListItem.svelte";
+  import type { AddOnListItem } from "../types.ts";
   // https://api.www.documentcloud.org/api/addon_runs/?expand=addon
   export interface Run {
     uuid: string;

--- a/src/addons/runs/ScheduledEvent.svelte
+++ b/src/addons/runs/ScheduledEvent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" context="module">
-  import type { AddOnListItem } from "../browser/AddOnListItem.svelte";
+  import type { AddOnListItem } from "../types.ts";
 
   export interface Event {
     id: number;

--- a/src/addons/sidebar/AddonListItem.svelte
+++ b/src/addons/sidebar/AddonListItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { AddOnListItem } from "../browser/AddOnListItem.svelte";
+  import type { AddOnListItem } from "../types.ts";
+
   import Pin from "../../common/icons/Pin.svelte";
   import ListItem from "./ListItem.svelte";
 

--- a/src/addons/sidebar/Sidebar.svelte
+++ b/src/addons/sidebar/Sidebar.svelte
@@ -3,7 +3,8 @@
   import { _ } from "svelte-i18n";
   import { ClockFill16 } from "svelte-octicons";
 
-  import { pinned, type AddOnListItem } from "../browser/AddOnListItem.svelte";
+  import { pinned } from "../AddOnPin.svelte";
+  import type { AddOnListItem } from "../types.ts";
   import ListItem from "./ListItem.svelte";
   import AddonListItem from "./AddonListItem.svelte";
   import { baseApiUrl } from "../../api/base.js";

--- a/src/addons/types.ts
+++ b/src/addons/types.ts
@@ -1,0 +1,20 @@
+interface Author {
+  name?: string;
+  avatar?: string;
+}
+
+// API endpoint https://api.www.documentcloud.org/api/addons/
+export interface AddOnListItem {
+  id: number;
+  name: string;
+  repository: string;
+  parameters: any;
+  description?: string;
+  author?: Author;
+  usage?: number;
+  categories: string[];
+  documents: string[];
+  active: boolean;
+  featured: boolean;
+  default: boolean;
+}

--- a/src/pages/app/menus/AddonsMenu.svelte
+++ b/src/pages/app/menus/AddonsMenu.svelte
@@ -4,7 +4,7 @@
 
   import Menu from "../../../common/Menu.svelte";
   import MenuItem from "../../../common/MenuItem.svelte";
-  import { pinned } from "../../../addons/browser/AddOnListItem.svelte";
+  import { pinned } from "../../../addons/AddOnPin.svelte";
 
   $: alphabetizedAddons = $pinned.sort((a, b) => a.name.localeCompare(b.name));
 


### PR DESCRIPTION
Closes #250

This provides a control to pin/unpin an add-on from its detail page. Since pinned add-ons in the application sidebar link to the detail page, this provides users a simple path to unpinning an add-on.

This update refactors an `AddOnPin` component and `pinned` store out of the AddOnListItem. It also extracts the types to a standalone file.