### PR TITLE
Sort image sizes smallest to biggest

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -45,7 +45,7 @@ export const IMAGE_WIDTHS_ENTRIES = [
 export const IMAGE_WIDTHS = IMAGE_WIDTHS_ENTRIES.map(([name, width]) => [
   width,
   name,
-]);
+]).sort((a, b) => a[0] - b[0]);
 
 export const IMAGE_WIDTHS_MAP = new Map(IMAGE_WIDTHS);
 


### PR DESCRIPTION
Fixes issue with old documents not having extra large images.

Visible on staging (last PR, without this fix): https://deploy-preview-417.muckcloud.com/documents/20000254-doc_3-copy-53

Production: https://www.documentcloud.org/documents/4488414-Edison-Electric-Institute-2004-2