### PR TITLE
Maybe handle redirects manually"

### DIFF
--- a/src/api/session.js
+++ b/src/api/session.js
@@ -91,7 +91,7 @@ session.getStatic = async function getStatic(url) {
   let result = await session.get(url).then((r) => r.data);
   let redirect = result.location;
 
-  // text requests return a 200 but have a location header
+  // text requests return a 200 but have a location property in the JSON result
   // this lets us send a second request to S3 without credentials
   if (redirect) {
     // note that this uses plain axios, not the session


### PR DESCRIPTION
Partially undoes #319 but in a way that redirects based on a location header, instead of hostname. 

Example document, private to MuckRock: https://deploy-preview-322.muckcloud.com/documents/20006188-change-assessment_w_mjw-letter

Closes #321 