### PR TITLE
JSON schema uses minimum and maximum, not min and max

### DIFF
--- a/src/addons/dispatch/fields/Number.svelte
+++ b/src/addons/dispatch/fields/Number.svelte
@@ -7,8 +7,8 @@
   export let value: number = defaultValue;
   export let required: boolean = false;
   export let description: string = "";
-  export let min: string | undefined = undefined;
-  export let max: string | undefined = undefined;
+  export let minimum: string | undefined = undefined;
+  export let maximum: string | undefined = undefined;
   export let inline = false;
 </script>
 
@@ -28,7 +28,7 @@
     on:input
     on:focus
     on:blur
-    {min}
-    {max}
+    min={minimum}
+    max={maximum}
   />
 </Field>


### PR DESCRIPTION
Closes #318 

See JSON schema: https://json-schema.org/understanding-json-schema/reference/numeric#number