### PR TITLE
CI for SvelteKit PRs

### DIFF
--- a/.github/workflows/sveltekit.yml
+++ b/.github/workflows/sveltekit.yml
@@ -1,0 +1,46 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+# This runs CI specifically for development of the `sveltekit` branch.
+# It uses our new testing infrastructure.
+
+name: SvelteKit CI
+
+on:
+  pull_request:
+    branches: [sveltekit]
+
+jobs:
+  
+  unit-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+      - run: npm ci
+      - run: npm run build
+        env:
+          NODE_ENV: production
+      - run: npm test:coverage
+      - name: Report Coverage
+        uses: davelosert/vitest-coverage-report-action@v2
+  
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+      - run: npm ci
+      - run: npm run build
+        env:
+          NODE_ENV: production
+      - run: npm run check
+  

--- a/.github/workflows/sveltekit.yml
+++ b/.github/workflows/sveltekit.yml
@@ -11,7 +11,6 @@ on:
     branches: [sveltekit]
 
 jobs:
-  
   unit-test:
     runs-on: ubuntu-latest
 
@@ -25,10 +24,10 @@ jobs:
       - run: npm run build
         env:
           NODE_ENV: production
-      - run: npm test:coverage
+      - run: npm run test:coverage
       - name: Report Coverage
         uses: davelosert/vitest-coverage-report-action@v2
-  
+
   check:
     runs-on: ubuntu-latest
 
@@ -43,4 +42,3 @@ jobs:
         env:
           NODE_ENV: production
       - run: npm run check
-  

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,7 +4,10 @@ const config: StorybookConfig = {
   core: {
     disableTelemetry: true, // 👈 Disables telemetry
   },
-  stories: ["../src/**/*.stories.@(js|jsx|ts|tsx|svelte)"],
+  stories: [
+    "../src/lib/**/*.stories.@(js|jsx|ts|tsx|svelte)",
+    "../src/routes/**/*.stories.@(js|jsx|ts|tsx|svelte)",
+  ],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,11 +8,26 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "strict": true,
+    "strict": false,
     "moduleResolution": "bundler"
-  }
+  },
   // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias and https://kit.svelte.dev/docs/configuration#files
   //
   // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
   // from the referenced tsconfig.json - TypeScript does not merge them in
+  "include": [
+    ".svelte-kit/**",
+    "vite.config.js",
+    "vite.config.ts",
+    "src/lib/**/*.js",
+    "src/lib/**/*.ts",
+    "src/lib/**/*.svelte",
+    "src/routes/**/*.js",
+    "src/routes/**/*.ts",
+    "src/routes/**/*.svelte",
+    "tests/**/*.js",
+    "tests/**/*.ts",
+    "tests/**/*.svelte"
+  ],
+  "exclude": ["node_modules/**", "public/**"]
 }

--- a/src/lib/api/fixtures/mock.ts
+++ b/src/lib/api/fixtures/mock.ts
@@ -1,6 +1,6 @@
 import { rest } from "msw";
 
-import meFixture from "../fixtures/users/me.json";
+import { me as meFixture } from "@/test/fixtures/accounts";
 import projectFixture from "../fixtures/projects/project.json";
 import projDocsPage1 from "../fixtures/projects/project-documents-expanded.json";
 import projDocsPage2 from "../fixtures/projects/project-documents-2.json";

--- a/src/routes/stories/project-embed.stories.svelte
+++ b/src/routes/stories/project-embed.stories.svelte
@@ -8,7 +8,7 @@
 
   import documents from "$lib/api/fixtures/projects/project-documents-expanded.json";
   import project from "$lib/api/fixtures/projects/project.json";
-  import * as mock from "$lib/api/fixtures/mock.js";
+  import * as mock from "$lib/api/fixtures/mock";
 
   export const meta = {
     title: "Embed / Project",

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,16 +37,21 @@ export default defineConfig({
 
   test: {
     setupFiles: ["./vitest-setup.js"],
-    include: ["src/**/*.{test,spec}.{js,ts}"],
+    include: [
+      "src/lib/**/*.{test,spec}.{js,ts}",
+      "src/routes/**/*.{test,spec}.{js,ts}",
+    ],
     exclude: [
       ...configDefaults.exclude,
       "storybook-static",
+      "node_modules",
       "./src/config/*",
       "../src/**/*.stories.@(js|jsx|ts|tsx|svelte)",
     ],
     environment: "jsdom",
     coverage: {
-      reporter: ["text", "html", "clover", "json"],
+      include: ["src/lib/**", "src/routes/**"],
+      reporter: ["text", "html", "lcov", "clover", "json", "json-summary"],
     },
   },
 });


### PR DESCRIPTION
This improves reporting on any SvelteKit PRs by:

- Limiting Storybook to only SvelteKit directories, hopefully allowing Chromatic to successfully build and report changes.
- Limiting Vitest to only SvelteKit directories, to provide more helpful feedback on PR coverage changes.
- Limiting `check` to only check SvelteKit directories and related files, to flag any type errors during the PR process.

When I say SvelteKit directories, I mean `src/lib` and `src/routes`.

Check is currently failing since we have a number of unaddressed type and a11y issues. Those can be fixed in a follow-up task, but having the failing check will be a good reminder that they need to be fixed.