### PR TITLE
Update Calendar to fixed "now" date for snapshots

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,5 +1,6 @@
 import type { Preview } from "@storybook/svelte";
 import { initialize, mswLoader } from "msw-storybook-addon";
+import { mockDateDecorator } from "storybook-mock-date-decorator";
 
 import "../src/langs/i18n.js";
 import "../src/style/variables.css";
@@ -23,5 +24,7 @@ const preview: Preview = {
   // Provide the MSW addon loader globally
   loaders: [mswLoader],
 };
+
+export let decorators = [mockDateDecorator];
 
 export default preview;

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "react-dom": "^18.2.0",
         "serve": "^14.2.0",
         "storybook": "7.5.3",
+        "storybook-mock-date-decorator": "^1.0.1",
         "svelte-jester": "^3.0.0",
         "tape": "^5.7.2"
       }
@@ -4871,6 +4872,287 @@
         }
       }
     },
+    "node_modules/@storybook/addons": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.5.16.tgz",
+      "integrity": "sha512-p3DqQi+8QRL5k7jXhXmJZLsE/GqHqyY6PcoA1oNTJr0try48uhTGUOYkgzmqtDaa/qPFO5LP+xCPzZXckGtquQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/api": "6.5.16",
+        "@storybook/channels": "6.5.16",
+        "@storybook/client-logger": "6.5.16",
+        "@storybook/core-events": "6.5.16",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/router": "6.5.16",
+        "@storybook/theming": "6.5.16",
+        "@types/webpack-env": "^1.16.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addons/node_modules/@storybook/channels": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.5.16.tgz",
+      "integrity": "sha512-VylzaWQZaMozEwZPJdyJoz+0jpDa8GRyaqu9TGG6QGv+KU5POoZaGLDkRE7TzWkyyP0KQLo80K99MssZCpgSeg==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addons/node_modules/@storybook/client-logger": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.5.16.tgz",
+      "integrity": "sha512-pxcNaCj3ItDdicPTXTtmYJE3YC1SjxFrBmHcyrN+nffeNyiMuViJdOOZzzzucTUG0wcOOX8jaSyak+nnHg5H1Q==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "global": "^4.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addons/node_modules/@storybook/core-events": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.5.16.tgz",
+      "integrity": "sha512-qMZQwmvzpH5F2uwNUllTPg6eZXr2OaYZQRRN8VZJiuorZzDNdAFmiVWMWdkThwmyLEJuQKXxqCL8lMj/7PPM+g==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addons/node_modules/@storybook/csf": {
+      "version": "0.0.2--canary.4566f4d.1",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.2--canary.4566f4d.1.tgz",
+      "integrity": "sha512-9OVvMVh3t9znYZwb0Svf/YQoxX2gVOeQTGe2bses2yj+a3+OJnCrUF3/hGv6Em7KujtOdL2LL+JnG49oMVGFgQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/@storybook/addons/node_modules/@storybook/router": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.5.16.tgz",
+      "integrity": "sha512-ZgeP8a5YV/iuKbv31V8DjPxlV4AzorRiR8OuSt/KqaiYXNXlOoQDz/qMmiNcrshrfLpmkzoq7fSo4T8lWo2UwQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.16",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addons/node_modules/@storybook/theming": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.16.tgz",
+      "integrity": "sha512-hNLctkjaYLRdk1+xYTkC1mg4dYz2wSv6SqbLpcKMbkPHTE0ElhddGPHQqB362md/w9emYXNkt1LSMD8Xk9JzVQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.16",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/addons/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
+    },
+    "node_modules/@storybook/api": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.5.16.tgz",
+      "integrity": "sha512-HOsuT8iomqeTMQJrRx5U8nsC7lJTwRr1DhdD0SzlqL4c80S/7uuCy4IZvOt4sYQjOzW5fOo/kamcoBXyLproTA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "6.5.16",
+        "@storybook/client-logger": "6.5.16",
+        "@storybook/core-events": "6.5.16",
+        "@storybook/csf": "0.0.2--canary.4566f4d.1",
+        "@storybook/router": "6.5.16",
+        "@storybook/semver": "^7.3.2",
+        "@storybook/theming": "6.5.16",
+        "core-js": "^3.8.2",
+        "fast-deep-equal": "^3.1.3",
+        "global": "^4.4.0",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7",
+        "store2": "^2.12.0",
+        "telejson": "^6.0.8",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/channels": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.5.16.tgz",
+      "integrity": "sha512-VylzaWQZaMozEwZPJdyJoz+0jpDa8GRyaqu9TGG6QGv+KU5POoZaGLDkRE7TzWkyyP0KQLo80K99MssZCpgSeg==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/client-logger": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.5.16.tgz",
+      "integrity": "sha512-pxcNaCj3ItDdicPTXTtmYJE3YC1SjxFrBmHcyrN+nffeNyiMuViJdOOZzzzucTUG0wcOOX8jaSyak+nnHg5H1Q==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2",
+        "global": "^4.4.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/core-events": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.5.16.tgz",
+      "integrity": "sha512-qMZQwmvzpH5F2uwNUllTPg6eZXr2OaYZQRRN8VZJiuorZzDNdAFmiVWMWdkThwmyLEJuQKXxqCL8lMj/7PPM+g==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.8.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/csf": {
+      "version": "0.0.2--canary.4566f4d.1",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.2--canary.4566f4d.1.tgz",
+      "integrity": "sha512-9OVvMVh3t9znYZwb0Svf/YQoxX2gVOeQTGe2bses2yj+a3+OJnCrUF3/hGv6Em7KujtOdL2LL+JnG49oMVGFgQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/router": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.5.16.tgz",
+      "integrity": "sha512-ZgeP8a5YV/iuKbv31V8DjPxlV4AzorRiR8OuSt/KqaiYXNXlOoQDz/qMmiNcrshrfLpmkzoq7fSo4T8lWo2UwQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.16",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/@storybook/theming": {
+      "version": "6.5.16",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.16.tgz",
+      "integrity": "sha512-hNLctkjaYLRdk1+xYTkC1mg4dYz2wSv6SqbLpcKMbkPHTE0ElhddGPHQqB362md/w9emYXNkt1LSMD8Xk9JzVQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "6.5.16",
+        "core-js": "^3.8.2",
+        "memoizerific": "^1.11.3",
+        "regenerator-runtime": "^0.13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/isobject": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+      "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@storybook/api/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
+    },
+    "node_modules/@storybook/api/node_modules/telejson": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/telejson/-/telejson-6.0.8.tgz",
+      "integrity": "sha512-nerNXi+j8NK1QEfBHtZUN/aLdDcyupA//9kAboYLrtzZlPLpUfqbVGWb9zz91f/mIjRbAYhbgtnJHY8I1b5MBg==",
+      "dev": true,
+      "dependencies": {
+        "@types/is-function": "^1.0.0",
+        "global": "^4.4.0",
+        "is-function": "^1.0.2",
+        "is-regex": "^1.1.2",
+        "is-symbol": "^1.0.3",
+        "isobject": "^4.0.0",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3"
+      }
+    },
     "node_modules/@storybook/blocks": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-7.5.3.tgz",
