### PR TITLE
sveltekit revisions

### DIFF
--- a/src/lib/api/accounts.test.ts
+++ b/src/lib/api/accounts.test.ts
@@ -1,9 +1,9 @@
 import { vi, test, describe, it, expect, beforeEach, afterEach } from "vitest";
 
-import { BASE_API_URL } from "@/config/config";
+import { BASE_API_URL, SQUARELET_BASE } from "@/config/config";
 import * as fixtures from "@/test/fixtures/accounts";
 
-import { getMe, getOrg } from "./accounts";
+import { getMe, getOrg, getUpgradeUrl } from "./accounts";
 
 describe("getMe", async () => {
   let mockFetch;
@@ -62,4 +62,9 @@ test("getOrg", async () => {
 
 test.todo("users.get");
 test.todo("users.list");
-test.todo("getUpgradeUrl");
+
+test("getUpgradeUrl", () => {
+  expect(getUpgradeUrl()).toEqual(new URL("/users/~payment/", SQUARELET_BASE));
+  expect(getUpgradeUrl(fixtures.proOrg)).toEqual(new URL("/users/~payment/", SQUARELET_BASE));
+  expect(getUpgradeUrl(fixtures.organization)).toEqual(new URL(`/organizations/${fixtures.organization.slug}/payment/`, SQUARELET_BASE))
+});

--- a/src/lib/api/accounts.test.ts
+++ b/src/lib/api/accounts.test.ts
@@ -62,3 +62,4 @@ test("getOrg", async () => {
 
 test.todo("users.get");
 test.todo("users.list");
+test.todo("getUpgradeUrl");

--- a/src/lib/api/accounts.ts
+++ b/src/lib/api/accounts.ts
@@ -1,5 +1,5 @@
 import type { Maybe, User, Org } from "@/api/types";
-import { BASE_API_URL } from "@/config/config.js";
+import { BASE_API_URL, SQUARELET_BASE } from "@/config/config.js";
 
 type Fetch = typeof globalThis.fetch;
 
@@ -20,4 +20,13 @@ export async function getOrg(fetch: Fetch, id: number): Promise<Org> {
   const endpoint = new URL(`organizations/${id}/`, BASE_API_URL);
   const resp = await fetch(endpoint, { credentials: "include" });
   return resp.json();
+}
+
+export function getUpgradeUrl(org: Org = null): URL {
+  if (!org || org.individual) {
+    // Redirect the user to their Squarelet account settings
+    return new URL("/users/~payment/", SQUARELET_BASE);
+  }
+  // Redirect the user to the Squarelet organization settings
+  return new URL(`/organizations/${org.slug}/payment/`, SQUARELET_BASE);
 }

--- a/src/lib/api/fixtures/documents/revisions.json
+++ b/src/lib/api/fixtures/documents/revisions.json
@@ -1,0 +1,37 @@
+[
+  {
+    "version": 1,
+    "user": 1020,
+    "created_at": "2024-02-06T18:52:18.806799Z",
+    "comment": "Enable",
+    "url": "https://api.www.documentcloud.org/files/documents/24028981/revisions/0001-a20supportive20school20for20every20student20-20how20massachusetts20districts20are20bringing20social2c20emotional2c20and20behavioral20health20supports20to20schools20and20classrooms.pdf"
+  },
+  {
+    "version": 2,
+    "user": 1020,
+    "created_at": "2024-02-06T18:53:03.656526Z",
+    "comment": "Modifying",
+    "url": "https://api.www.documentcloud.org/files/documents/24028981/revisions/0002-a20supportive20school20for20every20student20-20how20massachusetts20districts20are20bringing20social2c20emotional2c20and20behavioral20health20supports20to20schools20and20classrooms.pdf"
+  },
+  {
+    "version": 3,
+    "user": 1020,
+    "created_at": "2024-05-31T01:56:06.242292Z",
+    "comment": "Redacting",
+    "url": "https://api.www.documentcloud.org/files/documents/24028981/revisions/0003-a20supportive20school20for20every20student20-20how20massachusetts20districts20are20bringing20social2c20emotional2c20and20behavioral20health20supports20to20schools20and20classrooms.pdf"
+  },
+  {
+    "version": 4,
+    "user": 1020,
+    "created_at": "2024-05-31T02:18:44.222644Z",
+    "comment": "Re-enable",
+    "url": "https://api.www.documentcloud.org/files/documents/24028981/revisions/0004-a20supportive20school20for20every20student20-20how20massachusetts20districts20are20bringing20social2c20emotional2c20and20behavioral20health20supports20to20schools20and20classrooms.pdf"
+  },
+  {
+    "version": 5,
+    "user": 1020,
+    "created_at": "2024-06-17T15:18:01.906563Z",
+    "comment": "Redacting",
+    "url": "https://api.www.documentcloud.org/files/documents/24028981/revisions/0005-a20supportive20school20for20every20student20-20how20massachusetts20districts20are20bringing20social2c20emotional2c20and20behavioral20health20supports20to20schools20and20classrooms.pdf"
+  }
+]

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -101,6 +101,15 @@ export interface DocumentUpload {
   title: string;
 }
 
+// https://www.documentcloud.org/help/api#revisions
+export interface Revision {
+  version: number;
+  user: number;
+  created_at: string;
+  comment: string;
+  url: string;
+}
+
 // https://www.documentcloud.org/help/api#documents
 export interface Document {
   id: number | string;
@@ -138,6 +147,7 @@ export interface Document {
   projects?: number[] | Project[];
   notes?: Note[];
   sections?: Section[];
+  revisions?: Revision[];
 
   // present in search results when query includes hl=true
   highlights?: Highlights;

--- a/src/lib/components/common/Card.svelte
+++ b/src/lib/components/common/Card.svelte
@@ -10,6 +10,7 @@
     flex-direction: column;
     gap: 1rem;
     max-width: 40rem;
+    margin: 0 auto;
     overflow-x: hidden;
     overflow-y: auto;
     position: relative;

--- a/src/lib/components/common/Card.svelte
+++ b/src/lib/components/common/Card.svelte
@@ -1,0 +1,21 @@
+<!-- @component Wraps its content in a presentational card -->
+
+<div class="card">
+  <slot />
+</div>
+
+<style>
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    max-width: 40rem;
+    overflow-x: hidden;
+    overflow-y: auto;
+    position: relative;
+    padding: 1.5rem;
+    border-radius: var(--font-md, 1rem);
+    background: var(--white, #fff);
+    box-shadow: 0px 4px 16px 4px #99a8b3;
+  }
+</style>

--- a/src/lib/components/common/Card.svelte
+++ b/src/lib/components/common/Card.svelte
@@ -9,6 +9,7 @@
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    width: 100%;
     max-width: 40rem;
     margin: 0 auto;
     overflow-x: hidden;
@@ -17,6 +18,6 @@
     padding: 1.5rem;
     border-radius: var(--font-md, 1rem);
     background: var(--white, #fff);
-    box-shadow: 0px 4px 16px 4px #99a8b3;
+    box-shadow: 0px 2px 4px 2px var(--shadow, rgba(30, 48, 56, 0.15));
   }
 </style>

--- a/src/lib/components/documents/Revisions.svelte
+++ b/src/lib/components/documents/Revisions.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import type { Document } from "$lib/api/types";
+
+  import { _ } from "svelte-i18n";
+  import Button from "$lib/components/common/Button.svelte";
+  import RelativeTime from "@/common/RelativeTime.svelte";
+
+  export let document: Document;
+
+  $: revisions = document.revisions || [];
+</script>
+
+<table class="revisions">
+  {#each revisions as revision}
+    <tr class="revision">
+      <td class="revision-version count">{revision.version}</td>
+      <td class="revision-details">
+        <p class="revision-comment">{revision.comment}</p>
+        <span class="revision-time"
+          ><RelativeTime date={new Date(revision.created_at)} /></span
+        >
+      </td>
+      <td class="revision-download"
+        ><Button href={revision.url}
+          >{$_("dialogRevisionsDialog.download")}</Button
+        ></td
+      >
+    </tr>
+  {:else}
+    <tr class="empty"><td>{$_("dialogRevisionsDialog.empty")}</td></tr>
+  {/each}
+</table>
+
+<style>
+  .revisions {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .revision {
+    vertical-align: baseline;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  }
+  .revision:last-child {
+    border-bottom: none;
+  }
+  .revision td {
+    padding: 0.5rem 1rem;
+  }
+  .empty td {
+    padding: 1rem;
+    text-align: center;
+  }
+  .revision-details {
+    width: auto;
+    font-size: 0.875em;
+  }
+  .revision-comment {
+    margin: 0;
+  }
+  .revision-time {
+    opacity: 0.5;
+    font-size: 0.875em;
+  }
+  .revision-version {
+    background-color: rgba(0 0 0 / 0.05);
+  }
+  .revision-download {
+    text-align: right;
+  }
+  .count {
+    font-family: monospace;
+    font-size: 0.75em;
+    text-align: right;
+    opacity: 0.5;
+    text-transform: uppercase;
+    font-weight: 600;
+  }
+</style>

--- a/src/lib/components/documents/Revisions.svelte
+++ b/src/lib/components/documents/Revisions.svelte
@@ -2,6 +2,7 @@
   import type { Document } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
+
   import Button from "$lib/components/common/Button.svelte";
   import RelativeTime from "@/common/RelativeTime.svelte";
 
@@ -16,15 +17,15 @@
       <td class="revision-version count">{revision.version}</td>
       <td class="revision-details">
         <p class="revision-comment">{revision.comment}</p>
-        <span class="revision-time"
-          ><RelativeTime date={new Date(revision.created_at)} /></span
-        >
+        <span class="revision-time">
+          <RelativeTime date={new Date(revision.created_at)} />
+        </span>
       </td>
-      <td class="revision-download"
-        ><Button href={revision.url}
-          >{$_("dialogRevisionsDialog.download")}</Button
-        ></td
-      >
+      <td class="revision-download">
+        <Button href={revision.url}>
+          {$_("dialogRevisionsDialog.download")}
+        </Button>
+      </td>
     </tr>
   {:else}
     <tr class="empty"><td>{$_("dialogRevisionsDialog.empty")}</td></tr>

--- a/src/lib/components/documents/Revisions.svelte
+++ b/src/lib/components/documents/Revisions.svelte
@@ -5,6 +5,8 @@
 
   import Button from "$lib/components/common/Button.svelte";
   import RelativeTime from "@/common/RelativeTime.svelte";
+  import { Download16, History24 } from "svelte-octicons";
+  import Empty from "../common/Empty.svelte";
 
   export let document: Document;
 
@@ -22,13 +24,18 @@
         </span>
       </td>
       <td class="revision-download">
-        <Button href={revision.url}>
+        <Button mode="ghost" href={revision.url}>
+          <Download16 />
           {$_("dialogRevisionsDialog.download")}
         </Button>
       </td>
     </tr>
   {:else}
-    <tr class="empty"><td>{$_("dialogRevisionsDialog.empty")}</td></tr>
+    <tr class="empty"><td>
+      <Empty icon={History24}>
+        {$_("dialogRevisionsDialog.empty")}
+      </Empty>
+    </td></tr>
   {/each}
 </table>
 

--- a/src/lib/components/documents/Revisions.svelte
+++ b/src/lib/components/documents/Revisions.svelte
@@ -74,6 +74,12 @@
   .revision-version {
     background-color: rgba(0 0 0 / 0.05);
   }
+  .revision:first-child .revision-version {
+    border-top-right-radius: .5rem;
+  }
+  .revision:last-child .revision-version {
+    border-bottom-right-radius: .5rem;
+  }
   .revision-download {
     text-align: right;
   }

--- a/src/lib/components/documents/Revisions.svelte
+++ b/src/lib/components/documents/Revisions.svelte
@@ -43,6 +43,7 @@
   .revisions {
     width: 100%;
     border-collapse: collapse;
+    border-radius: var(--font-md, 1rem);
   }
   .revision {
     vertical-align: baseline;

--- a/src/lib/components/documents/Revisions.svelte
+++ b/src/lib/components/documents/Revisions.svelte
@@ -43,7 +43,8 @@
   .revisions {
     width: 100%;
     border-collapse: collapse;
-    border-radius: var(--font-md, 1rem);
+    border-radius: .5rem;
+    overflow: hidden;
   }
   .revision {
     vertical-align: baseline;

--- a/src/lib/components/documents/stories/Revisions.stories.svelte
+++ b/src/lib/components/documents/stories/Revisions.stories.svelte
@@ -1,0 +1,25 @@
+<script context="module" lang="ts">
+  import type { Document } from "$lib/api/types";
+  import { Story } from "@storybook/addon-svelte-csf";
+  import Revisions from "../Revisions.svelte";
+
+  export const meta = {
+    title: "Components / Documents / Revisions",
+    component: Revisions,
+    parameters: { layout: "padded" },
+  };
+
+  import revisions from "$lib/api/fixtures/documents/revisions.json";
+  import doc from "$lib/api/fixtures/documents/document-expanded.json";
+
+  const empty = doc as Document;
+  const document = { ...doc, revisions } as Document;
+</script>
+
+<Story name="default">
+  <Revisions {document} />
+</Story>
+
+<Story name="no revisions">
+  <Revisions document={empty} />
+</Story>

--- a/src/lib/components/documents/stories/Revisions.stories.svelte
+++ b/src/lib/components/documents/stories/Revisions.stories.svelte
@@ -16,10 +16,10 @@
   const document = { ...doc, revisions } as Document;
 </script>
 
-<Story name="default">
+<Story name="With Revisions">
   <Revisions {document} />
 </Story>
 
-<Story name="no revisions">
+<Story name="Empty">
   <Revisions document={empty} />
 </Story>

--- a/src/lib/components/forms/RevisionControl.svelte
+++ b/src/lib/components/forms/RevisionControl.svelte
@@ -32,7 +32,7 @@
 </script>
 
 <form {action} method="post" use:enhance={onSubmit} bind:this={formRef}>
-  <Flex gap={1} align="center">
+  <Flex gap={1} align="center" justify="between">
     <Field inline title={$_("dialogRevisionsDialog.controlLabel")}>
       <Switch name="revision_control" checked={document.revision_control} on:change={() => formRef.submit()} {disabled} />
     </Field>

--- a/src/lib/components/forms/RevisionControl.svelte
+++ b/src/lib/components/forms/RevisionControl.svelte
@@ -1,0 +1,9 @@
+<!-- @component
+Enable or disable revisions for a document,
+or get an upgrade prompt.
+-->
+<script lang="ts">
+  import type { Document } from "$lib/api/types";
+
+  export let document: Document;
+</script>

--- a/src/lib/components/forms/RevisionControl.svelte
+++ b/src/lib/components/forms/RevisionControl.svelte
@@ -14,6 +14,7 @@
   import { canonicalUrl } from "$lib/api/documents";
 
   export let document: Document;
+  export let disabled = false;
 
   let formRef: HTMLFormElement;
 
@@ -31,12 +32,12 @@
 </script>
 
 <form {action} method="post" use:enhance={onSubmit} bind:this={formRef}>
-  <Flex direction="column" gap={1} align="end">
+  <Flex gap={1} align="center">
     <Field inline title={$_("dialogRevisionsDialog.controlLabel")}>
-      <Switch name="revision_control" checked={document.revision_control} on:change={() => formRef.submit()} />
+      <Switch name="revision_control" checked={document.revision_control} on:change={() => formRef.submit()} {disabled} />
     </Field>
     <Flex class="buttons">
-      <Button size="small" type="submit" mode="primary">{$_("dialog.save")}</Button>
+      <Button size="small" type="submit" mode="primary" {disabled}>{$_("dialog.save")}</Button>
     </Flex>
   </Flex>
 </form>

--- a/src/lib/components/forms/RevisionControl.svelte
+++ b/src/lib/components/forms/RevisionControl.svelte
@@ -6,6 +6,8 @@ or get an upgrade prompt.
   import type { Document } from "$lib/api/types";
   import type { User, Org } from "@/api/types/orgAndUser";
 
+  import { enhance } from "$app/forms";
+  import { invalidate } from "$app/navigation";
   import { _ } from "svelte-i18n";
 
   import Button from "../common/Button.svelte";
@@ -20,14 +22,24 @@ or get an upgrade prompt.
   export let document: Document;
   export let user: User = null; // using a prop for testability
 
-  $: action = canonicalUrl(document).href + "?/revisions";
+  $: action = canonicalUrl(document).href + "?/edit";
   $: organization =
     typeof user?.organization === "object" ? (user.organization as Org) : null;
   $: plan = organization?.plan ?? "Free";
+
+  function onSubmit({ formData }) {
+    const enabled = formData.get("revision_control") === "on";
+    formData.set("revision_control", enabled);
+
+    return ({ result, update }) => {
+      invalidate(`document:${document.id}`);
+      update(result);
+    };
+  }
 </script>
 
 {#if plan !== "Free"}
-  <form {action} method="post">
+  <form {action} method="post" use:enhance={onSubmit}>
     <Flex direction="column" gap={1} align="center">
       <Field title={$_("dialogRevisionsDialog.controlLabel")}>
         <Switch name="revision_control" checked={document.revision_control} />

--- a/src/lib/components/forms/RevisionControl.svelte
+++ b/src/lib/components/forms/RevisionControl.svelte
@@ -4,6 +4,46 @@ or get an upgrade prompt.
 -->
 <script lang="ts">
   import type { Document } from "$lib/api/types";
+  import type { User, Org } from "@/api/types/orgAndUser";
+
+  import { _ } from "svelte-i18n";
+
+  import Button from "../common/Button.svelte";
+  import Flex from "../common/Flex.svelte";
+  import Field from "../inputs/Field.svelte";
+  import Switch from "../inputs/Switch.svelte";
+  import UpgradePrompt from "@/premium-credits/UpgradePrompt.svelte";
+
+  import { getUpgradeUrl } from "$lib/api/accounts";
+  import { canonicalUrl } from "$lib/api/documents";
 
   export let document: Document;
+  export let user: User = null; // using a prop for testability
+
+  $: action = canonicalUrl(document).href + "?/revisions";
+  $: organization =
+    typeof user?.organization === "object" ? (user.organization as Org) : null;
+  $: plan = organization?.plan ?? "Free";
 </script>
+
+{#if plan !== "Free"}
+  <form {action} method="post">
+    <Flex direction="column" gap={1} align="center">
+      <Field title={$_("dialogRevisionsDialog.controlLabel")}>
+        <Switch name="revision_control" checked={document.revision_control} />
+      </Field>
+      <Flex class="buttons">
+        <Button type="submit" mode="primary">{$_("dialog.save")}</Button>
+        <Button type="reset">
+          {$_("dialog.cancel")}
+        </Button>
+      </Flex>
+    </Flex>
+  </form>
+{:else}
+  <UpgradePrompt
+    message={$_("dialogRevisionsDialog.upgrade.message")}
+    callToAction={$_("dialogRevisionsDialog.upgrade.adminCta")}
+    href={getUpgradeUrl(organization).href}
+  />
+{/if}

--- a/src/lib/components/forms/RevisionControl.svelte
+++ b/src/lib/components/forms/RevisionControl.svelte
@@ -1,10 +1,6 @@
-<!-- @component
-Enable or disable revisions for a document,
-or get an upgrade prompt.
--->
+<!-- @component Enable or disable revisions for a document. -->
 <script lang="ts">
   import type { Document } from "$lib/api/types";
-  import type { User, Org } from "@/api/types/orgAndUser";
 
   import { enhance } from "$app/forms";
   import { invalidate } from "$app/navigation";
@@ -14,18 +10,14 @@ or get an upgrade prompt.
   import Flex from "../common/Flex.svelte";
   import Field from "../inputs/Field.svelte";
   import Switch from "../inputs/Switch.svelte";
-  import UpgradePrompt from "@/premium-credits/UpgradePrompt.svelte";
 
-  import { getUpgradeUrl } from "$lib/api/accounts";
   import { canonicalUrl } from "$lib/api/documents";
 
   export let document: Document;
-  export let user: User = null; // using a prop for testability
+
+  let formRef: HTMLFormElement;
 
   $: action = canonicalUrl(document).href + "?/edit";
-  $: organization =
-    typeof user?.organization === "object" ? (user.organization as Org) : null;
-  $: plan = organization?.plan ?? "Free";
 
   function onSubmit({ formData }) {
     const enabled = formData.get("revision_control") === "on";
@@ -38,24 +30,13 @@ or get an upgrade prompt.
   }
 </script>
 
-{#if plan !== "Free"}
-  <form {action} method="post" use:enhance={onSubmit}>
-    <Flex direction="column" gap={1} align="center">
-      <Field title={$_("dialogRevisionsDialog.controlLabel")}>
-        <Switch name="revision_control" checked={document.revision_control} />
-      </Field>
-      <Flex class="buttons">
-        <Button type="submit" mode="primary">{$_("dialog.save")}</Button>
-        <Button type="reset">
-          {$_("dialog.cancel")}
-        </Button>
-      </Flex>
+<form {action} method="post" use:enhance={onSubmit} bind:this={formRef}>
+  <Flex direction="column" gap={1} align="end">
+    <Field inline title={$_("dialogRevisionsDialog.controlLabel")}>
+      <Switch name="revision_control" checked={document.revision_control} on:change={() => formRef.submit()} />
+    </Field>
+    <Flex class="buttons">
+      <Button size="small" type="submit" mode="primary">{$_("dialog.save")}</Button>
     </Flex>
-  </form>
-{:else}
-  <UpgradePrompt
-    message={$_("dialogRevisionsDialog.upgrade.message")}
-    callToAction={$_("dialogRevisionsDialog.upgrade.adminCta")}
-    href={getUpgradeUrl(organization).href}
-  />
-{/if}
+  </Flex>
+</form>

--- a/src/lib/components/forms/stories/RevisionControl.stories.svelte
+++ b/src/lib/components/forms/stories/RevisionControl.stories.svelte
@@ -1,0 +1,26 @@
+<script context="module" lang="ts">
+  import type { Org, User } from "@/api/types";
+  import type { Document } from "$lib/api/types";
+  import { Story } from "@storybook/addon-svelte-csf";
+  import RevisionControl from "../RevisionControl.svelte";
+
+  export const meta = {
+    title: "Forms / Revision control",
+    component: RevisionControl,
+    parameters: { layout: "centered" },
+  };
+
+  import { me } from "@/test/fixtures/accounts";
+
+  import doc from "$lib/api/fixtures/documents/document-expanded.json";
+
+  const document = { ...doc, user: me } as Document;
+</script>
+
+<Story name="default">
+  <RevisionControl {document} user={me} />
+</Story>
+
+<Story name="upgrade prompt">
+  <RevisionControl {document} />
+</Story>

--- a/src/lib/components/forms/stories/RevisionControl.stories.svelte
+++ b/src/lib/components/forms/stories/RevisionControl.stories.svelte
@@ -1,6 +1,7 @@
 <script context="module" lang="ts">
   import type { Document } from "$lib/api/types";
   import { Story } from "@storybook/addon-svelte-csf";
+  import { action } from "@storybook/addon-actions";
   import RevisionControl from "../RevisionControl.svelte";
 
   export const meta = {
@@ -16,6 +17,10 @@
   const document = { ...doc, user: me } as Document;
 </script>
 
-<Story name="default">
-  <RevisionControl {document} />
+<Story name="Enabled">
+  <RevisionControl {document} on:change={() => action('change')} />
+</Story>
+
+<Story name="Disabled">
+  <RevisionControl {document} disabled />
 </Story>

--- a/src/lib/components/forms/stories/RevisionControl.stories.svelte
+++ b/src/lib/components/forms/stories/RevisionControl.stories.svelte
@@ -1,5 +1,4 @@
 <script context="module" lang="ts">
-  import type { Org, User } from "@/api/types";
   import type { Document } from "$lib/api/types";
   import { Story } from "@storybook/addon-svelte-csf";
   import RevisionControl from "../RevisionControl.svelte";
@@ -18,9 +17,5 @@
 </script>
 
 <Story name="default">
-  <RevisionControl {document} user={me} />
-</Story>
-
-<Story name="upgrade prompt">
   <RevisionControl {document} />
 </Story>

--- a/src/lib/components/inputs/Switch.svelte
+++ b/src/lib/components/inputs/Switch.svelte
@@ -16,7 +16,7 @@
     aria-checked={checked}
     on:click|preventDefault={handleClick}
   ></button>
-  <input {name} type="checkbox" bind:checked class="hidden" />
+  <input {name} type="checkbox" bind:checked class="hidden" on:change />
 </div>
 
 <style>

--- a/src/premium-credits/UpgradePrompt.svelte
+++ b/src/premium-credits/UpgradePrompt.svelte
@@ -5,6 +5,7 @@
 
   export let message: string;
   export let callToAction: string | null = null;
+  export let href: string = null;
 </script>
 
 <div class="container">
@@ -14,7 +15,7 @@
   </div>
   {#if callToAction}
     <div class="action">
-      <Button premium label={callToAction} on:click />
+      <Button premium label={callToAction} {href} on:click />
     </div>
   {/if}
 </div>

--- a/src/routes/documents/[id]-[slug]/+page.server.ts
+++ b/src/routes/documents/[id]-[slug]/+page.server.ts
@@ -33,6 +33,8 @@ export const actions = {
       return m;
     }, update);
 
+    console.log(update);
+
     try {
       const document = await edit(id, update, csrf_token, fetch);
       return {

--- a/src/routes/documents/[id]-[slug]/+page.server.ts
+++ b/src/routes/documents/[id]-[slug]/+page.server.ts
@@ -33,8 +33,6 @@ export const actions = {
       return m;
     }, update);
 
-    console.log(update);
-
     try {
       const document = await edit(id, update, csrf_token, fetch);
       return {

--- a/src/routes/documents/[id]-[slug]/revisions/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/revisions/+page.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <ContentLayout>
-  <Flex align="baseline" slot="header">
+  <Flex align="baseline" justify="center" slot="header">
     <h2>{$_("dialogRevisionsDialog.heading")}</h2>
     <PremiumBadge />
   </Flex>

--- a/src/routes/documents/[id]-[slug]/revisions/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/revisions/+page.svelte
@@ -26,9 +26,8 @@
     </Flex>
   </header>
   {#if plan !== "Free"}
-  <Revisions {document} />
-
   <RevisionControl {document} />
+  <Revisions {document} />
   {:else}
   <UpgradePrompt
     message={$_("dialogRevisionsDialog.upgrade.message")}

--- a/src/routes/documents/[id]-[slug]/revisions/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/revisions/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { _ } from "svelte-i18n";
+  import ContentLayout from "$lib/components/layouts/ContentLayout.svelte";
+  import Revisions from "$lib/components/documents/Revisions.svelte";
+  import PremiumBadge from "@/premium-credits/PremiumBadge.svelte";
+
+  export let data;
+
+  $: document = data.document;
+</script>
+
+<ContentLayout>
+  <header slot="header">
+    <h2>{$_("dialogRevisionsDialog.heading")}</h2>
+    <PremiumBadge />
+  </header>
+
+  <Revisions {document} />
+</ContentLayout>
+
+<style>
+  header {
+    display: flex;
+    gap: 1em;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+  }
+</style>

--- a/src/routes/documents/[id]-[slug]/revisions/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/revisions/+page.svelte
@@ -8,6 +8,8 @@
   import PremiumBadge from "@/premium-credits/PremiumBadge.svelte";
   import Flex from "@/lib/components/common/Flex.svelte";
   import UpgradePrompt from "@/premium-credits/UpgradePrompt.svelte";
+  import PageToolbar from "@/lib/components/common/PageToolbar.svelte";
+  import Card from "@/lib/components/common/Card.svelte";
 
   export let data;
 
@@ -19,15 +21,19 @@
 </script>
 
 <ContentLayout>
-  <header slot="header">
-    <Flex align="baseline">
+  <PageToolbar slot="header">
+    <Flex align="baseline" slot="left">
       <h2>{$_("dialogRevisionsDialog.heading")}</h2>
       <PremiumBadge />
     </Flex>
-  </header>
+    {#if plan !== "Free"}
+    <RevisionControl {document} slot="right" />
+    {/if}
+  </PageToolbar>
   {#if plan !== "Free"}
-  <RevisionControl {document} />
-  <Revisions {document} />
+  <Card>
+    <Revisions {document} />
+  </Card>
   {:else}
   <UpgradePrompt
     message={$_("dialogRevisionsDialog.upgrade.message")}
@@ -36,13 +42,3 @@
   />
   {/if}
 </ContentLayout>
-
-<style>
-  header {
-    display: flex;
-    gap: 1em;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-  }
-</style>

--- a/src/routes/documents/[id]-[slug]/revisions/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/revisions/+page.svelte
@@ -21,15 +21,14 @@
 </script>
 
 <ContentLayout>
-  <PageToolbar slot="header">
-    <Flex align="baseline" slot="left">
-      <h2>{$_("dialogRevisionsDialog.heading")}</h2>
-      <PremiumBadge />
-    </Flex>
-    <RevisionControl {document} disabled={plan == "Free"} slot="right" />
-  </PageToolbar>
+  <Flex align="baseline" slot="header">
+    <h2>{$_("dialogRevisionsDialog.heading")}</h2>
+    <PremiumBadge />
+  </Flex>
   {#if plan !== "Free"}
   <Card>
+    <RevisionControl {document} />
+    <hr class="divider" />
     <Revisions {document} />
   </Card>
   {:else}

--- a/src/routes/documents/[id]-[slug]/revisions/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/revisions/+page.svelte
@@ -2,11 +2,13 @@
   import { _ } from "svelte-i18n";
   import ContentLayout from "$lib/components/layouts/ContentLayout.svelte";
   import Revisions from "$lib/components/documents/Revisions.svelte";
+  import RevisionControl from "$lib/components/forms/RevisionControl.svelte";
   import PremiumBadge from "@/premium-credits/PremiumBadge.svelte";
 
   export let data;
 
   $: document = data.document;
+  $: user = data.me;
 </script>
 
 <ContentLayout>
@@ -16,6 +18,8 @@
   </header>
 
   <Revisions {document} />
+
+  <RevisionControl {document} {user} />
 </ContentLayout>
 
 <style>

--- a/src/routes/documents/[id]-[slug]/revisions/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/revisions/+page.svelte
@@ -26,9 +26,7 @@
       <h2>{$_("dialogRevisionsDialog.heading")}</h2>
       <PremiumBadge />
     </Flex>
-    {#if plan !== "Free"}
-    <RevisionControl {document} slot="right" />
-    {/if}
+    <RevisionControl {document} disabled={plan == "Free"} slot="right" />
   </PageToolbar>
   {#if plan !== "Free"}
   <Card>

--- a/src/routes/documents/[id]-[slug]/revisions/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/revisions/+page.svelte
@@ -1,25 +1,41 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
+  import type { Org } from "@/api/types/orgAndUser";
+  import { getUpgradeUrl } from "$lib/api/accounts";
   import ContentLayout from "$lib/components/layouts/ContentLayout.svelte";
   import Revisions from "$lib/components/documents/Revisions.svelte";
   import RevisionControl from "$lib/components/forms/RevisionControl.svelte";
   import PremiumBadge from "@/premium-credits/PremiumBadge.svelte";
+  import Flex from "@/lib/components/common/Flex.svelte";
+  import UpgradePrompt from "@/premium-credits/UpgradePrompt.svelte";
 
   export let data;
 
   $: document = data.document;
   $: user = data.me;
+  $: organization =
+    typeof user?.organization === "object" ? (user.organization as Org) : null;
+  $: plan = organization?.plan ?? "Free";
 </script>
 
 <ContentLayout>
   <header slot="header">
-    <h2>{$_("dialogRevisionsDialog.heading")}</h2>
-    <PremiumBadge />
+    <Flex align="baseline">
+      <h2>{$_("dialogRevisionsDialog.heading")}</h2>
+      <PremiumBadge />
+    </Flex>
   </header>
-
+  {#if plan !== "Free"}
   <Revisions {document} />
 
-  <RevisionControl {document} {user} />
+  <RevisionControl {document} />
+  {:else}
+  <UpgradePrompt
+    message={$_("dialogRevisionsDialog.upgrade.message")}
+    callToAction={$_("dialogRevisionsDialog.upgrade.adminCta")}
+    href={getUpgradeUrl(organization).href}
+  />
+  {/if}
 </ContentLayout>
 
 <style>

--- a/src/routes/documents/[id]-[slug]/sidebar/Actions.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Actions.svelte
@@ -77,7 +77,7 @@
     {/if}
   </SidebarItem>
 
-  {#if document.revision_control && document.edit_access}
+  {#if document.edit_access}
     <SidebarItem href={revisions}>
       <History16 />
       {$_("sidebar.revisions")}


### PR DESCRIPTION
Revision control, on its own URL route. Probably needs a little style help, but it works.

<img width="1512" alt="Screenshot 2024-06-25 at 8 15 53 PM" src="https://github.com/MuckRock/documentcloud-frontend/assets/25778/8209c3a2-79e1-4874-817c-28ec7f880303">
