### PR TITLE
Setup Chromatic with TurboSnap for optimized deployments

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,3 +24,6 @@ jobs:
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true
+          externals: |
+            - 'public/**'


### PR DESCRIPTION
Chromatic's [TurboSnap](https://www.chromatic.com/docs/turbosnap/) feature only builds stories related to changed files. This helps reduce our overall usage of the service and speeds up our PR testing.