@@ -6044,6 +6326,74 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/@storybook/semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^3.6.5",
+        "find-up": "^4.1.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@storybook/semver/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/semver/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/semver/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/semver/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@storybook/svelte": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/@storybook/svelte/-/svelte-7.5.3.tgz",
@@ -6726,6 +7076,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/is-function": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/is-function/-/is-function-1.0.3.tgz",
+      "integrity": "sha512-/CLhCW79JUeLKznI6mbVieGbl4QU5Hfn+6udw1YHZoofASjbQ5zaP5LzAUZYDpRYEjS4/P+DhEgyJ/PQmGGTWw==",
+      "dev": true
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -6951,6 +7307,12 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==",
+      "dev": true
+    },
+    "node_modules/@types/webpack-env": {
+      "version": "1.18.4",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.4.tgz",
+      "integrity": "sha512-I6e+9+HtWADAWeeJWDFQtdk4EVSAbj6Rtz4q8fJ7mSr1M0jzlFcs8/HZ+Xb5SHzVm1dxH7aUiI+A8kA8Gcrm0A==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -9194,6 +9556,17 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/core-js": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.34.0.tgz",
+      "integrity": "sha512-aDdvlDder8QmY91H88GzNi9EtQi2TjvQhpCX6B1v/dAZHU1AuLgHvRh54RiOerpEhEW46Tkf+vgAViB/CWC0ag==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.33.2",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.2.tgz",
@@ -9958,6 +10331,12 @@
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
@@ -12154,6 +12533,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -13159,6 +13548,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "dev": true
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
@@ -16425,6 +16820,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dev": true,
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -16550,6 +16954,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==",
+      "dev": true
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -19634,6 +20044,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/storybook-mock-date-decorator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/storybook-mock-date-decorator/-/storybook-mock-date-decorator-1.0.1.tgz",
+      "integrity": "sha512-ZHrl8ZdB++g1d3VmPYzUqguqwiXc6HOF6eUrC4m2xjAtTq9aDhHKqAiQu90TMatrZwkMJULfHpmG2qPLl3fRQQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^6.4.19",
+        "mockdate": "^3.0.5"
       }
     },
     "node_modules/stream-shift": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "react-dom": "^18.2.0",
     "serve": "^14.2.0",
     "storybook": "7.5.3",
+    "storybook-mock-date-decorator": "^1.0.1",
     "svelte-jester": "^3.0.0",
     "tape": "^5.7.2"
   },

--- a/src/common/stories/Calendar.stories.ts
+++ b/src/common/stories/Calendar.stories.ts
@@ -3,7 +3,6 @@ import type { Meta, StoryObj } from "@storybook/svelte";
 import "@/langs/i18n.js";
 import Calendar from "../Calendar.svelte";
 
-// More on how to set up stories at: https://storybook.js.org/docs/7.0/svelte/writing-stories/introduction
 const meta: Meta<Calendar> = {
   title: "Common/Calendar",
   component: Calendar,
@@ -11,12 +10,14 @@ const meta: Meta<Calendar> = {
   argTypes: {
     value: { control: { type: "date" } },
   },
+  parameters: {
+    date: new Date("December 5, 2023 10:00:00"),
+  },
 };
 
 export default meta;
 type Story = StoryObj<Calendar>;
 
-// More on writing stories with args: https://storybook.js.org/docs/7.0/svelte/writing-stories/args
 export const Default: Story = {
   args: {},
 };


### PR DESCRIPTION
This adds a Storybook date decorator for setting the "now" time when rendering components. This prevents the story snapshots from changing in Chromatic and requiring re-approval.

The date on the Calendar storybook should be set to 12/5/23 @ 11:00 in this PR and in perpetuity.