### PR TITLE
More common components into Storybook

### DIFF
--- a/src/common/dialog/SearchTipsDialog.svelte
+++ b/src/common/dialog/SearchTipsDialog.svelte
@@ -1,14 +1,6 @@
 <script>
   import SearchExample from "@/common/SearchExample.svelte";
 
-  import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
-  import { slugify } from "@/util/string.js";
-
-  $: userExample =
-    $orgsAndUsers.me != null
-      ? `user:${slugify($orgsAndUsers.me.name, $orgsAndUsers.me.id)}`
-      : "user:example-123";
-
   const table = [
     // Basic usage
     ["Basic usage"],
@@ -154,7 +146,7 @@
 
 <div>
   <div class="mcontent">
-    <h1>Search Tips</h1>
+    <h2>Search Tips</h2>
     <div class="padded">
       <p>
         The search bar is a flexible and powerful tool for searching your
@@ -163,18 +155,16 @@
         display your documents, but you can do a lot more.
       </p>
       <SearchExample
-        content={`${userExample} "mueller report" project:test-345  -pages:448`}
+        content={`"user:example-123" "mueller report" project:test-345  -pages:448`}
       />
       <p>
-        The above example, for instance, searches all documents within
-        {#if $orgsAndUsers.loggedIn}your account{:else}a user’s account{/if}
-        for a specific project that contain the exact text “mueller report” and don’t
-        have a page count of 448 (thus excluding the actual Mueller Report).
-        <a href="/help/search">Additional documentation</a>
+        The above example, for instance, searches all documents within a user’s
+        account for a specific project that contain the exact text “mueller
+        report” and don’t have a page count of 448 (thus excluding the actual
+        Mueller Report).
+        <a target="_blank" href="/help/search">Additional documentation</a>
       </p>
-      <p>
-        <b>Reference table:</b>
-      </p>
+      <h3>Reference table:</h3>
 
       <table cellspacing="0">
         {#each table as row}

--- a/src/common/dialog/SearchTipsDialog.svelte
+++ b/src/common/dialog/SearchTipsDialog.svelte
@@ -1,6 +1,5 @@
 <script>
   import SearchExample from "@/common/SearchExample.svelte";
-  import Link from "@/router/Link.svelte";
 
   import { orgsAndUsers } from "@/manager/orgsAndUsers.js";
   import { slugify } from "@/util/string.js";
@@ -171,7 +170,7 @@
         {#if $orgsAndUsers.loggedIn}your account{:else}a user’s account{/if}
         for a specific project that contain the exact text “mueller report” and don’t
         have a page count of 448 (thus excluding the actual Mueller Report).
-        <Link color={true} toUrl="/help/search">Additional documentation</Link>
+        <a href="/help/search">Additional documentation</a>
       </p>
       <p>
         <b>Reference table:</b>
@@ -212,72 +211,75 @@
   </div>
 </div>
 
-<style lang="scss">
+<style>
+  a {
+    color: var(--primary);
+  }
+
   .padded {
     margin-bottom: 35px;
   }
 
   table {
-    $border: solid 1px gainsboro;
+    --border: solid 1px gainsboro;
     margin-top: -10px;
+  }
 
-    td,
-    th {
-      border-right: $border;
-      border-bottom: $border;
-      vertical-align: middle;
-      padding: 4px 8px;
+  table td,
+  table th {
+    border-right: var(--border);
+    border-bottom: var(--border);
+    vertical-align: middle;
+    padding: 4px 8px;
+  }
 
-      &:first-child {
-        border-left: $border;
-      }
-    }
+  table td:first-child,
+  table th:first-child {
+    border-left: var(--border);
+  }
 
-    .name {
-      padding: 8px;
+  table .name {
+    padding: 8px;
+  }
 
-      h4 {
-        font-size: 15px;
-        margin: 0 0 3px 0;
-      }
+  table .name h4 {
+    font-size: 15px;
+    margin: 0 0 3px 0;
+  }
 
-      p {
-        font-size: 13px;
-        margin: 0;
-      }
-    }
+  table .name p {
+    font-size: 13px;
+    margin: 0;
+  }
 
-    .filter {
-      padding-bottom: 0;
-      width: 50%;
-      max-width: 270px;
-      min-width: 200px;
-    }
+  table .filter {
+    padding-bottom: 0;
+    width: 50%;
+    max-width: 270px;
+    min-width: 200px;
+  }
 
-    tr:first-child {
-      td,
-      th {
-        border-top: $border;
-      }
-    }
+  table tr:first-child th,
+  table tr:first-child td {
+    border-top: var(--border);
+  }
 
-    th {
-      background: rgb(244, 244, 244);
-      font-size: 14px;
+  table th {
+    background: rgb(244, 244, 244);
+    font-size: 14px;
+  }
 
-      &.header {
-        background: white !important;
-        border: none !important;
-        padding: 0 !important;
+  table th.header {
+    background: white !important;
+    border: none !important;
+    padding: 0 !important;
+  }
 
-        > div {
-          background: $primary;
-          color: white;
-          padding: 6px 8px;
-          margin-top: 14px;
-          border-bottom: $border;
-        }
-      }
-    }
+  table th.header > div {
+    background: var(--primary);
+    color: white;
+    padding: 6px 8px;
+    margin-top: 14px;
+    border-bottom: var(--border);
   }
 </style>

--- a/src/common/dialog/stories/SearchTipsDialog.stories.svelte
+++ b/src/common/dialog/stories/SearchTipsDialog.stories.svelte
@@ -1,0 +1,14 @@
+<script context="module">
+  import { Story } from "@storybook/addon-svelte-csf";
+  import SearchTipsDialog from "../SearchTipsDialog.svelte";
+  import Modal from "../../Modal.svelte";
+
+  export const meta = {
+    title: "Common / Dialog / Search Tips Dialog",
+    component: SearchTipsDialog,
+  };
+</script>
+
+<Story name="default">
+  <Modal component={SearchTipsDialog} />
+</Story>

--- a/src/common/stories/ErrorData.stories.svelte
+++ b/src/common/stories/ErrorData.stories.svelte
@@ -1,0 +1,17 @@
+<script context="module">
+  import { Story } from "@storybook/addon-svelte-csf";
+  import ErrorData from "../ErrorData.svelte";
+
+  export const meta = {
+    title: "Common / Error Data",
+    component: ErrorData,
+  };
+
+  const error = {
+    errorData: {},
+  };
+</script>
+
+<Story name="default">
+  <ErrorData {error} />
+</Story>

--- a/src/common/stories/HtmlField.stories.svelte
+++ b/src/common/stories/HtmlField.stories.svelte
@@ -1,0 +1,14 @@
+<script context="module">
+  import { Story } from "@storybook/addon-svelte-csf";
+  import HtmlField from "../HtmlField.svelte";
+
+  export const meta = {
+    title: "Common / HTML Field",
+    component: HtmlField,
+  };
+</script>
+
+<!-- this will not render without mocking the router -->
+<Story name="default">
+  <HtmlField />
+</Story>

--- a/src/common/stories/Logo.stories.svelte
+++ b/src/common/stories/Logo.stories.svelte
@@ -1,0 +1,27 @@
+<script context="module">
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+  import Logo from "../Logo.svelte";
+
+  export const meta = {
+    title: "Common / Logo",
+    component: Logo,
+  };
+
+  const args = {
+    newPage: false,
+    nopadding: false,
+    homeLink: false,
+  };
+</script>
+
+<Template let:args>
+  <Logo {...args} />
+</Template>
+
+<Story name="default" {args} />
+
+<Story name="new page" args={{ ...args, newPage: true }} />
+
+<Story name="no padding" args={{ ...args, nopadding: true }} />
+
+<Story name="home link" args={{ ...args, homeLink: true }} />


### PR DESCRIPTION
This adds four more components into Storybook. These all depend on the router, so my goal is to figure out whether we can make them stateless. 

`src/common/dialog/SearchTipsDialog.svelte` had one `Link` component, which is now an `a` tag. It still relies on the `orgsAndUsers` store in order to check if the current user is logged in, and use that to write an example search.

`src/common/ErrorData.svelte` uses the `nav` helper to turn route names into URLs.

`src/common/Logo.svelte` has a surprising amount of logic in it. This should really just be an icon that gets wrapped in a link, and that logic should be outside the component.

`src/common/HtmlField.svelte` gets used in the viewer, as text entry. Will probably make a new version in SvelteKit when we have more form handling options.

`src/common/Dropdown.svelte` should just get replaced with `src/common/Dropdown2.svelte`.