### PR TITLE
Search highlights

### DIFF
--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -438,6 +438,7 @@
     "totalMatchingPages": "{n} of {m} pages matching the query",
     "showAll": "Show all",
     "matchingPages": "{n} pages matching the query",
+    "page": "Page",
     "pageAbbrev": "p.",
     "pageCount": "{n, plural, one {# page} other {# pages}}",
     "source": "Source",

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -437,12 +437,14 @@
     "project": "Project",
     "totalMatchingPages": "{n} of {m} pages matching the query",
     "showAll": "Show all",
-    "matchingPages": "{n} pages matching the query",
+    "matchingPages": "{n, plural, one {# page} other {# pages}} matching the query",
+    "matchingNotes": "{n, plural, one {# note} other {# notes}} matching the query",
     "page": "Page",
     "pageAbbrev": "p.",
     "pageCount": "{n, plural, one {# page} other {# pages}}",
     "source": "Source",
-    "noteCount": "{n, plural, one {# note} other {# notes}}"
+    "noteCount": "{n, plural, one {# note} other {# notes}}",
+    "noteLink": "See note"
   },
   "documentThumbnail": {
     "pages": "pages",

--- a/src/lib/api/fixtures/documents/highlight.json
+++ b/src/lib/api/fixtures/documents/highlight.json
@@ -1,0 +1,32 @@
+{
+  "page_no_1": [
+    "Applicant Information\nName of Local Police Department:\n\n<em>Boston</em> Police Department\n\n30,000.00\nName of Police Chief: William B. "
+  ],
+  "page_no_2": [
+    "Non- Supplant\n\n<em>Boston</em> Police Department\n\nI hereby certify that, in accordance with DOJ Financial Guidelines, the ______________________________\n(NAME OF APPLICANT)\n\nhas been informed by the EOPSS that supplanting of JAG funds is strictly prohibited and if awarded will not\nuse grant funds to replace state and local funds that would, in the absence of such assistance, otherwise be\nmade available for this law enforcement purpose.\n"
+  ],
+  "page_no_3": [
+    "<em>Boston</em>\nName of City/Town ______________________________________________________________________\n\nMartin J. "
+  ],
+  "page_no_4": [
+    "Meanwhile, serious property crime in <em>Boston</em> tends to\nbe concentrated in our more commercial districts, including Districts D-4 (South End) and A-1\n(downtown <em>Boston</em>). "
+  ],
+  "page_no_5": [
+    "This plan will be focusing on four districts within the City of <em>Boston</em>—A-1,\nB-2, B-3 and C-11—the districts where serious violent and property crime tend to be\nconcentrated.\n"
+  ],
+  "page_no_6": [
+    "The BPD is currently preparing to launch a pilot DDACTS program in four hot-spot\nneighborhoods of <em>Boston</em>: Districts A-1 (downtown <em>Boston</em>), B-2 (Roxbury), B-3 (Mattapan), and\nDorchester (C-11). "
+  ],
+  "page_no_7": [
+    "Narrative Template, Continued\n\nTransportation Department (BTD) and Public Health Commission / EMS, <em>Boston</em> Cyclist Union,\nWalk <em>Boston</em>, Tufts Medical Center, Universities and Colleges, neighborhood and resident groups\nin the four hot spot neighborhoods of <em>Boston</em> (for DDACTS), and all neighborhoods for the overall\ncollision analysis work.\n"
+  ],
+  "page_no_9": [
+    "Budget Narrative Summary\n\nCost Category\n\nFederal Share\n\nConsultants\n\n$\n\n0.00\n\nContracts\n\n$\n\n0.00\n\nEquipment/Technology\n\n$\n\n29,029.60\n\nOther\n\n$\n\n931.85\n\nTotal\n\n$\n\n29,961.45\n\nLocal Police Department:\n\n<em>Boston</em> Police Department\n\n9\n\n "
+  ],
+  "page_no_13": [
+    "City of <em>Boston</em> applies an administration fee of 3.21% on all grant funds.\n$29,029.60 * 3.21% = $931.85\n\nApplicants must also complete a Budget Excel Worksheet (refer to Attachment B) and submit with the Application Template.\n13\n\n "
+  ],
+  "page_no_14": [
+    "Proposals must be mailed or hand-delivered* to:\nThe Executive Office of Public Safety and Security\nOffice of Grants and Research\nTen Park Plaza, Suite 3720\n<em>Boston</em>, MA 02116-3933\nAttention: Kevin Stanton\n\nThe signed and completed Application Template and required documents must be received by OGR on\nTuesday, January 6, 2015 by 4:00pm. "
+  ]
+}

--- a/src/lib/api/fixtures/documents/search-highlight.json
+++ b/src/lib/api/fixtures/documents/search-highlight.json
@@ -1,12 +1,29 @@
 {
-  "count": 316330,
-  "next": "https://api.www.documentcloud.org/api/documents/search/?q=boston&hl=true&cursor=AoMIQj4dOnHip%2FOcgwMoMjIzOTM0MDc%3D",
+  "count": 318905,
+  "next": "https://api.www.documentcloud.org/api/documents/search/?q=boston&hl=true&expand=user%2Corganization&cursor=AoMIQj5PanHip%2FOcgwMoMjIzOTM0MDc%3D",
   "previous": null,
   "results": [
     {
       "id": "2287364",
-      "user": 3379,
-      "organization": 487,
+      "user": {
+        "id": 3379,
+        "avatar_url": "",
+        "name": "Jennifer Valentino-DeVries",
+        "organization": 28481,
+        "organizations": [28481],
+        "admin_organizations": [28481],
+        "username": "JenniferValentino-DeVries_DwTWpBbP",
+        "uuid": "e421050a-7195-4fff-938a-d7353cfc989c",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 487,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "The Wall Street Journal",
+        "slug": "the-wall-street-journal",
+        "uuid": "84e563bc-6751-4702-9e30-fba52481cdcb"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston",
@@ -30,8 +47,25 @@
     },
     {
       "id": "23066715",
-      "user": 20080,
-      "organization": 125,
+      "user": {
+        "id": 20080,
+        "avatar_url": "https://cdn.muckrock.com/media/account_images/22_MuckRock_2018_PRELIMANRY_EDITS_DSC_5387_2018_Derek_Kouyoumjian_preview_SfuGGnJ.jpg",
+        "name": "Mitchell Kotler",
+        "organization": 125,
+        "organizations": [10000, 3168, 125, 41248, 10002],
+        "admin_organizations": [10000, 3168, 125, 41248, 10002],
+        "username": "mitch",
+        "uuid": "8136b9b8-95b9-4302-950d-5402e9065978",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 125,
+        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
+        "individual": false,
+        "name": "MuckRock Staff",
+        "slug": "muckrock",
+        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
+      },
       "access": "public",
       "status": "success",
       "title": "BOSTON",
@@ -89,8 +123,25 @@
     },
     {
       "id": "3513915",
-      "user": 1083,
-      "organization": 13,
+      "user": {
+        "id": 1083,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "BostonGlobe.com BG",
+        "organization": 25234,
+        "organizations": [13, 25234],
+        "admin_organizations": [13, 25234],
+        "username": "BostonGlobe.comBG",
+        "uuid": "e9f28a24-f001-44f1-8886-c35464532947",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 13,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "The Boston Globe",
+        "slug": "boston-globe",
+        "uuid": "2199ed94-7911-403e-8655-9e09fa2b57cc"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston",
@@ -110,8 +161,25 @@
     },
     {
       "id": "6243580",
-      "user": 22938,
-      "organization": 1569,
+      "user": {
+        "id": 22938,
+        "avatar_url": "",
+        "name": "Wheeler Cowperthwaite",
+        "organization": 1569,
+        "organizations": [1569, 23127],
+        "admin_organizations": [1569, 23127],
+        "username": "WheelerCowperthwaite_wOmeRVsb",
+        "uuid": "764c03ba-cfbd-4369-a485-09fe1a0ce55f",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 1569,
+        "avatar_url": "",
+        "individual": false,
+        "name": "Cape Cod Times",
+        "slug": "capecodtimes",
+        "uuid": "9c8d3c05-3de7-4d40-bfeb-0d31de2273d4"
+      },
       "access": "public",
       "status": "success",
       "title": "BOSTON",
@@ -142,8 +210,25 @@
     },
     {
       "id": "6243452",
-      "user": 22938,
-      "organization": 1569,
+      "user": {
+        "id": 22938,
+        "avatar_url": "",
+        "name": "Wheeler Cowperthwaite",
+        "organization": 1569,
+        "organizations": [1569, 23127],
+        "admin_organizations": [1569, 23127],
+        "username": "WheelerCowperthwaite_wOmeRVsb",
+        "uuid": "764c03ba-cfbd-4369-a485-09fe1a0ce55f",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 1569,
+        "avatar_url": "",
+        "individual": false,
+        "name": "Cape Cod Times",
+        "slug": "capecodtimes",
+        "uuid": "9c8d3c05-3de7-4d40-bfeb-0d31de2273d4"
+      },
       "access": "public",
       "status": "success",
       "title": "BOSTON",
@@ -174,8 +259,25 @@
     },
     {
       "id": "70328",
-      "user": 1083,
-      "organization": 13,
+      "user": {
+        "id": 1083,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "BostonGlobe.com BG",
+        "organization": 25234,
+        "organizations": [13, 25234],
+        "admin_organizations": [13, 25234],
+        "username": "BostonGlobe.comBG",
+        "uuid": "e9f28a24-f001-44f1-8886-c35464532947",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 13,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "The Boston Globe",
+        "slug": "boston-globe",
+        "uuid": "2199ed94-7911-403e-8655-9e09fa2b57cc"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston",
@@ -196,8 +298,25 @@
     },
     {
       "id": "21020996",
-      "user": 102442,
-      "organization": 32718,
+      "user": {
+        "id": 102442,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "George Joseph",
+        "organization": 32718,
+        "organizations": [32718],
+        "admin_organizations": [32718],
+        "username": "georgejosephreporting",
+        "uuid": "9253e26a-f75a-4cef-95ff-8639c363d573",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 32718,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": true,
+        "name": "georgejosephreporting",
+        "slug": "georgejosephreporting",
+        "uuid": "9253e26a-f75a-4cef-95ff-8639c363d573"
+      },
       "access": "public",
       "status": "success",
       "title": "BOSTON-e57ccc8cd255272caba251c540347f304f10438e",
@@ -225,8 +344,25 @@
     },
     {
       "id": "4229282",
-      "user": 6984,
-      "organization": 85,
+      "user": {
+        "id": 6984,
+        "avatar_url": "",
+        "name": "Jeff Ernsthausen",
+        "organization": 370,
+        "organizations": [370, 26824],
+        "admin_organizations": [26824],
+        "username": "JeffErnsthausen_OWctfCLJ",
+        "uuid": "dc9e1ef9-5e2d-473e-892f-8bab516c1933",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 85,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "Atlanta Journal-Constitution",
+        "slug": "atlanta-journal-constitution",
+        "uuid": "d080be61-c834-4c41-9792-2e827612afb6"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston,_Sherry_1_31_16_",
@@ -259,8 +395,25 @@
     },
     {
       "id": "3437950",
-      "user": 1083,
-      "organization": 13,
+      "user": {
+        "id": 1083,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "BostonGlobe.com BG",
+        "organization": 25234,
+        "organizations": [13, 25234],
+        "admin_organizations": [13, 25234],
+        "username": "BostonGlobe.comBG",
+        "uuid": "e9f28a24-f001-44f1-8886-c35464532947",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 13,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "The Boston Globe",
+        "slug": "boston-globe",
+        "uuid": "2199ed94-7911-403e-8655-9e09fa2b57cc"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston Order",
@@ -281,8 +434,25 @@
     },
     {
       "id": "1390996",
-      "user": 659,
-      "organization": 125,
+      "user": {
+        "id": 659,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "Muckrock Staff",
+        "organization": 60250,
+        "organizations": [60250, 12303],
+        "admin_organizations": [12303],
+        "username": "MuckrockStaff",
+        "uuid": "25d842d6-a24e-4dc6-8351-950824e432fc",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 125,
+        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
+        "individual": false,
+        "name": "MuckRock Staff",
+        "slug": "muckrock",
+        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
+      },
       "access": "public",
       "status": "success",
       "title": "851696 Boston",
@@ -308,8 +478,25 @@
     },
     {
       "id": "23926033",
-      "user": 20936,
-      "organization": 1088,
+      "user": {
+        "id": 20936,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "Akela Lacy",
+        "organization": 1088,
+        "organizations": [28143, 1088],
+        "admin_organizations": [28143],
+        "username": "AkelaLacy_daAuMBZe",
+        "uuid": "acfec596-0f77-4a54-8158-041596161ed2",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 1088,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "The Intercept",
+        "slug": "the-intercept",
+        "uuid": "6670f83b-7c10-4acb-89e3-44197ba295ae"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston affidavit",
@@ -337,8 +524,25 @@
     },
     {
       "id": "7033949",
-      "user": 13178,
-      "organization": 1602,
+      "user": {
+        "id": 13178,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "Eriq Gardner",
+        "organization": 20240,
+        "organizations": [20240, 1602],
+        "admin_organizations": [20240, 1602],
+        "username": "eriqgardner",
+        "uuid": "7b367166-104f-4cbd-83cc-d7eca489b055",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 1602,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "The Hollywood Reporter",
+        "slug": "thehollywoodreporter",
+        "uuid": "9f1fdad3-7dbb-4881-a5a6-f0dad3a4a8bf"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston TX",
@@ -380,8 +584,25 @@
     },
     {
       "id": "4178289",
-      "user": 659,
-      "organization": 125,
+      "user": {
+        "id": 659,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "Muckrock Staff",
+        "organization": 60250,
+        "organizations": [60250, 12303],
+        "admin_organizations": [12303],
+        "username": "MuckrockStaff",
+        "uuid": "25d842d6-a24e-4dc6-8351-950824e432fc",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 125,
+        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
+        "individual": false,
+        "name": "MuckRock Staff",
+        "slug": "muckrock",
+        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston Bid",
@@ -826,8 +1047,25 @@
     },
     {
       "id": "3913417",
-      "user": 659,
-      "organization": 125,
+      "user": {
+        "id": 659,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "Muckrock Staff",
+        "organization": 60250,
+        "organizations": [60250, 12303],
+        "admin_organizations": [12303],
+        "username": "MuckrockStaff",
+        "uuid": "25d842d6-a24e-4dc6-8351-950824e432fc",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 125,
+        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
+        "individual": false,
+        "name": "MuckRock Staff",
+        "slug": "muckrock",
+        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston PD_Redacted",
@@ -880,8 +1118,25 @@
     },
     {
       "id": "4229276",
-      "user": 6984,
-      "organization": 85,
+      "user": {
+        "id": 6984,
+        "avatar_url": "",
+        "name": "Jeff Ernsthausen",
+        "organization": 370,
+        "organizations": [370, 26824],
+        "admin_organizations": [26824],
+        "username": "JeffErnsthausen_OWctfCLJ",
+        "uuid": "dc9e1ef9-5e2d-473e-892f-8bab516c1933",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 85,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "Atlanta Journal-Constitution",
+        "slug": "atlanta-journal-constitution",
+        "uuid": "d080be61-c834-4c41-9792-2e827612afb6"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston,_Sherry_7_5_16_CCDR_CCDR_80904eb9108d4f97bbb813de06d1b37c.pdf",
@@ -935,8 +1190,25 @@
     },
     {
       "id": "3259890",
-      "user": 16677,
-      "organization": 57,
+      "user": {
+        "id": 16677,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "Reade Levinson",
+        "organization": 57,
+        "organizations": [24817, 57],
+        "admin_organizations": [24817, 57],
+        "username": "ReadeLevinson_JruvEVRW",
+        "uuid": "464329ae-a734-48c7-b813-f6c1dd6f7a80",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 57,
+        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/3VBu4_Sa_400x400.jpg",
+        "individual": false,
+        "name": "Thomson Reuters",
+        "slug": "thomson-reuters",
+        "uuid": "855d4473-f37a-4d5d-b536-f9133969006b"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston, MA",
@@ -981,8 +1253,25 @@
     },
     {
       "id": "690354",
-      "user": 4617,
-      "organization": 330,
+      "user": {
+        "id": 4617,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "Telegraph Graphics",
+        "organization": 330,
+        "organizations": [330, 19854],
+        "admin_organizations": [330, 19854],
+        "username": "TelegraphGraphics",
+        "uuid": "40871cfc-b78d-4353-bba4-000299ec6574",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 330,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "The Telegraph",
+        "slug": "telegraph",
+        "uuid": "a6f3b924-bd61-45bc-bcb9-f388300fd43f"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston Charge",
@@ -1027,8 +1316,25 @@
     },
     {
       "id": "5740788",
-      "user": 21213,
-      "organization": 2173,
+      "user": {
+        "id": 21213,
+        "avatar_url": "",
+        "name": "Maria Cela",
+        "organization": 2173,
+        "organizations": [30107, 2173],
+        "admin_organizations": [30107],
+        "username": "MariaCela",
+        "uuid": "bc9ec625-9df2-4cec-9a6e-587cb4e6210e",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 2173,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "Telemundo Station Group",
+        "slug": "telemundostationgroup",
+        "uuid": "37366958-17ec-414d-8ce1-36cb23c179d1"
+      },
       "access": "public",
       "status": "success",
       "title": "Opinión Boston",
@@ -1049,8 +1355,25 @@
     },
     {
       "id": "4229280",
-      "user": 6984,
-      "organization": 85,
+      "user": {
+        "id": 6984,
+        "avatar_url": "",
+        "name": "Jeff Ernsthausen",
+        "organization": 370,
+        "organizations": [370, 26824],
+        "admin_organizations": [26824],
+        "username": "JeffErnsthausen_OWctfCLJ",
+        "uuid": "dc9e1ef9-5e2d-473e-892f-8bab516c1933",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 85,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "Atlanta Journal-Constitution",
+        "slug": "atlanta-journal-constitution",
+        "uuid": "d080be61-c834-4c41-9792-2e827612afb6"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston,_Sherry_1_31_16_Not_Seeking_Reelection_Affidavit_Not_Seeking_Reelection_Affidavit_78c860fe1b8a4e9d9f0b725d9bfc463e.pdf",
@@ -1083,8 +1406,25 @@
     },
     {
       "id": "3728138",
-      "user": 17647,
-      "organization": 2383,
+      "user": {
+        "id": 17647,
+        "avatar_url": "",
+        "name": "Jo Herrera",
+        "organization": 2383,
+        "organizations": [13667, 2383],
+        "admin_organizations": [13667, 2383],
+        "username": "JoHerrera",
+        "uuid": "0d00a57f-29e5-468a-91ca-295ab8e9d57a",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 2383,
+        "avatar_url": "",
+        "individual": false,
+        "name": "Southwest News Media",
+        "slug": "southwestnewsmedia",
+        "uuid": "a4482f61-1f6a-4207-bb31-d68bb332aee5"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston 2015",
@@ -1121,8 +1461,25 @@
     },
     {
       "id": "353467",
-      "user": 657,
-      "organization": 124,
+      "user": {
+        "id": 657,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "Sean Lahman",
+        "organization": 124,
+        "organizations": [124, 22695],
+        "admin_organizations": [124, 22695],
+        "username": "SeanLahman_CALNYorD",
+        "uuid": "0ba39ddb-dbaa-40fa-99d0-f9ac19384d64",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 124,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "Democrat and Chronicle",
+        "slug": "dem-and-chron",
+        "uuid": "5946de32-eec3-41c7-8f71-4274a76bcb80"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston Matthew",
@@ -1142,8 +1499,25 @@
     },
     {
       "id": "236334",
-      "user": 98,
-      "organization": 206,
+      "user": {
+        "id": 98,
+        "avatar_url": "",
+        "name": "Sarah Cohen",
+        "organization": 23933,
+        "organizations": [23933],
+        "admin_organizations": [23933],
+        "username": "SarahCohen",
+        "uuid": "5a2bcbbc-c990-43e1-925f-7d804c0afb49",
+        "verified_journalist": false
+      },
+      "organization": {
+        "id": 206,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
+        "individual": false,
+        "name": "DeWitt Wallace Center for Media and Democracy",
+        "slug": "dewitt",
+        "uuid": "f7fad289-b4a9-49a2-8560-8008fd7903b2"
+      },
       "access": "public",
       "status": "success",
       "title": "20081219 Boston",
@@ -1163,8 +1537,25 @@
     },
     {
       "id": "23879788",
-      "user": 12709,
-      "organization": 1608,
+      "user": {
+        "id": 12709,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "jenifer mckim",
+        "organization": 1608,
+        "organizations": [1314, 24758, 1608],
+        "admin_organizations": [1314, 24758, 1608],
+        "username": "jmckim",
+        "uuid": "8238f184-4083-43ff-8003-786857322189",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 1608,
+        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/HzruDBHP_400x400.jpg",
+        "individual": false,
+        "name": "GBH News",
+        "slug": "wgbhnews",
+        "uuid": "4a725ef1-aa0b-4e72-ab72-dd7aa06a81a7"
+      },
       "access": "public",
       "status": "success",
       "title": "1723 Boston rules on Negroes - Boston Common",
@@ -1554,8 +1945,25 @@
     },
     {
       "id": "24164580",
-      "user": 102112,
-      "organization": 125,
+      "user": {
+        "id": 102112,
+        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        "name": "Sanjin, Open Source Fellow",
+        "organization": 125,
+        "organizations": [125, 39877, 2426, 32363],
+        "admin_organizations": [39877, 32363],
+        "username": "johnanderson22",
+        "uuid": "84859f4e-6757-47dc-8fe4-1976d31828dc",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 125,
+        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
+        "individual": false,
+        "name": "MuckRock Staff",
+        "slug": "muckrock",
+        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
+      },
       "access": "public",
       "status": "success",
       "title": "Boston Green Academy_EN",
@@ -1581,8 +1989,25 @@
     },
     {
       "id": "22393407",
-      "user": 20080,
-      "organization": 125,
+      "user": {
+        "id": 20080,
+        "avatar_url": "https://cdn.muckrock.com/media/account_images/22_MuckRock_2018_PRELIMANRY_EDITS_DSC_5387_2018_Derek_Kouyoumjian_preview_SfuGGnJ.jpg",
+        "name": "Mitchell Kotler",
+        "organization": 125,
+        "organizations": [10000, 3168, 125, 41248, 10002],
+        "admin_organizations": [10000, 3168, 125, 41248, 10002],
+        "username": "mitch",
+        "uuid": "8136b9b8-95b9-4302-950d-5402e9065978",
+        "verified_journalist": true
+      },
+      "organization": {
+        "id": 125,
+        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
+        "individual": false,
+        "name": "MuckRock Staff",
+        "slug": "muckrock",
+        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
+      },
       "access": "public",
       "status": "success",
       "title": "VISIT TO BOSTON",

--- a/src/lib/api/fixtures/documents/search-highlight.json
+++ b/src/lib/api/fixtures/documents/search-highlight.json
@@ -1,29 +1,217 @@
 {
-  "count": 318905,
-  "next": "https://api.www.documentcloud.org/api/documents/search/?q=boston&hl=true&expand=user%2Corganization&cursor=AoMIQj5PanHip%2FOcgwMoMjIzOTM0MDc%3D",
+  "count": 326697,
+  "next": "https://api.www.documentcloud.org/api/documents/search/?format=json&hl=true&q=boston&cursor=AoMIQkKnlnHToPabywInMTUxMzAwMg%3D%3D",
   "previous": null,
   "results": [
     {
+      "id": "1501881",
+      "user": 1083,
+      "organization": 13,
+      "access": "public",
+      "status": "success",
+      "title": "Mayor Walsh State of the City 2015 as Prepared",
+      "slug": "mayor-walsh-state-of-the-city-2015-as-prepared",
+      "language": "eng",
+      "created_at": "2015-01-13T20:55:46.282Z",
+      "updated_at": "2020-11-10T19:28:54.782Z",
+      "page_count": 9,
+      "original_extension": "pdf",
+      "file_hash": "6cbfbf0f05eca2c1902063a4d66d51972e19e2ac",
+      "related_article": "http://www.bostonglobe.com/metro/2015/01/13/mayor-martin-walsh-delivers-state-city-address/MEtguJ2GJu7N2fELAQviRN/story.html",
+      "edit_access": false,
+      "notes": [
+        {
+          "id": "196957",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "Firefighters killed in Back Bay fire receive top award",
+          "created_at": "2015-01-13T22:36:39.109Z",
+          "updated_at": "2020-11-10T19:29:00.833Z",
+          "content": "Boston Firefighter Michael R. Kennedy was a square-jawed, 33-year-old Marine Corps veteran who saw combat in Iraq and a first responder who rushed to treat victims of the Boston Marathon bombings. He spent days off roaring down the road on his motorcycle and pushing himself and others to the limits as a Crossfit trainer.\n\nFire Lieutenant Edward J. Walsh Jr. had tried a career in finance, but his passion was for firefighting. Nine and a half years ago, Walsh became a Boston firefighter, following in the footsteps of his late father, a lieutenant in the Watertown Fire Department.\n\n[<a href=\"Fire%20Lieutenant%20Edward%20J.%20Walsh%20Jr.%20had%20tried%20a%20career%20in%20finance,%20but%20his%20passion%20was%20for%20firefighting.%20Nine%20and%20a%20half%20years%20ago,%20Walsh%20became%20a%20Boston%20firefighter,%20following%20in%20the%20footsteps%20of%20his%20late%20father,%20a%20lieutenant%20in%20the%20Watertown%20Fire%20Department.\">Story</a>]",
+          "page_number": 0
+        },
+        {
+          "id": "196979",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "Paris terror attacks January 2015",
+          "created_at": "2015-01-13T23:31:14.434Z",
+          "updated_at": "2020-11-10T19:29:00.834Z",
+          "content": "<a href=\"http://www.bostonglobe.com/news/bigpicture/2015/01/07/paris-attack/uBmT4MiTPlmjL0fPyrSDEJ/story.html\">The Big Picture: Paris attack</a>\n",
+          "page_number": 0
+        },
+        {
+          "id": "197010",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "Boston police officer dies after medical emergency",
+          "created_at": "2015-01-14T00:55:03.392Z",
+          "updated_at": "2020-11-10T19:29:00.833Z",
+          "content": "Boston police officer dies after medical emergency. [<a href=\"http://www.bostonglobe.com/metro/2014/04/11/boston-police-officer-dies-after-medical-emergency/4Cg93lvhdmzcwTy0SPicKJ/story.html\">Story</a>]\n",
+          "page_number": 0
+        },
+        {
+          "id": "197011",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "Dawnn Jaffier’s life of service recalled by mourners",
+          "created_at": "2015-01-14T00:55:37.666Z",
+          "updated_at": "2020-11-10T19:29:00.836Z",
+          "content": "Dawnn Jaffier’s life of service recalled by mourners. [<a href=\"http://www.bostonglobe.com/2014/08/30/hundreds-gather-mourn-dawnn-jaffier/wlAbF5oZKb3swYgB9NvUKN/story.html\">Story</a>]\n",
+          "page_number": 0
+        },
+        {
+          "id": "197013",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "State and national economies poised for growth",
+          "created_at": "2015-01-14T00:57:45.167Z",
+          "updated_at": "2020-11-10T19:29:00.837Z",
+          "content": "State and national economies poised for growth. [<a href=\"http://www.bostonglobe.com/business/2014/01/30/state-economy-expands-strong-pace/86gXzvEr5Y8FSMJ6QRI1DL/story.html\">Story</a>]",
+          "page_number": 1
+        },
+        {
+          "id": "197012",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "Tom Menino's life",
+          "created_at": "2015-01-14T00:56:22.875Z",
+          "updated_at": "2020-11-10T19:29:00.833Z",
+          "content": "A look back at Tom Menino's tenure as Mayor of Boston. [<a href=\"http://www.bostonglobe.com/metro/specials/menino\">Story</a>]",
+          "page_number": 1
+        },
+        {
+          "id": "197014",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "Mayor Walsh visited Ireland this year",
+          "created_at": "2015-01-14T00:59:36.348Z",
+          "updated_at": "2020-11-10T19:29:00.835Z",
+          "content": "An emotional Mayor Martin J. Walsh of Boston landed before dawn Friday on Irish soil and paid homage to Shannon Airport, the point of departure to Boston for scores of immigrants, including his parents, and the setting of a poignant speech by President John F. Kennedy. [<a href=\"http://www.bostonglobe.com/metro/2014/09/19/walsh-lands-ireland-evoking-jfk/Hmos5Fv7EDFDnGAgbe33BO/story.html\">Story</a>]",
+          "page_number": 1
+        },
+        {
+          "id": "197031",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "City tests new weapons in fight against potholes",
+          "created_at": "2015-01-14T01:14:09.405Z",
+          "updated_at": "2020-11-10T19:29:00.835Z",
+          "content": "In the latest round of Boston versus potholes, the city is bringing in the big guns: a Silly Putty-like material encased in portable plastic bags invented by college students. Shape-shifting goo that hardens instantly under pressure. [<a href=\"http://www.bostonglobe.com/metro/2013/03/21/potholes/jUvJ1uT03j5tCGIlSvCsPL/story.html\">Story</a>]",
+          "page_number": 2
+        },
+        {
+          "id": "197034",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "Skyline blooms as Boston OK’s over $1.5b in projects",
+          "created_at": "2015-01-14T01:15:30.784Z",
+          "updated_at": "2020-11-10T19:29:00.836Z",
+          "content": "City regulators this week approved more than $1.5 billion in new construction projects, including a $500 million expansion of New Balance’s headquarters in Brighton, as well as large residential and retail developments in Downtown Crossing, the Fenway, and the South End. [<a href=\"http://www.bostonglobe.com/business/2012/09/14/boston-approves-billion-development-projects-boston-new-construction/ALjAbgqvSN0slA8KHN3gVP/story.html\">Story</a>]",
+          "page_number": 2
+        },
+        {
+          "id": "197023",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "Boston EMS workers OK pay raise",
+          "created_at": "2015-01-14T01:06:36.632Z",
+          "updated_at": "2020-11-10T19:29:00.837Z",
+          "content": "Workers in Boston’s Emergency Medical Services will receive a pay raise of nearly 15 percent over six years under a newly settled contract with Mayor Martin J. Walsh. [<a href=\"http://www.bostonglobe.com/metro/2014/08/29/boston-ems-union-approves-new-contract/01DPyGIoB4DOLmpOjajW5L/story.html\">Story</a>]",
+          "page_number": 2
+        }
+      ],
+      "highlights": {
+        "page_no_1": [
+          "To all the people of <em>Boston</em> and our region, present tonight or watching at home: good evening.\n"
+        ],
+        "page_no_2": [
+          "As <em>Boston</em>\napproaches its 400th birthday, our goal is a thriving, healthy, and innovative city for all; one\ncommunity that is a global leader for the 21st century. "
+        ],
+        "page_no_3": [
+          "We created\nthe most diverse command staff in the <em>Boston</em> Police Department's history. "
+        ],
+        "page_no_4": [
+          "<em>Boston</em> now competes\nagainst the world, as America’s city. Whatever the outcome, <em>Boston</em> will prove itself a global\nleader. "
+        ],
+        "page_no_5": [
+          "We tripled the size of\nthe Success <em>Boston</em> college completion program. "
+        ],
+        "page_no_6": [
+          "Page 6 of 9\n\n+++\n<em>Boston</em> is a city of revolutionary innovation. But in <em>Boston</em> we know that a revolution only\nsucceeds when it galvanizes the whole community. "
+        ],
+        "page_no_7": [
+          "Demand for housing in <em>Boston</em> is at a historic high:\nputting prices and rents out of reach for too many. "
+        ],
+        "page_no_8": [
+          "For that, I\ncommend the officers of the <em>Boston</em> Police Department ... and those who protested. "
+        ],
+        "page_no_9": [
+          "Finally, I think about the <em>Boston</em> firefighters I saw at Beacon Street on March 26. "
+        ]
+      },
+      "data": {},
+      "asset_url": "https://s3.documentcloud.org/",
+      "canonical_url": "https://www.documentcloud.org/documents/1501881-mayor-walsh-state-of-the-city-2015-as-prepared",
+      "note_highlights": {
+        "197010": {
+          "title": [
+            "<em>Boston</em> police officer dies after medical emergency"
+          ],
+          "description": [
+            "<em>Boston</em> police officer dies after medical emergency. [<a href=\"http://www.bostonglobe.com/metro/2014"
+          ]
+        },
+        "197034": {
+          "title": [
+            "Skyline blooms as <em>Boston</em> OK’s over $1.5b in projects"
+          ],
+          "description": [
+            "://www.bostonglobe.com/business/2012/09/14/<em>boston</em>-approves-billion-development-projects-<em>boston</em>-new-construction"
+          ]
+        },
+        "197023": {
+          "title": ["<em>Boston</em> EMS workers OK pay raise"],
+          "description": [
+            "://www.bostonglobe.com/metro/2014/08/29/<em>boston</em>-ems-union-approves-new-contract/01DPyGIoB4DOLmpOjajW5L/story.html\">Story</a>]"
+          ]
+        },
+        "197012": {
+          "description": [
+            "A look back at Tom Menino's tenure as Mayor of <em>Boston</em>. [<a href=\"http://www.bostonglobe.com/metro"
+          ]
+        },
+        "197014": {
+          "description": [
+            "An emotional Mayor Martin J. Walsh of <em>Boston</em> landed before dawn Friday on Irish soil and paid"
+          ]
+        },
+        "196957": {
+          "description": [
+            "<em>Boston</em> Firefighter Michael R. Kennedy was a square-jawed, 33-year-old Marine Corps veteran who saw"
+          ]
+        },
+        "197031": {
+          "description": [
+            "In the latest round of <em>Boston</em> versus potholes, the city is bringing in the big guns: a Silly Putty"
+          ]
+        }
+      }
+    },
+    {
       "id": "2287364",
-      "user": {
-        "id": 3379,
-        "avatar_url": "",
-        "name": "Jennifer Valentino-DeVries",
-        "organization": 28481,
-        "organizations": [28481],
-        "admin_organizations": [28481],
-        "username": "JenniferValentino-DeVries_DwTWpBbP",
-        "uuid": "e421050a-7195-4fff-938a-d7353cfc989c",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 487,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "The Wall Street Journal",
-        "slug": "the-wall-street-journal",
-        "uuid": "84e563bc-6751-4702-9e30-fba52481cdcb"
-      },
+      "user": 3379,
+      "organization": 487,
       "access": "public",
       "status": "success",
       "title": "Boston",
@@ -43,29 +231,13 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/2287364-boston"
+      "canonical_url": "https://www.documentcloud.org/documents/2287364-boston",
+      "note_highlights": {}
     },
     {
       "id": "23066715",
-      "user": {
-        "id": 20080,
-        "avatar_url": "https://cdn.muckrock.com/media/account_images/22_MuckRock_2018_PRELIMANRY_EDITS_DSC_5387_2018_Derek_Kouyoumjian_preview_SfuGGnJ.jpg",
-        "name": "Mitchell Kotler",
-        "organization": 125,
-        "organizations": [10000, 3168, 125, 41248, 10002],
-        "admin_organizations": [10000, 3168, 125, 41248, 10002],
-        "username": "mitch",
-        "uuid": "8136b9b8-95b9-4302-950d-5402e9065978",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 125,
-        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
-        "individual": false,
-        "name": "MuckRock Staff",
-        "slug": "muckrock",
-        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
-      },
+      "user": 20080,
+      "organization": 125,
       "access": "public",
       "status": "success",
       "title": "BOSTON",
@@ -81,7 +253,7 @@
       "description": "",
       "published_url": "",
       "related_article": "",
-      "edit_access": false,
+      "edit_access": true,
       "notes": [],
       "highlights": {},
       "data": {
@@ -119,29 +291,13 @@
         "more1_link": [""]
       },
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/23066715-boston"
+      "canonical_url": "https://www.documentcloud.org/documents/23066715-boston",
+      "note_highlights": {}
     },
     {
       "id": "3513915",
-      "user": {
-        "id": 1083,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "BostonGlobe.com BG",
-        "organization": 25234,
-        "organizations": [13, 25234],
-        "admin_organizations": [13, 25234],
-        "username": "BostonGlobe.comBG",
-        "uuid": "e9f28a24-f001-44f1-8886-c35464532947",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 13,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "The Boston Globe",
-        "slug": "boston-globe",
-        "uuid": "2199ed94-7911-403e-8655-9e09fa2b57cc"
-      },
+      "user": 1083,
+      "organization": 13,
       "access": "public",
       "status": "success",
       "title": "Boston",
@@ -157,29 +313,13 @@
       "highlights": {},
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/3513915-Boston"
+      "canonical_url": "https://www.documentcloud.org/documents/3513915-Boston",
+      "note_highlights": {}
     },
     {
       "id": "6243580",
-      "user": {
-        "id": 22938,
-        "avatar_url": "",
-        "name": "Wheeler Cowperthwaite",
-        "organization": 1569,
-        "organizations": [1569, 23127],
-        "admin_organizations": [1569, 23127],
-        "username": "WheelerCowperthwaite_wOmeRVsb",
-        "uuid": "764c03ba-cfbd-4369-a485-09fe1a0ce55f",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 1569,
-        "avatar_url": "",
-        "individual": false,
-        "name": "Cape Cod Times",
-        "slug": "capecodtimes",
-        "uuid": "9c8d3c05-3de7-4d40-bfeb-0d31de2273d4"
-      },
+      "user": 22938,
+      "organization": 1569,
       "access": "public",
       "status": "success",
       "title": "BOSTON",
@@ -206,29 +346,13 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/6243580-BOSTON"
+      "canonical_url": "https://www.documentcloud.org/documents/6243580-BOSTON",
+      "note_highlights": {}
     },
     {
       "id": "6243452",
-      "user": {
-        "id": 22938,
-        "avatar_url": "",
-        "name": "Wheeler Cowperthwaite",
-        "organization": 1569,
-        "organizations": [1569, 23127],
-        "admin_organizations": [1569, 23127],
-        "username": "WheelerCowperthwaite_wOmeRVsb",
-        "uuid": "764c03ba-cfbd-4369-a485-09fe1a0ce55f",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 1569,
-        "avatar_url": "",
-        "individual": false,
-        "name": "Cape Cod Times",
-        "slug": "capecodtimes",
-        "uuid": "9c8d3c05-3de7-4d40-bfeb-0d31de2273d4"
-      },
+      "user": 22938,
+      "organization": 1569,
       "access": "public",
       "status": "success",
       "title": "BOSTON",
@@ -255,29 +379,13 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/6243452-BOSTON"
+      "canonical_url": "https://www.documentcloud.org/documents/6243452-BOSTON",
+      "note_highlights": {}
     },
     {
       "id": "70328",
-      "user": {
-        "id": 1083,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "BostonGlobe.com BG",
-        "organization": 25234,
-        "organizations": [13, 25234],
-        "admin_organizations": [13, 25234],
-        "username": "BostonGlobe.comBG",
-        "uuid": "e9f28a24-f001-44f1-8886-c35464532947",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 13,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "The Boston Globe",
-        "slug": "boston-globe",
-        "uuid": "2199ed94-7911-403e-8655-9e09fa2b57cc"
-      },
+      "user": 1083,
+      "organization": 13,
       "access": "public",
       "status": "success",
       "title": "Boston",
@@ -294,29 +402,66 @@
       "highlights": {},
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/70328-boston"
+      "canonical_url": "https://www.documentcloud.org/documents/70328-boston",
+      "note_highlights": {}
+    },
+    {
+      "id": "3259890",
+      "user": 16677,
+      "organization": 57,
+      "access": "public",
+      "status": "success",
+      "title": "Boston, MA",
+      "slug": "Boston-MA",
+      "language": "eng",
+      "created_at": "2017-01-10T21:41:09.259Z",
+      "updated_at": "2020-11-10T17:02:40.656Z",
+      "page_count": 13,
+      "projects": [31169],
+      "original_extension": "pdf",
+      "file_hash": "589110e1ac30be1e598458ff5b7dc5e6f224acd0",
+      "edit_access": false,
+      "notes": [
+        {
+          "id": "334535",
+          "user": 16677,
+          "organization": 57,
+          "access": "public",
+          "title": "The contract is still in effect as of January 2017, according to a spokesperson from the Boston Police Patrolmen's Association.",
+          "created_at": "2017-01-12T19:40:21.486Z",
+          "updated_at": "2020-11-10T17:02:52.658Z",
+          "page_number": 0
+        }
+      ],
+      "highlights": {
+        "page_no_1": [
+          "Sep 27 13 11 :20a\n\nEstelle\n\n954-752-5581\n\nCity of <em>Boston</em> and <em>Boston</em> Police Patrolmen's Association\nJLMC No. 12-32P\n\nAWARD\n\nThe panel convened pursuant to the joint submission of the parties after a declaration that\nthe parties were unable to agree to the terms and conditions of a new collective\nbargaining agreement for the period commencing July 1, 2010.\n"
+        ],
+        "page_no_8": [
+          "This includes but is not limited to the\nfollowing events/circumstances: First Night, <em>Boston</em> Marathon, Caribbean\nFestival, July 4th, major sporting events, major cultural events, and weather\nemergencies.\nii. "
+        ],
+        "page_no_12": [
+          "CITY OF <em>BOSTON</em>\nOFFICE OF ADMINISTRATION\n\n& FINANCE\n\nCity of <em>Boston</em> and <em>Boston</em> Police Patrolmen's Association JLMC No. 12-32P\nDissent by the City of <em>Boston</em> Panel Member John Dunlap\nThis award grants a sa lary increase of 25.4% to police officers over a six-yea r period and will cost the taxpayers\nmore than $80 million- more than twice as much as the City's offer would have cost. "
+        ],
+        "page_no_13": [
+          "The group of unions which had\nvoluntarily settled with the City included the <em>Boston</em> Teachers Union (BTU)- the City's largest union. "
+        ]
+      },
+      "data": {},
+      "asset_url": "https://s3.documentcloud.org/",
+      "canonical_url": "https://www.documentcloud.org/documents/3259890-Boston-MA",
+      "note_highlights": {
+        "334535": {
+          "title": [
+            "The contract is still in effect as of January 2017, according to a spokesperson from the <em>Boston</em>"
+          ]
+        }
+      }
     },
     {
       "id": "21020996",
-      "user": {
-        "id": 102442,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "George Joseph",
-        "organization": 32718,
-        "organizations": [32718],
-        "admin_organizations": [32718],
-        "username": "georgejosephreporting",
-        "uuid": "9253e26a-f75a-4cef-95ff-8639c363d573",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 32718,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": true,
-        "name": "georgejosephreporting",
-        "slug": "georgejosephreporting",
-        "uuid": "9253e26a-f75a-4cef-95ff-8639c363d573"
-      },
+      "user": 102442,
+      "organization": 32718,
       "access": "public",
       "status": "success",
       "title": "BOSTON-e57ccc8cd255272caba251c540347f304f10438e",
@@ -340,29 +485,13 @@
         "mos_name": ["BOSTON"]
       },
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/21020996-boston-e57ccc8cd255272caba251c540347f304f10438e"
+      "canonical_url": "https://www.documentcloud.org/documents/21020996-boston-e57ccc8cd255272caba251c540347f304f10438e",
+      "note_highlights": {}
     },
     {
       "id": "4229282",
-      "user": {
-        "id": 6984,
-        "avatar_url": "",
-        "name": "Jeff Ernsthausen",
-        "organization": 370,
-        "organizations": [370, 26824],
-        "admin_organizations": [26824],
-        "username": "JeffErnsthausen_OWctfCLJ",
-        "uuid": "dc9e1ef9-5e2d-473e-892f-8bab516c1933",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 85,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "Atlanta Journal-Constitution",
-        "slug": "atlanta-journal-constitution",
-        "uuid": "d080be61-c834-4c41-9792-2e827612afb6"
-      },
+      "user": 6984,
+      "organization": 85,
       "access": "public",
       "status": "success",
       "title": "Boston,_Sherry_1_31_16_",
@@ -391,29 +520,13 @@
         "document_type": ["<$2500 Affidavit"]
       },
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/4229282-Boston-Sherry-1-31-16"
+      "canonical_url": "https://www.documentcloud.org/documents/4229282-Boston-Sherry-1-31-16",
+      "note_highlights": {}
     },
     {
       "id": "3437950",
-      "user": {
-        "id": 1083,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "BostonGlobe.com BG",
-        "organization": 25234,
-        "organizations": [13, 25234],
-        "admin_organizations": [13, 25234],
-        "username": "BostonGlobe.comBG",
-        "uuid": "e9f28a24-f001-44f1-8886-c35464532947",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 13,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "The Boston Globe",
-        "slug": "boston-globe",
-        "uuid": "2199ed94-7911-403e-8655-9e09fa2b57cc"
-      },
+      "user": 1083,
+      "organization": 13,
       "access": "public",
       "status": "success",
       "title": "Boston Order",
@@ -430,29 +543,13 @@
       "highlights": {},
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/3437950-Boston-Order"
+      "canonical_url": "https://www.documentcloud.org/documents/3437950-Boston-Order",
+      "note_highlights": {}
     },
     {
       "id": "1390996",
-      "user": {
-        "id": 659,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "Muckrock Staff",
-        "organization": 60250,
-        "organizations": [60250, 12303],
-        "admin_organizations": [12303],
-        "username": "MuckrockStaff",
-        "uuid": "25d842d6-a24e-4dc6-8351-950824e432fc",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 125,
-        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
-        "individual": false,
-        "name": "MuckRock Staff",
-        "slug": "muckrock",
-        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
-      },
+      "user": 659,
+      "organization": 125,
       "access": "public",
       "status": "success",
       "title": "851696 Boston",
@@ -465,7 +562,7 @@
       "original_extension": "pdf",
       "file_hash": "3ab71d546b463810c2cb38afafa49724e08b69fc",
       "related_article": "https://www.muckrock.com/foi/california-52/ca-doc-contractsmous-re-cai-boston-avenue-15063/",
-      "edit_access": false,
+      "edit_access": true,
       "notes": [],
       "highlights": {
         "page_no_1": [
@@ -474,29 +571,13 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/1390996-851696-boston"
+      "canonical_url": "https://www.documentcloud.org/documents/1390996-851696-boston",
+      "note_highlights": {}
     },
     {
       "id": "23926033",
-      "user": {
-        "id": 20936,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "Akela Lacy",
-        "organization": 1088,
-        "organizations": [28143, 1088],
-        "admin_organizations": [28143],
-        "username": "AkelaLacy_daAuMBZe",
-        "uuid": "acfec596-0f77-4a54-8158-041596161ed2",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 1088,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "The Intercept",
-        "slug": "the-intercept",
-        "uuid": "6670f83b-7c10-4acb-89e3-44197ba295ae"
-      },
+      "user": 20936,
+      "organization": 1088,
       "access": "public",
       "status": "success",
       "title": "Boston affidavit",
@@ -520,29 +601,13 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/23926033-boston-affidavit"
+      "canonical_url": "https://www.documentcloud.org/documents/23926033-boston-affidavit",
+      "note_highlights": {}
     },
     {
       "id": "7033949",
-      "user": {
-        "id": 13178,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "Eriq Gardner",
-        "organization": 20240,
-        "organizations": [20240, 1602],
-        "admin_organizations": [20240, 1602],
-        "username": "eriqgardner",
-        "uuid": "7b367166-104f-4cbd-83cc-d7eca489b055",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 1602,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "The Hollywood Reporter",
-        "slug": "thehollywoodreporter",
-        "uuid": "9f1fdad3-7dbb-4881-a5a6-f0dad3a4a8bf"
-      },
+      "user": 13178,
+      "organization": 1602,
       "access": "public",
       "status": "success",
       "title": "Boston TX",
@@ -580,29 +645,13 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/7033949-Boston-TX"
+      "canonical_url": "https://www.documentcloud.org/documents/7033949-Boston-TX",
+      "note_highlights": {}
     },
     {
       "id": "4178289",
-      "user": {
-        "id": 659,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "Muckrock Staff",
-        "organization": 60250,
-        "organizations": [60250, 12303],
-        "admin_organizations": [12303],
-        "username": "MuckrockStaff",
-        "uuid": "25d842d6-a24e-4dc6-8351-950824e432fc",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 125,
-        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
-        "individual": false,
-        "name": "MuckRock Staff",
-        "slug": "muckrock",
-        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
-      },
+      "user": 659,
+      "organization": 125,
       "access": "public",
       "status": "success",
       "title": "Boston Bid",
@@ -614,7 +663,7 @@
       "original_extension": "pdf",
       "file_hash": "c5f9b973237e44deb76e8bdb7e10f65328b1be6b",
       "related_article": "https://www.muckrock.com/foi/boston-3/amazon-hq2-bid-44971/",
-      "edit_access": false,
+      "edit_access": true,
       "notes": [],
       "highlights": {
         "page_no_2": [
@@ -1043,29 +1092,13 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/4178289-Boston-Bid"
+      "canonical_url": "https://www.documentcloud.org/documents/4178289-Boston-Bid",
+      "note_highlights": {}
     },
     {
       "id": "3913417",
-      "user": {
-        "id": 659,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "Muckrock Staff",
-        "organization": 60250,
-        "organizations": [60250, 12303],
-        "admin_organizations": [12303],
-        "username": "MuckrockStaff",
-        "uuid": "25d842d6-a24e-4dc6-8351-950824e432fc",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 125,
-        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
-        "individual": false,
-        "name": "MuckRock Staff",
-        "slug": "muckrock",
-        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
-      },
+      "user": 659,
+      "organization": 125,
       "access": "public",
       "status": "success",
       "title": "Boston PD_Redacted",
@@ -1078,7 +1111,7 @@
       "original_extension": "pdf",
       "file_hash": "d40f695c55ea6c381244c0ffb11f9aaeebb2379d",
       "related_article": "https://www.muckrock.com/foi/massachusetts-1/2016-byrnes-jag-pass-through-grants-38864/",
-      "edit_access": false,
+      "edit_access": true,
       "notes": [],
       "highlights": {
         "page_no_1": [
@@ -1114,29 +1147,13 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/3913417-Boston-PD-Redacted"
+      "canonical_url": "https://www.documentcloud.org/documents/3913417-Boston-PD-Redacted",
+      "note_highlights": {}
     },
     {
       "id": "4229276",
-      "user": {
-        "id": 6984,
-        "avatar_url": "",
-        "name": "Jeff Ernsthausen",
-        "organization": 370,
-        "organizations": [370, 26824],
-        "admin_organizations": [26824],
-        "username": "JeffErnsthausen_OWctfCLJ",
-        "uuid": "dc9e1ef9-5e2d-473e-892f-8bab516c1933",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 85,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "Atlanta Journal-Constitution",
-        "slug": "atlanta-journal-constitution",
-        "uuid": "d080be61-c834-4c41-9792-2e827612afb6"
-      },
+      "user": 6984,
+      "organization": 85,
       "access": "public",
       "status": "success",
       "title": "Boston,_Sherry_7_5_16_CCDR_CCDR_80904eb9108d4f97bbb813de06d1b37c.pdf",
@@ -1186,92 +1203,13 @@
         "document_type": ["CCDR"]
       },
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/4229276-Boston-Sherry-7-5-16-CCDR-CCDR"
-    },
-    {
-      "id": "3259890",
-      "user": {
-        "id": 16677,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "Reade Levinson",
-        "organization": 57,
-        "organizations": [24817, 57],
-        "admin_organizations": [24817, 57],
-        "username": "ReadeLevinson_JruvEVRW",
-        "uuid": "464329ae-a734-48c7-b813-f6c1dd6f7a80",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 57,
-        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/3VBu4_Sa_400x400.jpg",
-        "individual": false,
-        "name": "Thomson Reuters",
-        "slug": "thomson-reuters",
-        "uuid": "855d4473-f37a-4d5d-b536-f9133969006b"
-      },
-      "access": "public",
-      "status": "success",
-      "title": "Boston, MA",
-      "slug": "Boston-MA",
-      "language": "eng",
-      "created_at": "2017-01-10T21:41:09.259Z",
-      "updated_at": "2020-11-10T17:02:40.656Z",
-      "page_count": 13,
-      "projects": [31169],
-      "original_extension": "pdf",
-      "file_hash": "589110e1ac30be1e598458ff5b7dc5e6f224acd0",
-      "edit_access": false,
-      "notes": [
-        {
-          "id": "334535",
-          "user": 16677,
-          "organization": 57,
-          "access": "public",
-          "title": "The contract is still in effect as of January 2017, according to a spokesperson from the Boston Police Patrolmen's Association.",
-          "created_at": "2017-01-12T19:40:21.486Z",
-          "updated_at": "2020-11-10T17:02:52.658Z",
-          "page_number": 0
-        }
-      ],
-      "highlights": {
-        "page_no_1": [
-          "Sep 27 13 11 :20a\n\nEstelle\n\n954-752-5581\n\nCity of <em>Boston</em> and <em>Boston</em> Police Patrolmen's Association\nJLMC No. 12-32P\n\nAWARD\n\nThe panel convened pursuant to the joint submission of the parties after a declaration that\nthe parties were unable to agree to the terms and conditions of a new collective\nbargaining agreement for the period commencing July 1, 2010.\n"
-        ],
-        "page_no_8": [
-          "This includes but is not limited to the\nfollowing events/circumstances: First Night, <em>Boston</em> Marathon, Caribbean\nFestival, July 4th, major sporting events, major cultural events, and weather\nemergencies.\nii. "
-        ],
-        "page_no_12": [
-          "CITY OF <em>BOSTON</em>\nOFFICE OF ADMINISTRATION\n\n& FINANCE\n\nCity of <em>Boston</em> and <em>Boston</em> Police Patrolmen's Association JLMC No. 12-32P\nDissent by the City of <em>Boston</em> Panel Member John Dunlap\nThis award grants a sa lary increase of 25.4% to police officers over a six-yea r period and will cost the taxpayers\nmore than $80 million- more than twice as much as the City's offer would have cost. "
-        ],
-        "page_no_13": [
-          "The group of unions which had\nvoluntarily settled with the City included the <em>Boston</em> Teachers Union (BTU)- the City's largest union. "
-        ]
-      },
-      "data": {},
-      "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/3259890-Boston-MA"
+      "canonical_url": "https://www.documentcloud.org/documents/4229276-Boston-Sherry-7-5-16-CCDR-CCDR",
+      "note_highlights": {}
     },
     {
       "id": "690354",
-      "user": {
-        "id": 4617,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "Telegraph Graphics",
-        "organization": 330,
-        "organizations": [330, 19854],
-        "admin_organizations": [330, 19854],
-        "username": "TelegraphGraphics",
-        "uuid": "40871cfc-b78d-4353-bba4-000299ec6574",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 330,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "The Telegraph",
-        "slug": "telegraph",
-        "uuid": "a6f3b924-bd61-45bc-bcb9-f388300fd43f"
-      },
+      "user": 4617,
+      "organization": 330,
       "access": "public",
       "status": "success",
       "title": "Boston Charge",
@@ -1312,29 +1250,13 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/690354-boston-charge"
+      "canonical_url": "https://www.documentcloud.org/documents/690354-boston-charge",
+      "note_highlights": {}
     },
     {
       "id": "5740788",
-      "user": {
-        "id": 21213,
-        "avatar_url": "",
-        "name": "Maria Cela",
-        "organization": 2173,
-        "organizations": [30107, 2173],
-        "admin_organizations": [30107],
-        "username": "MariaCela",
-        "uuid": "bc9ec625-9df2-4cec-9a6e-587cb4e6210e",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 2173,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "Telemundo Station Group",
-        "slug": "telemundostationgroup",
-        "uuid": "37366958-17ec-414d-8ce1-36cb23c179d1"
-      },
+      "user": 21213,
+      "organization": 2173,
       "access": "public",
       "status": "success",
       "title": "Opinión Boston",
@@ -1351,29 +1273,13 @@
       "highlights": {},
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/5740788-Opinio-N-Boston"
+      "canonical_url": "https://www.documentcloud.org/documents/5740788-Opinio-N-Boston",
+      "note_highlights": {}
     },
     {
       "id": "4229280",
-      "user": {
-        "id": 6984,
-        "avatar_url": "",
-        "name": "Jeff Ernsthausen",
-        "organization": 370,
-        "organizations": [370, 26824],
-        "admin_organizations": [26824],
-        "username": "JeffErnsthausen_OWctfCLJ",
-        "uuid": "dc9e1ef9-5e2d-473e-892f-8bab516c1933",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 85,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "Atlanta Journal-Constitution",
-        "slug": "atlanta-journal-constitution",
-        "uuid": "d080be61-c834-4c41-9792-2e827612afb6"
-      },
+      "user": 6984,
+      "organization": 85,
       "access": "public",
       "status": "success",
       "title": "Boston,_Sherry_1_31_16_Not_Seeking_Reelection_Affidavit_Not_Seeking_Reelection_Affidavit_78c860fe1b8a4e9d9f0b725d9bfc463e.pdf",
@@ -1402,29 +1308,13 @@
         "document_type": ["Not Seeking Reelection Affidavit"]
       },
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/4229280-Boston-Sherry-1-31-16-Not-Seeking-Reelection"
+      "canonical_url": "https://www.documentcloud.org/documents/4229280-Boston-Sherry-1-31-16-Not-Seeking-Reelection",
+      "note_highlights": {}
     },
     {
       "id": "3728138",
-      "user": {
-        "id": 17647,
-        "avatar_url": "",
-        "name": "Jo Herrera",
-        "organization": 2383,
-        "organizations": [13667, 2383],
-        "admin_organizations": [13667, 2383],
-        "username": "JoHerrera",
-        "uuid": "0d00a57f-29e5-468a-91ca-295ab8e9d57a",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 2383,
-        "avatar_url": "",
-        "individual": false,
-        "name": "Southwest News Media",
-        "slug": "southwestnewsmedia",
-        "uuid": "a4482f61-1f6a-4207-bb31-d68bb332aee5"
-      },
+      "user": 17647,
+      "organization": 2383,
       "access": "public",
       "status": "success",
       "title": "Boston 2015",
@@ -1457,29 +1347,13 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/3728138-Boston-2015"
+      "canonical_url": "https://www.documentcloud.org/documents/3728138-Boston-2015",
+      "note_highlights": {}
     },
     {
       "id": "353467",
-      "user": {
-        "id": 657,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "Sean Lahman",
-        "organization": 124,
-        "organizations": [124, 22695],
-        "admin_organizations": [124, 22695],
-        "username": "SeanLahman_CALNYorD",
-        "uuid": "0ba39ddb-dbaa-40fa-99d0-f9ac19384d64",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 124,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "Democrat and Chronicle",
-        "slug": "dem-and-chron",
-        "uuid": "5946de32-eec3-41c7-8f71-4274a76bcb80"
-      },
+      "user": 657,
+      "organization": 124,
       "access": "public",
       "status": "success",
       "title": "Boston Matthew",
@@ -1495,29 +1369,13 @@
       "highlights": {},
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/353467-boston-matthew"
+      "canonical_url": "https://www.documentcloud.org/documents/353467-boston-matthew",
+      "note_highlights": {}
     },
     {
       "id": "236334",
-      "user": {
-        "id": 98,
-        "avatar_url": "",
-        "name": "Sarah Cohen",
-        "organization": 23933,
-        "organizations": [23933],
-        "admin_organizations": [23933],
-        "username": "SarahCohen",
-        "uuid": "5a2bcbbc-c990-43e1-925f-7d804c0afb49",
-        "verified_journalist": false
-      },
-      "organization": {
-        "id": 206,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/organization.png",
-        "individual": false,
-        "name": "DeWitt Wallace Center for Media and Democracy",
-        "slug": "dewitt",
-        "uuid": "f7fad289-b4a9-49a2-8560-8008fd7903b2"
-      },
+      "user": 98,
+      "organization": 206,
       "access": "public",
       "status": "success",
       "title": "20081219 Boston",
@@ -1533,29 +1391,13 @@
       "highlights": {},
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/236334-20081219-boston"
+      "canonical_url": "https://www.documentcloud.org/documents/236334-20081219-boston",
+      "note_highlights": {}
     },
     {
       "id": "23879788",
-      "user": {
-        "id": 12709,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "jenifer mckim",
-        "organization": 1608,
-        "organizations": [1314, 24758, 1608],
-        "admin_organizations": [1314, 24758, 1608],
-        "username": "jmckim",
-        "uuid": "8238f184-4083-43ff-8003-786857322189",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 1608,
-        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/HzruDBHP_400x400.jpg",
-        "individual": false,
-        "name": "GBH News",
-        "slug": "wgbhnews",
-        "uuid": "4a725ef1-aa0b-4e72-ab72-dd7aa06a81a7"
-      },
+      "user": 12709,
+      "organization": 1608,
       "access": "public",
       "status": "success",
       "title": "1723 Boston rules on Negroes - Boston Common",
@@ -1941,113 +1783,103 @@
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/23879788-1723-boston-rules-on-negroes-boston-common"
+      "canonical_url": "https://www.documentcloud.org/documents/23879788-1723-boston-rules-on-negroes-boston-common",
+      "note_highlights": {
+        "2362326": {
+          "title": [
+            "<em>Boston</em> rules: \"No Indian Negro or Molatto Servant or Slave...Shal abide there after Sun Sett\""
+          ]
+        }
+      }
     },
     {
-      "id": "24164580",
-      "user": {
-        "id": 102112,
-        "avatar_url": "https://cdn.muckrock.com/static/images/avatars/profile.png",
-        "name": "Sanjin, Open Source Fellow",
-        "organization": 125,
-        "organizations": [125, 39877, 2426, 32363],
-        "admin_organizations": [39877, 32363],
-        "username": "johnanderson22",
-        "uuid": "84859f4e-6757-47dc-8fe4-1976d31828dc",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 125,
-        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
-        "individual": false,
-        "name": "MuckRock Staff",
-        "slug": "muckrock",
-        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
-      },
+      "id": "1513002",
+      "user": 1083,
+      "organization": 13,
       "access": "public",
       "status": "success",
-      "title": "Boston Green Academy_EN",
-      "slug": "boston-green-academy_en",
+      "title": "Data Agreement between Uber and Boston",
+      "slug": "final-city-data-agreement-boston-uber-011215",
       "language": "eng",
-      "created_at": "2023-11-13T19:52:58.192Z",
-      "updated_at": "2023-11-13T19:53:11.214Z",
-      "page_count": 1,
-      "projects": [215836],
+      "created_at": "2015-01-29T22:39:04.497Z",
+      "updated_at": "2020-11-10T19:28:47.819Z",
+      "page_count": 7,
       "original_extension": "pdf",
-      "file_hash": "080bbaefc55170f72feb1cfb7ca26107a560ca23",
-      "noindex": false,
+      "file_hash": "216b9e697fd04e828b7f7d1f7cc0d4485c38d9a8",
       "edit_access": false,
-      "notes": [],
+      "notes": [
+        {
+          "id": "201412",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "Scope of Uber ridership",
+          "created_at": "2015-01-29T22:45:19.389Z",
+          "updated_at": "2020-11-10T19:29:00.841Z",
+          "content": "Although Uber has provided statistics about its driver base in Boston, including how much they work and earn, little is known about the level of service it provides.",
+          "page_number": 0
+        },
+        {
+          "id": "201411",
+          "user": 1083,
+          "organization": 13,
+          "access": "public",
+          "title": "Boston will notify Uber",
+          "created_at": "2015-01-29T22:43:57.436Z",
+          "updated_at": "2020-11-10T19:29:00.841Z",
+          "content": "Under the agreement, the City of Boston has to tell Uber if it receives a request for the data.",
+          "page_number": 1
+        }
+      ],
       "highlights": {
         "page_no_1": [
-          "The Energy \nAudit is to provide <em>Boston</em> Public Schools with a baseline of energy usage, for both \nrenewable and non-renewable Energy Conservation Measures to reduce carbon \nemissions. "
+          "Agreement\nBetween Uber Technologies, Inc. and the City of <em>Boston</em>\nOn the Provision obeer City Data\n\nThis Agreement is entered into this 12m day of January, 2015, between the City of <em>Boston</em>\n(hereinafter the ?"
+        ],
+        "page_no_3": [
+          "representatives to execute this Agreement on\n\nCITY OF <em>BOSTON</em>\nBy: \nprimed: Jascha Franklin-Hodge\n\nTitle; Chief Information Officer\n\nAPPROVED AS 10 FQRM\n.  \n\n.- r15\" \n\"1(9qu 1\" arr?) "
+        ],
+        "page_no_5": [
+          "Dorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDorchester\nDowntown\nDowntown\nDowntown\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nEast <em>Boston</em>\nFenway\nFenway\nFenway\nFenway\nFenway\nFenway\nFenway\nFenway\nFenway\nHarbor Islands\nHyde Park\nHyde Park\nHyde Park\nHyde Park\nHyde Park\nHyde Park\nHyde Park\n\nCensus Tract 910.01\nCensus Tract 911\nCensus Tract 912\nCensus Tract 913\nCensus Tract 914\nCensus Tract 915\nCensus Tract 916\nCensus Tract 917\nCensus Tract 918\nCensus Tract 919\nCensus Tract 920\nCensus Tract 921.01\nCensus Tract 922\nCensus Tract 923\nCensus Tract 924\nCensus Tract 303\nCensus Tract 701.01\nCensus Tract 702\nCensus Tract 501.01\nCensus Tract 502\nCensus Tract 503\nCensus Tract 504\nCensus Tract 505\nCensus Tract 506\nCensus Tract 50?\n"
+        ],
+        "page_no_7": [
+          "Roxbury\nRoxbury\nRoxbury\nRoxbury\nRoxbury\nSouth <em>Boston</em>\nSouth <em>Boston</em>\nSouth <em>Boston</em>\nSouth <em>Boston</em>\nSouth <em>Boston</em>\nSouth <em>Boston</em>\nSouth <em>Boston</em>\nSouth <em>Boston</em>\nSouth <em>Boston</em>\nSouth <em>Boston</em>\nSouth <em>Boston</em>\n\nSouth <em>Boston</em> Waterfront\nSouth <em>Boston</em> Waterfront\n\nSouth End\nSouth End\nSouth End\nSouth End\nSouth End\nSouth End\nSouth End\nSouth End\nSouth End\nWest End\nWest End\nWest Roxhury\nWest Roxbury\nWest Roxbury\nWest Roxbury\nWest Roxbury\nWest Roxbury\nWest Roxbury\n\nCensus Tract 820\nCensus Tract 8221\nCensus Tract 904\nCensus Tract 906\nCensus Tract 9803\nCensus Tract 601.01\nCensus Tract 602\nCensus Tract 603.01\nCensus Tract 604\nCensus Tract 605.01\nCensus Tract 607\nCensus Tract 608\nCensus Tract 610\nCensus Tract 611.01\nCensus Tract 612\nCensus Tract 9812.01\nCensus Tract 606\nCensus Tract 9812.02\n\nCensus Tract 703\n\nCensus Tract 704.02\nCensus Tract 705\nCensus Tract 706\nCensus Tract 707\nCensus Tract 708\nCensus Tract 709\nCensus Tract 711.01\nCensus Tract 712.01\nCensus Tract 203.01\nCensus Tract 203.03\nCensus Tract 1106.01\nCensus Tract 1301\nCensus Tract 1302\nCensus Tract 1303\nCensus Tract 1304.02\nCensus Tract 1304.04\nCensus Tract 1304.06\n\n25025082000\n25025082100\n25025090400\n25025090600\n25025980300\n25025060101\n25025060200\n25025060301\n25025060400\n25025060501\n25025060700\n25025060800\n25025061000\n25025061101\n25025061200\n25025981201\n25025060600\n25025981202\n25025070300\n25025070402\n25025070500\n25025070600\n25025070700\n25025070800\n25025070900\n25025071101\n25025071201\n25025020301\n25025020303\n25025110601\n25025130100\n25025130200\n25025130300\n25025130402\n25025130404\n25025130406\n\n"
         ]
       },
       "data": {},
       "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/24164580-boston-green-academy_en"
-    },
-    {
-      "id": "22393407",
-      "user": {
-        "id": 20080,
-        "avatar_url": "https://cdn.muckrock.com/media/account_images/22_MuckRock_2018_PRELIMANRY_EDITS_DSC_5387_2018_Derek_Kouyoumjian_preview_SfuGGnJ.jpg",
-        "name": "Mitchell Kotler",
-        "organization": 125,
-        "organizations": [10000, 3168, 125, 41248, 10002],
-        "admin_organizations": [10000, 3168, 125, 41248, 10002],
-        "username": "mitch",
-        "uuid": "8136b9b8-95b9-4302-950d-5402e9065978",
-        "verified_journalist": true
-      },
-      "organization": {
-        "id": 125,
-        "avatar_url": "https://cdn.muckrock.com/media/org_avatars/logo.png",
-        "individual": false,
-        "name": "MuckRock Staff",
-        "slug": "muckrock",
-        "uuid": "97109cc6-e52e-41e7-adb7-834ab7c6819c"
-      },
-      "access": "public",
-      "status": "success",
-      "title": "VISIT TO BOSTON",
-      "slug": "visit-to-boston",
-      "source": "CIA CREST Database",
-      "language": "eng",
-      "created_at": "2022-09-14T02:21:35.649Z",
-      "updated_at": "2022-09-14T02:21:48.015Z",
-      "page_count": 1,
-      "projects": [209284],
-      "original_extension": "pdf",
-      "file_hash": "cfcb07abd75d86f9b47a2c2080d6d0903fb88ce9",
-      "edit_access": false,
-      "notes": [],
-      "highlights": {
-        "page_no_1": [
-          "Santzed Copy Approve for Relea 2078052 CA RDPETROOSZERC0200120023-4\nhe oiecron oF\ncenteaL meiGENCe\n\n| PL, He to. 7481-63\n| [— 1 octiner 1083\n1\n\nWIE TO: Charles vatermin WT 10: charles Vatersan\n® oi wren omer on tn toner\n\nSECT © Vist to <em>boston</em> Seer: visit to toston\n\n. oistribution:\n| plan to te 10 <em>Boston</em>, October Lath ibtion:\n\nana She\" lcs best Eurpean affairs Ee\n\ntar speek 51 Shares ovens\n\nic hubing ers Putnas st Rarvard, Robert 112 Mri chore\n\nPipette riiits 1 2 dori\n\nen Mop ManR §iT\n\nnea , Via SAT\n\nind\nWith Rouner\nwomore\nIGE TE wo\nSE ———\n\f"
-        ]
-      },
-      "data": {
-        "url": [
-          "https://www.cia.gov/library/readingroom/document/cia-rdp87r00529r000200130023-4"
-        ],
-        "file": [
-          "https://www.cia.gov/library/readingroom/docs/cia-rdp87r00529r000200130023-4.pdf"
-        ],
-        "collection": ["General CIA Records"],
-        "content_type": ["MEMO"],
-        "document_type": ["CREST"],
-        "document_number": ["CIA-RDP87R00529R000200130023-4"],
-        "sequence_number": ["23"],
-        "publication_date": ["October 14, 1983"],
-        "release_decision": ["RIPPUB"],
-        "document_page_count": ["1"],
-        "document_creation_date": ["December 22, 2016"],
-        "document_publication_date": ["May 26, 2010"]
-      },
-      "asset_url": "https://s3.documentcloud.org/",
-      "canonical_url": "https://www.documentcloud.org/documents/22393407-visit-to-boston"
+      "canonical_url": "https://www.documentcloud.org/documents/1513002-final-city-data-agreement-boston-uber-011215",
+      "note_highlights": {
+        "201411": {
+          "title": ["<em>Boston</em> will notify Uber"],
+          "description": [
+            "Under the agreement, the City of <em>Boston</em> has to tell Uber if it receives a request for the data."
+          ]
+        },
+        "201412": {
+          "description": [
+            "Although Uber has provided statistics about its driver base in <em>Boston</em>, including how much they work"
+          ]
+        }
+      }
     }
   ],
-  "escaped": false
+  "escaped": false,
+  "debug": {
+    "text_query": "(boston) _query_:\"{!join from=document_s fromIndex=notes to=id score=total v='+type:note +(access:public OR user:1020) +(title:(boston) description:(boston))' }\" _query_:\" +( ( (user:1020 OR projects_edit_access:(911 212458 215823 212199 215229 215525 217646 215836 217855 216360 6909 214482 45565)) AND access:(private organization) ) OR (access:(public organization) AND organization:(19198 170 125)) ) +{!join from=document_s fromIndex=notes to=id score=total v='+type:note +(access:organization) +(title:(boston) description:(boston))'} \" ",
+    "qtime": 1864,
+    "fq": [
+      "!access:invisible",
+      "filter(access:public AND status:(success readable)) OR (user:1020) OR (access:organization AND organization:(19198 170 125)) OR (projects_edit_access:(911 212458 215823 212199 215229 215525 217646 215836 217855 216360 6909 214482 45565))"
+    ],
+    "sort": "score desc, created_at desc, id desc",
+    "hl": "on",
+    "hl.highlightMultiTerm": "true",
+    "rows": 25,
+    "cursorMark": "*",
+    "uf": "* _query_ -projects_edit_access",
+    "qq_user": 1020,
+    "notes.qq_user": 1020,
+    "qq_organizations": "19198,170,125",
+    "qq_projects": "911,212458,215823,212199,215229,215525,217646,215836,217855,216360,6909,214482,45565"
+  }
 }

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -17,7 +17,7 @@ export type Status = "success" | "readable" | "pending" | "error" | "nofile"; //
 
 export type Sizes = "thumbnail" | "small" | "normal" | "large" | "xlarge";
 
-export type Highlight = Record<string, string[]>;
+export type Highlights = Record<string, string[]>;
 
 type AddOnCategory = "premium" | string;
 
@@ -122,8 +122,8 @@ export interface Document {
   sections?: Section[];
 
   // present in search results when query includes hl=true
-  highlights?: Highlight;
-  note_highlights?: Record<string, Highlight[]>;
+  highlights?: Highlights;
+  note_highlights?: Record<string, Highlights[]>;
 }
 
 export interface DocumentResults extends Page<Document> {}

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -19,6 +19,11 @@ export type Sizes = "thumbnail" | "small" | "normal" | "large" | "xlarge";
 
 export type Highlights = Record<string, string[]>;
 
+export interface NoteHighlight {
+  title: string[];
+  description: string[];
+}
+
 type AddOnCategory = "premium" | string;
 
 interface AddOnProperty {
@@ -123,7 +128,7 @@ export interface Document {
 
   // present in search results when query includes hl=true
   highlights?: Highlights;
-  note_highlights?: Record<string, Highlights[]>;
+  note_highlights?: Record<string, NoteHighlight>;
 }
 
 export interface DocumentResults extends Page<Document> {}

--- a/src/lib/components/documents/DocumentListItem.svelte
+++ b/src/lib/components/documents/DocumentListItem.svelte
@@ -62,7 +62,7 @@ It's deliberately minimal and can be wrapped in other components to add addition
     </a>
   </div>
   <div class="info">
-    <h4>{document.title}</h4>
+    <h3>{document.title}</h3>
     <p class="meta">
       {$_("document.pageCount", { values: { n: document.page_count } })} -
       {#if userOrgString(document)}{userOrgString(document)} -
@@ -115,7 +115,7 @@ It's deliberately minimal and can be wrapped in other components to add addition
     min-width: 0;
   }
 
-  h4 {
+  h3 {
     color: var(--gray-5, #233944);
     font-size: var(--font-m, 1rem);
     font-style: normal;

--- a/src/lib/components/documents/NoteHighlights.svelte
+++ b/src/lib/components/documents/NoteHighlights.svelte
@@ -64,7 +64,16 @@
 <style>
   h4 :global(em),
   .segment :global(em) {
-    background-color: var(--yellow);
+    background-color: var(--yellow-bright);
     font-style: normal;
+  }
+
+  blockquote {
+    border-left: 0.25rem solid var(--yellow-bright);
+    padding-left: 0.5rem;
+  }
+
+  cite {
+    font-size: var(--font-s);
   }
 </style>

--- a/src/lib/components/documents/NoteHighlights.svelte
+++ b/src/lib/components/documents/NoteHighlights.svelte
@@ -1,0 +1,70 @@
+<!--
+  @component
+  Highlights from annotations matching a search query, like this:
+
+  ```json
+  "197010": {
+    "title": [
+      "<em>Boston</em> police officer dies after medical emergency"
+    ],
+    "description": [
+      "<em>Boston</em> police officer dies after medical emergency. [<a href=\"http://www.bostonglobe.com/metro/2014"
+    ]
+  }
+  ```
+
+  Note that highlights may contain broken bits of HTML. Sanitize accordingly.
+-->
+
+<script lang="ts">
+  import type { Document } from "$lib/api/types";
+
+  import DOMPurify from "isomorphic-dompurify";
+  import { _ } from "svelte-i18n";
+  import { noteUrl } from "$lib/api/notes";
+
+  export let document: Document;
+  export let open = false;
+
+  $: note_highlights = document.note_highlights;
+  $: count = Object.keys(note_highlights).length;
+  $: notes = new Map(document.notes.map((n) => [n.id, n]));
+
+  function sanitize(s: string): string {
+    return DOMPurify.sanitize(s, { ALLOWED_TAGS: ["em"] });
+  }
+</script>
+
+{#if count > 0}
+  <details bind:open>
+    <summary>{$_("document.matchingNotes", { values: { n: count } })}</summary>
+
+    {#each Object.entries(note_highlights) as [note_id, highlight]}
+      {@const note = notes.get(note_id)}
+      <blockquote>
+        {#if highlight.title}
+          <h4>{@html sanitize(highlight.title.join("\n").trim())}</h4>
+        {/if}
+
+        {#if highlight.description}
+          {#each highlight.description as segment}
+            <p class="segment">{@html sanitize(segment)}</p>
+          {/each}
+        {/if}
+        <cite>
+          <a href={noteUrl(document, note).toString()}
+            >{$_("document.noteLink")}</a
+          >
+        </cite>
+      </blockquote>
+    {/each}
+  </details>
+{/if}
+
+<style>
+  h4 :global(em),
+  .segment :global(em) {
+    background-color: var(--yellow);
+    font-style: normal;
+  }
+</style>

--- a/src/lib/components/documents/ResultsList.svelte
+++ b/src/lib/components/documents/ResultsList.svelte
@@ -88,16 +88,19 @@
 
 <div class="container">
   {#each results as document (document.id)}
-    <Flex gap={0.625} align="center">
-      <label>
-        <span class="sr-only">Select</span>
-        <input
-          type="checkbox"
-          bind:group={$selected}
-          value={String(document.id)}
-        />
-      </label>
-      <DocumentListItem {document} />
+    <Flex direction="column">
+      <Flex gap={0.625} align="center">
+        <label>
+          <span class="sr-only">Select</span>
+          <input
+            type="checkbox"
+            bind:group={$selected}
+            value={String(document.id)}
+          />
+        </label>
+        <DocumentListItem {document} />
+      </Flex>
+
       {#if document.highlights}
         <SearchHighlights {document} />
       {/if}

--- a/src/lib/components/documents/ResultsList.svelte
+++ b/src/lib/components/documents/ResultsList.svelte
@@ -14,12 +14,13 @@
 
   import { onMount } from "svelte";
   import { _ } from "svelte-i18n";
-
-  import DocumentListItem from "./DocumentListItem.svelte";
-  import Button from "../common/Button.svelte";
-  import Flex from "../common/Flex.svelte";
   import { Search24 } from "svelte-octicons";
+
+  import Button from "../common/Button.svelte";
+  import DocumentListItem from "./DocumentListItem.svelte";
   import Empty from "../common/Empty.svelte";
+  import Flex from "../common/Flex.svelte";
+  import SearchHighlights from "./SearchHighlights.svelte";
 
   export let results: Document[] = [];
   export let count: number = undefined;
@@ -96,6 +97,8 @@
         />
       </label>
       <DocumentListItem {document} />
+
+      <SearchHighlights {document} highlights={document.highlights} />
     </Flex>
   {:else}
     <Empty icon={Search24}>

--- a/src/lib/components/documents/ResultsList.svelte
+++ b/src/lib/components/documents/ResultsList.svelte
@@ -20,6 +20,7 @@
   import DocumentListItem from "./DocumentListItem.svelte";
   import Empty from "../common/Empty.svelte";
   import Flex from "../common/Flex.svelte";
+  import NoteHighlights from "./NoteHighlights.svelte";
   import SearchHighlights from "./SearchHighlights.svelte";
 
   export let results: Document[] = [];
@@ -97,8 +98,13 @@
         />
       </label>
       <DocumentListItem {document} />
+      {#if document.highlights}
+        <SearchHighlights {document} />
+      {/if}
 
-      <SearchHighlights {document} highlights={document.highlights} />
+      {#if document.note_highlights}
+        <NoteHighlights {document} />
+      {/if}
     </Flex>
   {:else}
     <Empty icon={Search24}>

--- a/src/lib/components/documents/SearchHighlight.svelte
+++ b/src/lib/components/documents/SearchHighlight.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { Highlight } from "$lib/api/types";
+
+  /*
+  {
+  "page_no_1": [
+      ". - Suite 1402 West Tower - Atlanta, GA 30334\nEffective as of\n\n01/31/2016\n\nSherry <em>Boston</em>\nP.O. "
+    ]
+  }
+  */
+  export let highlight: Highlight;
+</script>
+
+{#each Object.entries(highlight) as [page, segments]}
+  <h4>{page}</h4>
+  <blockquote class="highlight">
+    {#each segments as segment}
+      <p class="segment">{@html segment}</p>
+    {/each}
+  </blockquote>
+{/each}
+
+<style>
+  .segment :global(em) {
+    background-color: var(--yellow);
+  }
+</style>

--- a/src/lib/components/documents/SearchHighlight.svelte
+++ b/src/lib/components/documents/SearchHighlight.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { Highlight } from "$lib/api/types";
+  import type { Document, Highlight } from "$lib/api/types";
+  import { pageUrl } from "$lib/api/documents";
 
   /*
   {
@@ -9,10 +10,22 @@
   }
   */
   export let highlight: Highlight;
+  export let document: Document;
+
+  const PAGE_NO_RE = /^page_no_(\d+)$/;
+
+  function pageLink(page: string): [number, string] {
+    const match = PAGE_NO_RE.exec(page);
+    if (!match) return [NaN, ""];
+
+    const number = +match[1];
+    return [number, pageUrl(document, number).toString()];
+  }
 </script>
 
 {#each Object.entries(highlight) as [page, segments]}
-  <h4>{page}</h4>
+  {@const [number, href] = pageLink(page)}
+  <h4><a {href}>Page {number}</a></h4>
   <blockquote class="highlight">
     {#each segments as segment}
       <p class="segment">{@html segment}</p>

--- a/src/lib/components/documents/SearchHighlights.svelte
+++ b/src/lib/components/documents/SearchHighlights.svelte
@@ -12,18 +12,19 @@
 -->
 
 <script lang="ts">
-  import type { Document, Highlights } from "$lib/api/types";
+  import type { Document } from "$lib/api/types";
 
+  import DOMPurify from "isomorphic-dompurify";
   import { _ } from "svelte-i18n";
 
   import { pageUrl } from "$lib/api/documents";
 
-  export let highlights: Highlights;
   export let document: Document;
   export let open = false;
 
   const PAGE_NO_RE = /^page_no_(\d+)$/;
 
+  $: highlights = document.highlights;
   $: count = Object.keys(highlights).length;
 
   function pageLink(page: string): [number, string] {
@@ -32,6 +33,10 @@
 
     const number = +match[1];
     return [number, pageUrl(document, number).toString()];
+  }
+
+  function sanitize(s: string): string {
+    return DOMPurify.sanitize(s, { ALLOWED_TAGS: ["em"] });
   }
 </script>
 
@@ -44,7 +49,7 @@
       <h4><a {href}>{$_("document.page")} {number}</a></h4>
       <blockquote class="highlight">
         {#each segments as segment}
-          <p class="segment">{@html segment}</p>
+          <p class="segment">{@html sanitize(segment)}</p>
         {/each}
       </blockquote>
     {/each}

--- a/src/lib/components/documents/SearchHighlights.svelte
+++ b/src/lib/components/documents/SearchHighlights.svelte
@@ -1,3 +1,16 @@
+<!--
+  @component
+  Highlights from search results in document text.
+  A highlight looks like this:
+  ```json
+  {
+  "page_no_1": [
+      ". - Suite 1402 West Tower - Atlanta, GA 30334\nEffective as of\n\n01/31/2016\n\nSherry <em>Boston</em>\nP.O. "
+    ]
+  }
+  ```
+-->
+
 <script lang="ts">
   import type { Document, Highlights } from "$lib/api/types";
 
@@ -5,17 +18,13 @@
 
   import { pageUrl } from "$lib/api/documents";
 
-  /*
-  {
-  "page_no_1": [
-      ". - Suite 1402 West Tower - Atlanta, GA 30334\nEffective as of\n\n01/31/2016\n\nSherry <em>Boston</em>\nP.O. "
-    ]
-  }
-  */
   export let highlights: Highlights;
   export let document: Document;
+  export let open = false;
 
   const PAGE_NO_RE = /^page_no_(\d+)$/;
+
+  $: count = Object.keys(highlights).length;
 
   function pageLink(page: string): [number, string] {
     const match = PAGE_NO_RE.exec(page);
@@ -26,15 +35,21 @@
   }
 </script>
 
-{#each Object.entries(highlights) as [page, segments]}
-  {@const [number, href] = pageLink(page)}
-  <h4><a {href}>{$_("document.page")} {number}</a></h4>
-  <blockquote class="highlight">
-    {#each segments as segment}
-      <p class="segment">{@html segment}</p>
+{#if count}
+  <details class="highlights" bind:open>
+    <summary>{$_("document.matchingPages", { values: { n: count } })}</summary>
+
+    {#each Object.entries(highlights) as [page, segments]}
+      {@const [number, href] = pageLink(page)}
+      <h4><a {href}>{$_("document.page")} {number}</a></h4>
+      <blockquote class="highlight">
+        {#each segments as segment}
+          <p class="segment">{@html segment}</p>
+        {/each}
+      </blockquote>
     {/each}
-  </blockquote>
-{/each}
+  </details>
+{/if}
 
 <style>
   .segment :global(em) {

--- a/src/lib/components/documents/SearchHighlights.svelte
+++ b/src/lib/components/documents/SearchHighlights.svelte
@@ -58,7 +58,7 @@
 
 <style>
   .segment :global(em) {
-    background-color: var(--yellow);
+    background-color: var(--yellow-bright);
     font-style: normal;
   }
 </style>

--- a/src/lib/components/documents/SearchHighlights.svelte
+++ b/src/lib/components/documents/SearchHighlights.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import type { Document, Highlight } from "$lib/api/types";
+  import type { Document, Highlights } from "$lib/api/types";
+
+  import { _ } from "svelte-i18n";
+
   import { pageUrl } from "$lib/api/documents";
 
   /*
@@ -9,7 +12,7 @@
     ]
   }
   */
-  export let highlight: Highlight;
+  export let highlights: Highlights;
   export let document: Document;
 
   const PAGE_NO_RE = /^page_no_(\d+)$/;
@@ -23,9 +26,9 @@
   }
 </script>
 
-{#each Object.entries(highlight) as [page, segments]}
+{#each Object.entries(highlights) as [page, segments]}
   {@const [number, href] = pageLink(page)}
-  <h4><a {href}>Page {number}</a></h4>
+  <h4><a {href}>{$_("document.page")} {number}</a></h4>
   <blockquote class="highlight">
     {#each segments as segment}
       <p class="segment">{@html segment}</p>
@@ -36,5 +39,6 @@
 <style>
   .segment :global(em) {
     background-color: var(--yellow);
+    font-style: normal;
   }
 </style>

--- a/src/lib/components/documents/stories/NoteHighlights.stories.svelte
+++ b/src/lib/components/documents/stories/NoteHighlights.stories.svelte
@@ -1,0 +1,24 @@
+<script context="module" lang="ts">
+  import type { Document } from "$lib/api/types";
+  import { Story } from "@storybook/addon-svelte-csf";
+  import NoteHighlights from "../NoteHighlights.svelte";
+
+  import search from "$lib/api/fixtures/documents/search-highlight.json";
+
+  const document = search.results.find((d) => d.id === "1501881") as Document;
+
+  export const meta = {
+    title: "Components / Documents / Note Highlights",
+    component: NoteHighlights,
+    tags: ["autodocs"],
+    parameters: { layout: "centered" },
+  };
+</script>
+
+<Story name="closed">
+  <NoteHighlights {document} />
+</Story>
+
+<Story name="open">
+  <NoteHighlights {document} open />
+</Story>

--- a/src/lib/components/documents/stories/ResultsList.stories.svelte
+++ b/src/lib/components/documents/stories/ResultsList.stories.svelte
@@ -1,10 +1,11 @@
 <script context="module" lang="ts">
-  import type { Document, DocumentResults } from "@/lib/api/types";
+  import type { Document } from "@/lib/api/types";
+
   import { Story } from "@storybook/addon-svelte-csf";
   import ResultsList from "../ResultsList.svelte";
 
   // typescript complains without the type assertion
-  import searchResults from "../../../api/fixtures/documents/search-highlight.json";
+  import searchResults from "$lib/api/fixtures/documents/search-highlight.json";
   const results = searchResults.results as Document[];
   const count = searchResults.count;
   const next = searchResults.next;
@@ -27,4 +28,8 @@
 
 <Story name="Infinite">
   <div style="width: 36rem"><ResultsList {results} {count} {next} auto /></div>
+</Story>
+
+<Story name="Highlighted">
+  <div style="width: 36rem"><ResultsList {results} {count} {next} /></div>
 </Story>

--- a/src/lib/components/documents/stories/ResultsList.stories.svelte
+++ b/src/lib/components/documents/stories/ResultsList.stories.svelte
@@ -6,7 +6,12 @@
 
   // typescript complains without the type assertion
   import searchResults from "$lib/api/fixtures/documents/search-highlight.json";
-  const results = searchResults.results as Document[];
+  const highlighted = searchResults.results as Document[];
+  const results = highlighted.map((d) => ({
+    ...d,
+    highlights: null,
+    note_highlights: null,
+  }));
   const count = searchResults.count;
   const next = searchResults.next;
 
@@ -31,5 +36,7 @@
 </Story>
 
 <Story name="Highlighted">
-  <div style="width: 36rem"><ResultsList {results} {count} {next} /></div>
+  <div style="width: 36rem">
+    <ResultsList results={highlighted} {count} {next} />
+  </div>
 </Story>

--- a/src/lib/components/documents/stories/SearchHighlights.stories.svelte
+++ b/src/lib/components/documents/stories/SearchHighlights.stories.svelte
@@ -1,8 +1,14 @@
 <script context="module" lang="ts">
+  import type { Document } from "$lib/api/types";
+
   import { Story } from "@storybook/addon-svelte-csf";
   import SearchHighlight from "../SearchHighlight.svelte";
 
-  import highlight from "$lib/api/fixtures/documents/highlight.json";
+  import search from "$lib/api/fixtures/documents/search-highlight.json";
+
+  // find one document with highlights
+  const document = search.results.find((d) => d.id === "3913417") as Document;
+  const highlight = document.highlights;
 
   export const meta = {
     title: "Components / Documents / Search Highlight",
@@ -13,5 +19,5 @@
 </script>
 
 <Story name="default">
-  <SearchHighlight {highlight} />
+  <SearchHighlight {document} {highlight} />
 </Story>

--- a/src/lib/components/documents/stories/SearchHighlights.stories.svelte
+++ b/src/lib/components/documents/stories/SearchHighlights.stories.svelte
@@ -18,6 +18,10 @@
   };
 </script>
 
-<Story name="default">
+<Story name="closed">
   <SearchHighlights {document} {highlights} />
+</Story>
+
+<Story name="open">
+  <SearchHighlights {document} {highlights} open />
 </Story>

--- a/src/lib/components/documents/stories/SearchHighlights.stories.svelte
+++ b/src/lib/components/documents/stories/SearchHighlights.stories.svelte
@@ -1,0 +1,17 @@
+<script context="module" lang="ts">
+  import { Story } from "@storybook/addon-svelte-csf";
+  import SearchHighlight from "../SearchHighlight.svelte";
+
+  import highlight from "$lib/api/fixtures/documents/highlight.json";
+
+  export const meta = {
+    title: "Components / Documents / Search Highlight",
+    component: highlight,
+    tags: ["autodocs"],
+    parameters: { layout: "centered" },
+  };
+</script>
+
+<Story name="default">
+  <SearchHighlight {highlight} />
+</Story>

--- a/src/lib/components/documents/stories/SearchHighlights.stories.svelte
+++ b/src/lib/components/documents/stories/SearchHighlights.stories.svelte
@@ -2,22 +2,22 @@
   import type { Document } from "$lib/api/types";
 
   import { Story } from "@storybook/addon-svelte-csf";
-  import SearchHighlight from "../SearchHighlight.svelte";
+  import SearchHighlights from "../SearchHighlights.svelte";
 
   import search from "$lib/api/fixtures/documents/search-highlight.json";
 
   // find one document with highlights
   const document = search.results.find((d) => d.id === "3913417") as Document;
-  const highlight = document.highlights;
+  const highlights = document.highlights;
 
   export const meta = {
-    title: "Components / Documents / Search Highlight",
-    component: highlight,
+    title: "Components / Documents / Search Highlights",
+    component: highlights,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
   };
 </script>
 
 <Story name="default">
-  <SearchHighlight {document} {highlight} />
+  <SearchHighlights {document} {highlights} />
 </Story>

--- a/src/lib/components/documents/stories/SearchHighlights.stories.svelte
+++ b/src/lib/components/documents/stories/SearchHighlights.stories.svelte
@@ -12,16 +12,16 @@
 
   export const meta = {
     title: "Components / Documents / Search Highlights",
-    component: highlights,
+    component: SearchHighlights,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
   };
 </script>
 
 <Story name="closed">
-  <SearchHighlights {document} {highlights} />
+  <SearchHighlights {document} />
 </Story>
 
 <Story name="open">
-  <SearchHighlights {document} {highlights} open />
+  <SearchHighlights {document} open />
 </Story>

--- a/src/lib/components/documents/tests/ResultsList.test.ts
+++ b/src/lib/components/documents/tests/ResultsList.test.ts
@@ -24,7 +24,7 @@ describe("ResultsList", () => {
       next: results.next,
     });
 
-    const headings = screen.getAllByRole("heading");
+    const headings = screen.getAllByRole("heading", { level: 3 });
 
     // check that we rendered the right number of documents
     expect(headings.length).toEqual(results.results.length);

--- a/src/style/kit.css
+++ b/src/style/kit.css
@@ -144,6 +144,10 @@ dd {
   font-weight: var(--font-regular, 400);
 }
 
+summary {
+  cursor: pointer;
+}
+
 /*
 Utility classes
 */


### PR DESCRIPTION
This adds two components -- `SearchHighlights.svelte` and `NoteHighlights.svelte` -- that wrap respective highlights in a `details/summary` block for collapsing.

This very much needs a style pass.
