### PR TITLE
Fixes missing edit button on sidebar projects

### DIFF
--- a/src/pages/app/sidebar/projects/ProjectListItem.svelte
+++ b/src/pages/app/sidebar/projects/ProjectListItem.svelte
@@ -8,12 +8,17 @@
 </script>
 
 <ListItem label={title}>
-  <span slot="icon" class="folder"><FileDirectoryFill16 slot="icon" /></span>
-  {#if onEditClick}
-    <button class="edit" on:click|stopPropagation|preventDefault={onEditClick}>
-      <Pencil16 />
-    </button>
-  {/if}
+  <span slot="icon" class="folder"><FileDirectoryFill16 /></span>
+  <span slot="action">
+    {#if onEditClick}
+      <button
+        class="edit"
+        on:click|stopPropagation|preventDefault={onEditClick}
+      >
+        <Pencil16 />
+      </button>
+    {/if}
+  </span>
 </ListItem>
 
 <style>
@@ -49,9 +54,9 @@
 
   .edit {
     flex: 0 0 2rem;
-    padding: 0.125rem;
-    height: 2rem;
-    width: 2rem;
+    padding: 0.25rem;
+    height: 1.25rem;
+    width: 1.25rem;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
The edit action was not assigned to the ListItem's "action" slot. This fixes that.