### PR TITLE
Basic tag and KV rendering

### DIFF
--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -822,7 +822,6 @@
     "modifyDesc": "Rearrange, rotate, delete, insert, and split pages.",
     "info": "Edit Document Info",
     "infoDesc": "Modify document information like description and related URL.",
-    "data": "Edit Tags and Data",
     "dataDesc": "Add tags and key/value pairs to categorize your document.",
     "sections": "Edit Sections",
     "sectionsDesc": "Add sections to organize your document with a table of contents.",
@@ -837,6 +836,12 @@
     "addons": {
       "title": "Add-Ons",
       "pinned": "Pinned add-ons will appear here"
+    },
+    "data": {
+      "title": "Data & Tags",
+      "empty": "Use tags or key/value data to organize documents",
+      "tags": "Tags",
+      "data": "Data"
     },
     "projects": {
       "title": "Projects",

--- a/src/lib/components/common/KV.svelte
+++ b/src/lib/components/common/KV.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
-  export let key: string;
+  export let key: string = "";
   export let value: string;
   export let href: string = null;
+  export let inline: boolean = false;
   export let tag: boolean = false;
 </script>
 
-<div class="kv">
+<div class="kv" class:inline>
   {#if !tag}
     <span class="key">{key}</span>
   {/if}
@@ -29,6 +30,10 @@
     border-radius: 0.25rem;
     border: 1px solid var(--blue-2, #b5ceed);
     background: var(--blue-1, #eef3f9);
+  }
+
+  .kv.inline {
+    display: inline-flex;
   }
 
   .key,

--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -38,5 +38,5 @@ export function tag(t: string): string {
  * @returns formatted query
  */
 export function kv(key: string, value: string): string {
-  return `+data__${key}:"${value}"`;
+  return `+data_${key}:"${value}"`;
 }

--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -1,16 +1,16 @@
 import type { User } from "@/api/types";
 import type { Access } from "../api/types";
-import { APP_URL } from "@/config/config";
+import { APP_URL } from "@/config/config.js";
 import { slugify } from "@/util/string.js";
 
 export function searchUrl(query: string): URL {
-  const href = new URL("app", APP_URL);
+  const href = new URL("app/", APP_URL);
   href.searchParams.set("q", query);
   return href;
 }
 
 export function projectSearchUrl(project): string {
-  return searchUrl(`+project:${project.id} `).toString();
+  return searchUrl(`+project:${project.id} `).href;
 }
 
 /**
@@ -20,4 +20,23 @@ export function projectSearchUrl(project): string {
  */
 export function userDocs(user: User, access: Access): string {
   return `+user:${slugify(user.name)}-${user.id} access:${access}`;
+}
+
+/**
+ * Tag search query
+ * @param t tag
+ * @returns formatted query
+ */
+export function tag(t: string): string {
+  return `+tag:"${t}"`;
+}
+
+/**
+ * Data search query
+ * @param key
+ * @param value
+ * @returns formatted query
+ */
+export function kv(key: string, value: string): string {
+  return `+data__${key}:"${value}"`;
 }

--- a/src/lib/utils/tests/search.test.ts
+++ b/src/lib/utils/tests/search.test.ts
@@ -30,7 +30,7 @@ describe("search utilities", () => {
 
   test("kv", () => {
     expect(kv("parties", "David Cameron")).toStrictEqual(
-      `+data__parties:"David Cameron"`,
+      `+data_parties:"David Cameron"`,
     );
   });
 });

--- a/src/lib/utils/tests/search.test.ts
+++ b/src/lib/utils/tests/search.test.ts
@@ -1,14 +1,36 @@
-import { test, expect } from "vitest";
+import { test, expect, describe } from "vitest";
+
+import { APP_URL } from "@/config/config.js";
 import { slugify } from "@/util/string";
 import { me } from "@/test/fixtures/accounts";
-import { userDocs } from "../search";
+import { userDocs, tag, kv, searchUrl } from "../search";
 
-test("userDocs", () => {
-  expect(userDocs(me, "public")).toStrictEqual(
-    `+user:${slugify(me.name)}-${me.id} access:public`,
-  );
+describe("search utilities", () => {
+  test("search URL", () => {
+    const href = new URL(`/app/`, APP_URL);
+    href.searchParams.set("q", "Nick Clegg");
+    expect(searchUrl("Nick Clegg")).toStrictEqual(href);
+  });
 
-  expect(userDocs(me, "private")).toStrictEqual(
-    `+user:${slugify(me.name)}-${me.id} access:private`,
-  );
+  test("userDocs", () => {
+    expect(userDocs(me, "public")).toStrictEqual(
+      `+user:${slugify(me.name)}-${me.id} access:public`,
+    );
+
+    expect(userDocs(me, "private")).toStrictEqual(
+      `+user:${slugify(me.name)}-${me.id} access:private`,
+    );
+  });
+
+  test("tags", () => {
+    expect(tag("research")).toStrictEqual(`+tag:"research"`);
+
+    expect(tag("PBS NewsHour")).toStrictEqual(`+tag:"PBS NewsHour"`);
+  });
+
+  test("kv", () => {
+    expect(kv("parties", "David Cameron")).toStrictEqual(
+      `+data__parties:"David Cameron"`,
+    );
+  });
 });

--- a/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
@@ -37,7 +37,7 @@
         <h4>{$_("sidebar.data.tags")}</h4>
       </SidebarItem>
 
-      <Flex>
+      <Flex wrap>
         {#each tags as tag}
           <KV tag value={tag} />
         {/each}
@@ -50,7 +50,7 @@
       <SidebarItem>
         <h4>{$_("sidebar.data.data")}</h4>
       </SidebarItem>
-      <Flex direction="row">
+      <Flex wrap>
         {#each data as [key, values]}
           {#each values as value}
             <KV {key} {value} />

--- a/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
@@ -10,6 +10,8 @@
   import SidebarGroup from "$lib/components/sidebar/SidebarGroup.svelte";
   import SidebarItem from "$lib/components/sidebar/SidebarItem.svelte";
 
+  import * as search from "$lib/utils/search";
+
   export let document: Document;
 
   $: tags = document.data["_tag"];
@@ -39,7 +41,7 @@
 
       <Flex wrap>
         {#each tags as tag}
-          <KV tag value={tag} />
+          <KV tag value={tag} href={search.searchUrl(search.tag(tag)).href} />
         {/each}
       </Flex>
     </div>
@@ -53,7 +55,11 @@
       <Flex wrap>
         {#each data as [key, values]}
           {#each values as value}
-            <KV {key} {value} />
+            <KV
+              {key}
+              {value}
+              href={search.searchUrl(search.kv(key, value)).href}
+            />
           {/each}
         {/each}
       </Flex>

--- a/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import type { Document } from "$lib/api/types";
 
+  import { _ } from "svelte-i18n";
   import { Tag16, Tag24 } from "svelte-octicons";
 
-  import Empty from "@/lib/components/common/Empty.svelte";
-  import KV from "@/lib/components/common/KV.svelte";
-  import SidebarGroup from "@/lib/components/sidebar/SidebarGroup.svelte";
-  import SidebarItem from "@/lib/components/sidebar/SidebarItem.svelte";
+  import Empty from "$lib/components/common/Empty.svelte";
+  import Flex from "$lib/components/common/Flex.svelte";
+  import KV from "$lib/components/common/KV.svelte";
+  import SidebarGroup from "$lib/components/sidebar/SidebarGroup.svelte";
+  import SidebarItem from "$lib/components/sidebar/SidebarItem.svelte";
 
   export let document: Document;
 
@@ -18,13 +20,43 @@
 <SidebarGroup>
   <SidebarItem slot="title">
     <Tag16 />
-    Data & Tags
+    <h3>
+      {$_("sidebar.data.title")}
+    </h3>
   </SidebarItem>
 
   {#if empty}
     <Empty icon={Tag24}>
-      <p>Use tags or key/value data to organize documents</p>
+      <p>{$_("sidebar.data.empty")}</p>
     </Empty>
-    <!-- todo: data and tag components -->
+  {/if}
+
+  {#if tags}
+    <div class="tags">
+      <SidebarItem>
+        <h4>{$_("sidebar.data.tags")}</h4>
+      </SidebarItem>
+
+      <Flex>
+        {#each tags as tag}
+          <KV tag value={tag} />
+        {/each}
+      </Flex>
+    </div>
+  {/if}
+
+  {#if data.length}
+    <div class="data">
+      <SidebarItem>
+        <h4>{$_("sidebar.data.data")}</h4>
+      </SidebarItem>
+      <Flex direction="row">
+        {#each data as [key, values]}
+          {#each values as value}
+            <KV {key} {value} />
+          {/each}
+        {/each}
+      </Flex>
+    </div>
   {/if}
 </SidebarGroup>

--- a/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
@@ -31,26 +31,17 @@
     </Empty>
   {/if}
 
-  {#if tags}
-    <div class="tags">
-      <SidebarItem>
-        <h4>{$_("sidebar.data.tags")}</h4>
-      </SidebarItem>
-
-      <Flex wrap>
+  <Flex direction="column">
+    {#if tags}
+      <Flex wrap class="tags">
         {#each tags as tag}
           <KV tag value={tag} href={search.searchUrl(search.tag(tag)).href} />
         {/each}
       </Flex>
-    </div>
-  {/if}
+    {/if}
 
-  {#if data.length}
-    <div class="data">
-      <SidebarItem>
-        <h4>{$_("sidebar.data.data")}</h4>
-      </SidebarItem>
-      <Flex wrap>
+    {#if data.length}
+      <Flex wrap class="data">
         {#each data as [key, values]}
           {#each values as value}
             <KV
@@ -61,6 +52,6 @@
           {/each}
         {/each}
       </Flex>
-    </div>
-  {/if}
+    {/if}
+  </Flex>
 </SidebarGroup>

--- a/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
@@ -12,8 +12,8 @@
 
   export let document: Document;
 
-  $: tags = document.data["_tags"];
-  $: data = Object.entries(document.data).filter(([k, v]) => k !== "_tags");
+  $: tags = document.data["_tag"];
+  $: data = Object.entries(document.data).filter(([k, v]) => k !== "_tag");
   $: empty = Object.keys(document.data).length === 0;
 </script>
 

--- a/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
@@ -22,9 +22,7 @@
 <SidebarGroup>
   <SidebarItem slot="title">
     <Tag16 />
-    <h3>
-      {$_("sidebar.data.title")}
-    </h3>
+    {$_("sidebar.data.title")}
   </SidebarItem>
 
   {#if empty}

--- a/src/routes/documents/[id]-[slug]/sidebar/stories/Data.stories.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/stories/Data.stories.svelte
@@ -12,7 +12,7 @@
   } as Document;
 
   const tags = {
-    _tags: ["British politics", "2010", "PBS NewsHour"],
+    _tag: ["British politics", "2010", "PBS NewsHour"],
   };
 
   const kv = {

--- a/src/routes/documents/[id]-[slug]/sidebar/stories/Data.stories.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/stories/Data.stories.svelte
@@ -1,0 +1,53 @@
+<script context="module" lang="ts">
+  import type { Document } from "$lib/api/types";
+
+  import { Story } from "@storybook/addon-svelte-csf";
+  import Data from "../Data.svelte";
+
+  import doc from "$lib/api/fixtures/documents/document.json";
+
+  const document = {
+    ...doc,
+    data: {},
+  } as Document;
+
+  const tags = {
+    _tags: ["British politics", "2010", "PBS NewsHour"],
+  };
+
+  const kv = {
+    people: ["David Cameron", "Nick Clegg"],
+    parties: ["Tories", "Liberal Democrats"],
+    country: ["UK"],
+  };
+
+  const data = {
+    ...tags,
+    ...kv,
+  };
+
+  export const meta = {
+    title: "Viewer / Sidebar / Data",
+    component: Data,
+    parameters: {
+      layout: "centered",
+    },
+    tags: ["autodocs"],
+  };
+</script>
+
+<Story name="Data + Tags">
+  <Data document={{ ...document, data }} />
+</Story>
+
+<Story name="Empty">
+  <Data {document} />
+</Story>
+
+<Story name="Tags">
+  <Data document={{ ...document, data: tags }} />
+</Story>
+
+<Story name="KV Data">
+  <Data document={{ ...document, data: kv }} />
+</Story>


### PR DESCRIPTION
This uses the existing `KV.svelte` component to render both tags and data in the viewer sidebar. Read-only for now.

Very minimal implementation, but this might be enough for now.

<img width="256" alt="Screenshot 2024-05-31 at 9 18 43 AM" src="https://github.com/MuckRock/documentcloud-frontend/assets/25778/97285efd-248a-40d1-96d1-2466b2ed8c88">

Example: https://deploy-preview-554.muckcloud.com/documents/20000353-miliaraki03/