### PR TITLE
Fixes for Chromatic

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -21,9 +21,10 @@ const preview: Preview = {
       },
     },
   },
-  // Provide the MSW addon loader globally
-  loaders: [mswLoader],
 };
+
+// Provide the MSW addon loader globally
+export const loaders = [mswLoader];
 
 export let decorators = [mockDateDecorator];
 

--- a/README.md
+++ b/README.md
@@ -121,3 +121,9 @@ nvm install 16
 # or
 nvm install --lts
 ```
+
+## Thanks
+
+<a href="https://www.chromatic.com/"><img src="https://user-images.githubusercontent.com/321738/84662277-e3db4f80-af1b-11ea-88f5-91d67a5e59f6.png" width="153" height="30" alt="Chromatic" /></a>
+
+Thanks to [Chromatic](https://www.chromatic.com/) for providing the visual testing platform that helps us review UI changes and catch visual regressions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@storybook/addon-links": "^7.6.4",
         "@storybook/addon-svelte-csf": "^4.0.13",
         "@storybook/blocks": "^7.6.4",
+        "@storybook/jest": "^0.2.3",
         "@storybook/svelte": "^7.6.4",
         "@storybook/svelte-webpack5": "^7.6.4",
         "@storybook/testing-library": "^0.2.2",
@@ -96,6 +97,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.2.tgz",
+      "integrity": "sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -4546,6 +4553,66 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/addon-interactions/node_modules/@storybook/channels": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.6.4.tgz",
+      "integrity": "sha512-Z4PY09/Czl70ap4ObmZ4bgin+EQhPaA3HdrEDNwpnH7A9ttfEO5u5KThytIjMq6kApCCihmEPDaYltoVrfYJJA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.6.4",
+        "@storybook/core-events": "7.6.4",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-interactions/node_modules/@storybook/client-logger": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.6.4.tgz",
+      "integrity": "sha512-vJwMShC98tcoFruRVQ4FphmFqvAZX1FqZqjFyk6IxtFumPKTVSnXJjlU1SnUIkSK2x97rgdUMqkdI+wAv/tugQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-interactions/node_modules/@storybook/core-events": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.6.4.tgz",
+      "integrity": "sha512-i3xzcJ19ILSy4oJL5Dz9y0IlyApynn5RsGhAMIsW+mcfri+hGfeakq1stNCo0o7jW4Y3A7oluFTtIoK8DOxQdQ==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/addon-interactions/node_modules/@storybook/types": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.6.4.tgz",
+      "integrity": "sha512-qyiiXPCvol5uVgfubcIMzJBA0awAyFPU+TyUP1mkPYyiTHnsHYel/mKlSdPjc8a97N3SlJXHOCx41Hde4IyJgg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.6.4",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/addon-links": {
       "version": "7.6.4",
       "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-7.6.4.tgz",
@@ -5861,11 +5928,32 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/expect": {
+      "version": "28.1.3-5",
+      "resolved": "https://registry.npmjs.org/@storybook/expect/-/expect-28.1.3-5.tgz",
+      "integrity": "sha512-lS1oJnY1qTAxnH87C765NdfvGhksA6hBcbUVI5CHiSbNsEtr456wtg/z+dT9XlPriq1D5t2SgfNL9dBAoIGyIA==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "28.1.3"
+      }
+    },
     "node_modules/@storybook/global": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
       "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
       "dev": true
+    },
+    "node_modules/@storybook/jest": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@storybook/jest/-/jest-0.2.3.tgz",
+      "integrity": "sha512-ov5izrmbAFObzKeh9AOC5MlmFxAcf0o5i6YFGae9sDx6DGh6alXsRM+chIbucVkUwVHVlSzdfbLDEFGY/ShaYw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/expect": "storybook-jest",
+        "@testing-library/jest-dom": "^6.1.2",
+        "@types/jest": "28.1.3",
+        "jest-mock": "^27.3.0"
+      }
     },
     "node_modules/@storybook/manager": {
       "version": "7.6.4",
@@ -6555,6 +6643,96 @@
         "node": ">=8"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.1.5.tgz",
+      "integrity": "sha512-3y04JLW+EceVPy2Em3VwNr95dOKqA8DhR0RJHhHKDZNYXcVXnEK7WIrpj4eYU8SVt/qYZ2aRWt/WgQ+grNES8g==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.3.1",
+        "@babel/runtime": "^7.9.2",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@jest/globals": ">= 28",
+        "@types/jest": ">= 28",
+        "jest": ">= 28",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@testing-library/user-event": {
       "version": "14.5.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.1.tgz",
@@ -6809,6 +6987,167 @@
       "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.3.tgz",
+      "integrity": "sha512-Tsbjk8Y2hkBaY/gJsataeb4q9Mubw9EOz7+4RjPkzD5KjTvHHs7cpws22InaoXxAVAhF5HfFbzJjo6oKWqSZLw==",
+      "dev": true,
+      "dependencies": {
+        "jest-matcher-utils": "^28.0.0",
+        "pretty-format": "^28.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
+      "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.24.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.24.51",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
+      "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
+      "dev": true
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/diff-sequences": {
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
+      "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^28.1.1",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-get-type": {
+      "version": "28.0.2",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
+      "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^28.1.3",
+        "jest-get-type": "^28.0.2",
+        "pretty-format": "^28.1.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "28.1.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
+      "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^28.1.3",
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
+    "node_modules/@types/jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@types/js-levenshtein": {
@@ -9527,6 +9866,12 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -18420,6 +18765,19 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regenerate": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@storybook/addon-links": "^7.6.4",
     "@storybook/addon-svelte-csf": "^4.0.13",
     "@storybook/blocks": "^7.6.4",
+    "@storybook/jest": "^0.2.3",
     "@storybook/svelte": "^7.6.4",
     "@storybook/svelte-webpack5": "^7.6.4",
     "@storybook/testing-library": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
   "engine": 18,
   "browserslist": "> 0.25%, not dead",
   "msw": {
-    "workerDirectory": "public"
+    "workerDirectory": "./public"
   }
 }

--- a/src/api/orgAndUser.js
+++ b/src/api/orgAndUser.js
@@ -1,22 +1,14 @@
-import session, { cookiesEnabled } from "./session.js";
+import session from "./session.js";
 import { USER_EXPAND, ORG_EXPAND, DEFAULT_EXPAND } from "./common.js";
 import { queryBuilder } from "@/util/url.js";
 import { grabAllPages } from "@/util/paginate.js";
 import { apiUrl } from "./base.js";
 
-const hasCsrfToken = /(^|;\s*)csrftoken=[a-zA-Z0-9]+/;
-
 export async function getMe(expand = DEFAULT_EXPAND) {
-  // Check that the user is logged in via cookies
-  if (cookiesEnabled) {
-    if (!hasCsrfToken.test(document.cookie)) {
-      return null;
-    }
-  }
-  // Check that the user is logged in via network request
-  const { data } = await session.get(
+  const { status, data } = await session.get(
     queryBuilder(apiUrl(`users/me/`), { expand }),
   );
+  if (status !== 200) return null;
   return data;
 }
 

--- a/src/common/dialog/RevisionsDialog.svelte
+++ b/src/common/dialog/RevisionsDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { _ } from "svelte-i18n";
   import { getMe } from "../../api/orgAndUser.js";
   import {
@@ -25,23 +26,31 @@
       return b.version - a.version;
     }) ?? null;
 
-  let getMePromise = getMe();
-  function retryGetMe() {
-    getMePromise = getMe();
+  let user;
+  let loading = false;
+  let error;
+
+  async function load() {
+    loading = true;
+    try {
+      user = await getMe();
+    } catch {
+      error = true;
+    }
+    loading = false;
   }
+
+  onMount(load);
 </script>
 
-{#await getMePromise}
-  <Loader active>
+<Loader active={loading}>
+  {#if error}
     <div class="mcontent">
-      <header>
-        <h3>{$_("dialogRevisionsDialog.heading")}</h3>
-        <PremiumBadge />
-      </header>
+      <ErrorMessage message={$_("dialogRevisionsDialog.error")}
+        ><Button caution action on:click={load}>Retry</Button></ErrorMessage
+      >
     </div>
-  </Loader>
-{:then user}
-  <Loader active={false}>
+  {:else}
     <div class="mcontent">
       <header>
         <h3>{$_("dialogRevisionsDialog.heading")}</h3>
@@ -115,17 +124,8 @@
         />
       {/if}
     </div>
-  </Loader>
-{:catch}
-  <Loader active={false}>
-    <div class="mcontent">
-      <ErrorMessage message={$_("dialogRevisionsDialog.error")}
-        ><Button caution action on:click={retryGetMe}>Retry</Button
-        ></ErrorMessage
-      >
-    </div>
-  </Loader>
-{/await}
+  {/if}
+</Loader>
 
 <style>
   .mcontent {

--- a/src/common/dialog/stories/RevisionsDialog.stories.svelte
+++ b/src/common/dialog/stories/RevisionsDialog.stories.svelte
@@ -37,10 +37,7 @@
     component: RevisionsDialog,
     parameters: {
       layout: "centered",
-      chromatic: { delay: 300 },
-      msw: {
-        handlers: [revisionControl.success, mockGetMe.data],
-      },
+      chromatic: { delay: 1000 },
     },
     argTypes: {
       enabled: {
@@ -75,13 +72,39 @@
       await expect(downloadButtons[0]).toHaveAttribute("target", "download");
     });
   }}
+  parameters={{
+    msw: {
+      handlers: [revisionControl.success, mockGetMe.data],
+    },
+  }}
 />
-<Story name="With Zero Revisions" args={{ ...args, revisions: [] }} />
+<Story
+  name="With Zero Revisions"
+  args={{ ...args, revisions: [] }}
+  parameters={{
+    msw: {
+      handlers: [revisionControl.success, mockGetMe.data],
+    },
+  }}
+/>
 <Story
   name="With Many Revisions"
   args={{ ...args, revisions: manyRevisions }}
+  parameters={{
+    msw: {
+      handlers: [revisionControl.success, mockGetMe.data],
+    },
+  }}
 />
-<Story name="Disabled Revision Control" args={{ ...args, enabled: false }} />
+<Story
+  name="Disabled Revision Control"
+  args={{ ...args, enabled: false }}
+  parameters={{
+    msw: {
+      handlers: [revisionControl.success, mockGetMe.data],
+    },
+  }}
+/>
 <Story
   name="With Change Loading"
   {args}

--- a/src/common/dialog/stories/RevisionsDialog.stories.svelte
+++ b/src/common/dialog/stories/RevisionsDialog.stories.svelte
@@ -1,5 +1,7 @@
 <script lang="ts" context="module">
   import { Story, Template } from "@storybook/addon-svelte-csf";
+  import { userEvent, within } from "@storybook/testing-library";
+  import { expect } from "@storybook/jest";
 
   import RevisionsDialog from "../RevisionsDialog.svelte";
 
@@ -54,7 +56,26 @@
   <RevisionsDialog {...args} />
 </Template>
 
-<Story name="With Revisions" {args} />
+<Story
+  name="With Revisions"
+  {args}
+  play={async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step("Display document revisions", async () => {
+      await canvas.findByText("3 total");
+    });
+    await step("Toggle revisions", async () => {
+      await canvas.findByText("Revision Control");
+      const checkbox = await canvas.getByRole("checkbox");
+      await userEvent.click(checkbox);
+      await expect(checkbox).not.toBeChecked();
+    });
+    await step("Download revisions", async () => {
+      const downloadButtons = await canvas.getAllByText("Download");
+      await expect(downloadButtons[0]).toHaveAttribute("target", "download");
+    });
+  }}
+/>
 <Story name="With Zero Revisions" args={{ ...args, revisions: [] }} />
 <Story
   name="With Many Revisions"

--- a/src/common/dialog/stories/RevisionsDialog.stories.svelte
+++ b/src/common/dialog/stories/RevisionsDialog.stories.svelte
@@ -61,15 +61,17 @@
     await step("Display document revisions", async () => {
       await canvas.findByText("3 total");
     });
+    await step("Download revisions", async () => {
+      const downloadButtons = await canvas.getAllByText("Download");
+      await expect(downloadButtons[0]).toHaveAttribute("target", "download");
+    });
     await step("Toggle revisions", async () => {
       await canvas.findByText("Revision Control");
       const checkbox = await canvas.getByRole("checkbox");
       await userEvent.click(checkbox);
       await expect(checkbox).not.toBeChecked();
-    });
-    await step("Download revisions", async () => {
-      const downloadButtons = await canvas.getAllByText("Download");
-      await expect(downloadButtons[0]).toHaveAttribute("target", "download");
+      await userEvent.click(checkbox);
+      await expect(checkbox).toBeChecked();
     });
   }}
   parameters={{

--- a/src/manager/orgsAndUsers.js
+++ b/src/manager/orgsAndUsers.js
@@ -249,7 +249,9 @@ export function getUpgradeURL(org) {
 }
 
 export async function triggerPremiumUpgradeFlow(org) {
-  window?.open(getUpgradeUrl(org));
+  if (org) {
+    window?.open(getUpgradeUrl(org));
+  }
 }
 
 // TODO: Handle flow for purchasing premium credits (#342)


### PR DESCRIPTION
This makes changes to improve the stability of Chromatic renders across builds.

- It adds an interaction test to `RevisionsDialog` that does integration testing on the component. This can serve as a model for future component tests.
- Major change is updating `src/api/orgAndUser.js:getMe` to not check for a CSRF token when fetching user data, instead relying on a 404 response to know if the user is signed out.

We've also been granted a free open-source project plan by Chromatic, so this adds a "thank you" to the README at their request.