### PR TITLE
Ensure ArrayField value is always an array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "rlite-router": "^2.0.3",
         "sass": "^1.60.0",
         "sass-loader": "^13.3.2",
-        "scrollzoom": "MuckRock/scrollzoom",
+        "scrollzoom": "github:MuckRock/scrollzoom",
         "style-loader": "^3.3.3",
         "svelte": "^4.0.0",
         "svelte-i18n": "^4.0.0",

--- a/src/addons/dispatch/fields/ArrayField.svelte
+++ b/src/addons/dispatch/fields/ArrayField.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { beforeUpdate } from "svelte";
   import Plus16 from "svelte-octicons/lib/Plus16.svelte";
+
   import Checkbox from "./Checkbox.svelte";
   import X16 from "svelte-octicons/lib/X16.svelte";
   import Number from "./Number.svelte";
@@ -15,9 +17,16 @@
   };
 
   export let count: number = 1;
-  export let value = Array(count).fill(null);
+  export let value: [any] = Array(count).fill(null);
 
-  $: numItems = value.length;
+  $: numItems = value?.length ?? 0;
+
+  beforeUpdate(() => {
+    // value should always be an array
+    if (!Array.isArray(value)) {
+      value = [];
+    }
+  });
 
   // only one level of nesting allowed
   const types = {


### PR DESCRIPTION
Closes #358 

Sometimes the `value` property on `ArrayField` gets set to `undefined` and that breaks things that assume it's an array.