### PR TITLE
Namespace built assets to make caching easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ public/node_modules_*
 public/embed/*
 public/notes/*
 public/viewer/*
+public/assets/
 
 # Netlify
 .netlify

--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,5 @@ browser-test-debug:
 
 clean:
 	# delete Webpack chunks
-	rm -f public/[0-9]*.*.* public/bundle.*.js public/bundle.*.css public/bundle.*.txt
+	rm -f public/index.html public/[0-9]*.*.* public/bundle.*.js public/bundle.*.css public/bundle.*.txt public/*.map public/*.*.js
+	rm -rf public/assets public/notes public/viewer public/embed

--- a/deploy-to-netlify.sh
+++ b/deploy-to-netlify.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-npm run build
-netlify deploy -d public --prod

--- a/public/_headers
+++ b/public/_headers
@@ -2,10 +2,10 @@
 # generated css and js files all have hashes in their names, so can be
 # cached forever
 
-/*.css
+/assets/*.css
   Cache-Control: public, max-age=604800, immutable
 
-/*.js
+/assets/*.js
   Cache-Control: public, max-age=604800, immutable
 
 
@@ -14,8 +14,5 @@
 # will set to cache for one day in the browser
 
 /favicon.png
-  Cache-Control: public, max-age=86400, s-maxage=604800, immutable
-
-/global.css
   Cache-Control: public, max-age=86400, s-maxage=604800, immutable
 

--- a/public/_redirects
+++ b/public/_redirects
@@ -4,3 +4,4 @@ https://beta.documentcloud.org/* https://www.documentcloud.org/:splat 301!
 /api/oembed.json https://api.www.documentcloud.org/api/oembed/
 /documents/:id/:path https://api.www.documentcloud.org/files/documents/:id/:path
 /*    /index.html   200
+/assets/* /assets/:splat

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,5 +3,5 @@ https://beta.documentcloud.org/* https://www.documentcloud.org/:splat 301!
 
 /api/oembed.json https://api.www.documentcloud.org/api/oembed/
 /documents/:id/:path https://api.www.documentcloud.org/files/documents/:id/:path
-/*    /index.html   200
 /assets/* /assets/:splat
+/*    /index.html   200

--- a/src/common/Dropdown.svelte
+++ b/src/common/Dropdown.svelte
@@ -79,7 +79,7 @@
 
   afterUpdate(() => {
     if (active && name) {
-      plausible("dropdown", { props: { name } });
+      window.plausible && plausible("dropdown", { props: { name } });
     }
   });
 </script>

--- a/src/pages/app/App.svelte
+++ b/src/pages/app/App.svelte
@@ -120,7 +120,7 @@
         (window.plausible.q = window.plausible.q || []).push(arguments);
       };
 
-    plausible("pageview");
+    window.plausible && plausible("pageview");
     hashRoute();
 
     // debug

--- a/src/pages/viewer/Viewer.svelte
+++ b/src/pages/viewer/Viewer.svelte
@@ -84,7 +84,7 @@
     if (!$viewer.embed) {
       await initOrgsAndUsers();
 
-      plausible("pageview", { u: obscureURL() });
+      window.plausible && plausible("pageview", { u: obscureURL() });
     }
   });
 

--- a/webpack.app.config.js
+++ b/webpack.app.config.js
@@ -12,8 +12,9 @@ const config = {
     bundle: ["./src/main.js"],
   },
   output: {
-    path: __dirname + "/public",
-    filename: "[name].[chunkhash].js",
+    path: path.join(__dirname, "public"),
+    filename: "assets/[name].[chunkhash].js",
+    chunkFilename: "assets/[name].[chunkhash].js",
     publicPath: "/",
   },
   plugins: [...baseConfig.plugins],

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -118,7 +118,7 @@ export default wrap({
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: "[name].[contenthash].css",
+      filename: "assets/[name].[contenthash].css",
     }),
     new DotEnv({
       path: prod ? `.env.${environment}` : ".env",


### PR DESCRIPTION
Everything webpack builds should end up under `public/assets`, except for `public/index.html`.

This also keeps static assets out of the client side router, so a 404 like https://deploy-preview-337.muckcloud.com/assets/foo.js won't get rendered as HTML (and therefore not cached).