### PR TITLE
Prevent calls to `getMe` from embed

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,6 +14,7 @@ const config: StorybookConfig = {
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
     "@storybook/addon-svelte-csf",
+    "storybook-addon-cookie",
   ],
   framework: {
     name: "@storybook/svelte-webpack5",

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -20,6 +20,10 @@ const preview: Preview = {
         date: /Date$/,
       },
     },
+    cookie: {
+      csrftoken: "mockToken",
+    },
+    cookiePreserve: true,
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "react-dom": "^18.2.0",
         "serve": "^14.2.0",
         "storybook": "7.6.10",
+        "storybook-addon-cookie": "^3.2.0",
         "storybook-mock-date-decorator": "^1.0.1",
         "svelte-jester": "^3.0.0",
         "tape": "^5.7.2",
@@ -20133,6 +20134,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/storybook-addon-cookie": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-cookie/-/storybook-addon-cookie-3.2.0.tgz",
+      "integrity": "sha512-m98yfGNDbNHkvRsQVVQe+RiasoxU1c0u8SA2svuT+VfofAv3b55xZzDSnZ6Yn0h7zY9wmpRaJ4Twx+H4ryvkWQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@storybook/blocks": "^7.0.0",
+        "@storybook/components": "^7.0.0",
+        "@storybook/manager-api": "^7.0.0",
+        "@storybook/preview-api": "^7.0.0",
+        "@storybook/types": "^7.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/storybook-mock-date-decorator": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-dom": "^18.2.0",
     "serve": "^14.2.0",
     "storybook": "7.6.10",
+    "storybook-addon-cookie": "^3.2.0",
     "storybook-mock-date-decorator": "^1.0.1",
     "svelte-jester": "^3.0.0",
     "tape": "^5.7.2",

--- a/src/api/orgAndUser.js
+++ b/src/api/orgAndUser.js
@@ -1,10 +1,13 @@
-import session from "./session.js";
+import session, { cookiesEnabled, getCsrfToken } from "./session.js";
 import { USER_EXPAND, ORG_EXPAND, DEFAULT_EXPAND } from "./common.js";
 import { queryBuilder } from "@/util/url.js";
 import { grabAllPages } from "@/util/paginate.js";
 import { apiUrl } from "./base.js";
 
 export async function getMe(expand = DEFAULT_EXPAND) {
+  // Check that the user is logged in via cookies
+  if (cookiesEnabled && !getCsrfToken()) return null;
+  // Check that the user is logged in via network request
   const { status, data } = await session.get(
     queryBuilder(apiUrl(`users/me/`), { expand }),
   );

--- a/src/common/dialog/stories/RevisionsDialog.stories.svelte
+++ b/src/common/dialog/stories/RevisionsDialog.stories.svelte
@@ -38,6 +38,10 @@
     parameters: {
       layout: "centered",
       chromatic: { delay: 1000 },
+      cookie: {
+        csrftoken: "mockToken",
+      },
+      cookiePreserve: true,
     },
     argTypes: {
       enabled: {
@@ -141,5 +145,16 @@
   {args}
   parameters={{
     msw: { handlers: [revisionControl.loading, mockGetMe.loading] },
+  }}
+/>
+<Story
+  name="Without CSRF Token"
+  {args}
+  parameters={{
+    msw: { handlers: [revisionControl.success, mockGetMe.data] },
+    cookie: {
+      csrftoken: "",
+    },
+    cookiePreserve: false,
   }}
 />

--- a/src/common/dialog/stories/RevisionsDialog.stories.svelte
+++ b/src/common/dialog/stories/RevisionsDialog.stories.svelte
@@ -38,10 +38,6 @@
     parameters: {
       layout: "centered",
       chromatic: { delay: 1000 },
-      cookie: {
-        csrftoken: "mockToken",
-      },
-      cookiePreserve: true,
     },
     argTypes: {
       enabled: {


### PR DESCRIPTION
A recent change removed the CSRF token check during the call to the `getMe` API handler. This led to increased unauthenticated calls to getMe from the embedded viewer. This reintroduces that check and should minimize unnecessary requests to the endpoint.