### PR TITLE
Render Modals in Portals

### DIFF
--- a/src/lib/components/common/Portal.svelte
+++ b/src/lib/components/common/Portal.svelte
@@ -1,0 +1,29 @@
+<!-- lib/components/common/Portal.svelte -->
+<!-- Source: https://github.com/sveltejs/svelte/issues/3088#issuecomment-1065827485 -->
+
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+
+  export let target: HTMLElement | null | undefined = globalThis.document?.body;
+
+  let ref: HTMLElement;
+
+  onMount(() => {
+    if (target) {
+      target.appendChild(ref);
+    }
+  })
+
+  // this block is almost needless/useless (if not totally) as, on destroy, the ref will no longer exist/be in the DOM anyways
+  onDestroy(() => {
+    setTimeout(() => {
+      if (ref?.parentNode) {
+        ref.parentNode?.removeChild(ref);
+      }
+    })
+  })
+</script>
+
+<div bind:this={ref}>
+  <slot />
+</div>

--- a/src/lib/components/layouts/MainLayout.svelte
+++ b/src/lib/components/layouts/MainLayout.svelte
@@ -19,10 +19,7 @@
   import LanguageMenu from "../navigation/LanguageMenu.svelte";
   import HelpMenu from "../navigation/HelpMenu.svelte";
 
-  import Modal, { MODAL, type ModalContext } from "./Modal.svelte";
-
   const me = getContext<Writable<User>>("me");
-  const modal: ModalContext = getContext(MODAL);
   const org = getContext<Writable<Org>>("org");
 
   let panel: "navigation" | "action" | null = null;
@@ -35,10 +32,6 @@
     return () => {
       panel = name;
     };
-  }
-
-  function closeModal() {
-    $modal = null;
   }
 </script>
 
@@ -113,16 +106,6 @@
     on:click={closePanel}
     on:keydown={closePanel}
   />
-
-  {#if $modal}
-    <Modal on:close={closeModal} title={$modal?.title}>
-      <svelte:component
-        this={$modal?.component}
-        {...$modal?.props}
-        on:close={closeModal}
-      />
-    </Modal>
-  {/if}
 </div>
 
 <style>

--- a/src/lib/components/layouts/Modal.svelte
+++ b/src/lib/components/layouts/Modal.svelte
@@ -30,8 +30,6 @@ of the $modal store. These are used to set the active modal on any given page.
 
   const dispatch = createEventDispatcher();
 
-  export let title: string = null;
-
   function onKeydown(e: KeyboardEvent) {
     if (e.key === "Escape") {
       dispatch("close");
@@ -50,9 +48,7 @@ of the $modal store. These are used to set the active modal on any given page.
       <Button minW={false} mode="ghost" on:click={() => dispatch("close")}>
         <XCircle24 />
       </Button>
-      {#if title}
-        <h1>{title}</h1>
-      {/if}
+      <slot name="title" />
     </header>
     <main class="content">
       <slot />
@@ -97,11 +93,6 @@ of the $modal store. These are used to set the active modal on any given page.
     align-items: center;
     justify-content: space-between;
     flex-direction: row-reverse;
-  }
-
-  .card > header > h1 {
-    font-weight: var(--font-semibold);
-    font-size: var(--font-xl);
   }
 
   .content {

--- a/src/lib/components/layouts/Portal.svelte
+++ b/src/lib/components/layouts/Portal.svelte
@@ -1,4 +1,4 @@
-<!-- lib/components/common/Portal.svelte -->
+<!-- lib/components/layouts/Portal.svelte -->
 <!-- Source: https://github.com/sveltejs/svelte/issues/3088#issuecomment-1065827485 -->
 
 <script lang="ts">

--- a/src/lib/components/layouts/stories/MainLayout.stories.svelte
+++ b/src/lib/components/layouts/stories/MainLayout.stories.svelte
@@ -55,18 +55,11 @@
 </script>
 
 <script>
-  import { setContext } from "svelte";
   import Dialog from "./Dialog.demo.svelte";
-  import { modal } from "../Modal.svelte";
+  import Modal from "../Modal.svelte";
+  import Portal from "../../common/Portal.svelte";
 
-  setContext("modal", modal);
-
-  function openModal() {
-    $modal = {
-      title: 'Chowder.',
-      component: Dialog,
-    };
-  }
+  let modalOpen = false;
 </script>
 
 <Template let:args>
@@ -113,9 +106,17 @@
 
       <PageToolbar slot="footer">
         <svelte:fragment slot="center">
-          <Button disabled={Boolean($modal)} mode="ghost" on:click={openModal}
-            >Open modal</Button
-          >
+          <Button disabled={modalOpen} mode="ghost" on:click={() => modalOpen = true}>
+            Open modal
+          </Button>
+          {#if modalOpen}
+          <Portal>
+            <Modal on:close={() => modalOpen = false}>
+              <h1 slot="title">Chowder.</h1>
+              <Dialog />
+            </Modal>
+          </Portal>
+          {/if}
         </svelte:fragment>
       </PageToolbar>
     </ContentLayout>

--- a/src/lib/components/layouts/stories/MainLayout.stories.svelte
+++ b/src/lib/components/layouts/stories/MainLayout.stories.svelte
@@ -57,7 +57,7 @@
 <script>
   import Dialog from "./Dialog.demo.svelte";
   import Modal from "../Modal.svelte";
-  import Portal from "../../common/Portal.svelte";
+  import Portal from "../Portal.svelte";
 
   let modalOpen = false;
 </script>

--- a/src/lib/components/layouts/stories/Modal.stories.svelte
+++ b/src/lib/components/layouts/stories/Modal.stories.svelte
@@ -10,7 +10,8 @@
 </script>
 
 <Story name="With Title">
-  <Modal title="The Ship">
+  <Modal>
+    <h1 slot="title">The Ship</h1>
     <div>
       <p>
         In bed we concocted our plans for the morrow. But to my surprise and no

--- a/src/routes/documents/[id]-[slug]/+layout.svelte
+++ b/src/routes/documents/[id]-[slug]/+layout.svelte
@@ -6,11 +6,6 @@
   import { setContext } from "svelte";
 
   import MainLayout from "$lib/components/layouts/MainLayout.svelte";
-  import {
-    modal,
-    MODAL,
-    type ModalContext,
-  } from "$lib/components/layouts/Modal.svelte";
 
   // sidebars
   import DocumentMetadata from "./sidebar/DocumentMetadata.svelte";
@@ -27,7 +22,6 @@
   export let data;
 
   setContext<Document>("document", data.document);
-  setContext<ModalContext>(MODAL, modal);
 
   $: document = data.document;
   $: projects = document.projects as Project[];

--- a/src/routes/documents/[id]-[slug]/redact/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/redact/+page.svelte
@@ -24,7 +24,7 @@
   import { pageFromHash } from "$lib/api/documents";
   import { noteFromHash } from "$lib/api/notes";
   import { scrollToPage } from "$lib/utils/scroll";
-  import Portal from "@/lib/components/common/Portal.svelte";
+  import Portal from "@/lib/components/layouts/Portal.svelte";
   import Modal from "@/lib/components/layouts/Modal.svelte";
 
   export let data;

--- a/src/routes/documents/[id]-[slug]/sidebar/Actions.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Actions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Document } from "$lib/api/types";
-  import Portal from "$lib/components/common/Portal.svelte";
+  import Portal from "@/lib/components/layouts/Portal.svelte";
   import Modal from "$lib/components/layouts/Modal.svelte";
 
   import {

--- a/src/routes/documents/[id]-[slug]/sidebar/Actions.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Actions.svelte
@@ -110,7 +110,7 @@
 
   {#if document.edit_access}
     <!-- TODO: Processing component -->
-    <SidebarItem disabled={!modal || document.status === "nofile"}>
+    <SidebarItem disabled={document.status === "nofile"}>
       {#if document.status !== "success"}
         {$_("status.status")}:
         {$_(`status.${document.status}.title`)}

--- a/src/routes/documents/[id]-[slug]/sidebar/Actions.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Actions.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
   import type { Document } from "$lib/api/types";
-  import {
-    MODAL,
-    type ModalContext,
-  } from "$lib/components/layouts/Modal.svelte";
+  import Portal from "$lib/components/common/Portal.svelte";
+  import Modal from "$lib/components/layouts/Modal.svelte";
 
-  import { getContext } from "svelte";
   import {
     Alert16,
     Apps16,
@@ -33,8 +30,6 @@
 
   export let document: Document;
 
-  const modal: ModalContext = getContext(MODAL);
-
   // urls
   $: revisions = relative(document, "revisions/");
   $: pdf = pdfUrl(document).toString();
@@ -46,33 +41,9 @@
     return new URL(path, canonicalUrl(document)).href;
   }
 
-  function openEdit() {
-    if (!modal) return console.warn("modal store is not in context");
-    $modal = {
-      title: $_("edit.title"),
-      component: Edit,
-      props: { document },
-    };
-  }
-
-  function openReprocess() {
-    if (!modal) return console.warn("modal store is not in context");
-    $modal = {
-      title: $_("dialogReprocessDialog.title"),
-      component: Reprocess,
-      props: { documents: [document] },
-    };
-  }
-
-  function openDelete() {
-    if (!modal) return console.warn("modal store is not in context");
-
-    $modal = {
-      title: $_("delete.title"),
-      component: ConfirmDelete,
-      props: { documents: [document] },
-    };
-  }
+  let editOpen = false;
+  let reprocessOpen = false;
+  let deleteOpen = false;
 </script>
 
 <Flex direction="column">
@@ -83,11 +54,19 @@
     >
 
     {#if document.edit_access}
-      <Action icon={Pencil16} on:click={openEdit} disabled={!modal}
-        >{$_("sidebar.edit")}</Action
-      >
+      <Action icon={Pencil16} on:click={() => editOpen = true}>
+        {$_("sidebar.edit")}
+      </Action>
     {/if}
   </SidebarItem>
+  {#if editOpen}
+    <Portal>
+      <Modal on:close={() => editOpen = false}>
+        <h1 slot="title">{$_("edit.title")}</h1>
+        <Edit {document} on:close={() => editOpen = false} />
+      </Modal>
+    </Portal>
+  {/if}
 
   {#if document.edit_access}
     <SidebarItem href={revisions}>
@@ -136,24 +115,39 @@
         {$_("status.status")}:
         {$_(`status.${document.status}.title`)}
       {/if}
-      <Action on:click={openReprocess}>
+      <Action on:click={() => reprocessOpen = true}>
         <IssueReopened16 />
         {$_("sidebar.reprocess")}
       </Action>
+      {#if reprocessOpen}
+      <Portal>
+        <Modal on:close={() => reprocessOpen = false}>
+          <h1 slot="title">{$_("dialogReprocessDialog.title")}</h1>
+          <Reprocess documents={[document]} on:close={() => reprocessOpen = false} />
+        </Modal>
+      </Portal>
+      {/if}
     </SidebarItem>
   {/if}
 
   {#if document.edit_access}
     <SidebarItem>
       <Action
-        on:click={openDelete}
-        disabled={!modal}
-        --fill="var(--caution)"
-        --color="var(--caution)"
+        on:click={() => deleteOpen = true}
+        --fill="var(--orange-3)"
+        --color="var(--orange-3)"
       >
         <Alert16 />
         {$_("sidebar.delete")}
       </Action>
     </SidebarItem>
+    {#if deleteOpen}
+    <Portal>
+      <Modal on:close={() => deleteOpen = false}>
+        <h1 slot="title">{$_("delete.title")}</h1>
+        <ConfirmDelete documents={[document]} on:close={() => deleteOpen = false} />
+      </Modal>
+    </Portal>
+    {/if}
   {/if}
 </Flex>

--- a/src/routes/documents/[id]-[slug]/sidebar/DocumentMetadata.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/DocumentMetadata.svelte
@@ -11,7 +11,7 @@
 
   import { LANGUAGE_MAP } from "@/config/config.js";
   import { userOrgString } from "$lib/api/documents";
-  import Portal from "$lib/components/common/Portal.svelte";
+  import Portal from "@/lib/components/layouts/Portal.svelte";
   import Modal from "$lib/components/layouts/Modal.svelte";
 
   export let document: Document;

--- a/src/routes/documents/[id]-[slug]/sidebar/DocumentMetadata.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/DocumentMetadata.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
   import type { Document } from "$lib/api/types";
-  import {
-    MODAL,
-    type ModalContext,
-  } from "$lib/components/layouts/Modal.svelte";
-
-  import { getContext } from "svelte";
+  
   import { _ } from "svelte-i18n";
   import { Clock16, Pencil16 } from "svelte-octicons";
 
@@ -16,21 +11,15 @@
 
   import { LANGUAGE_MAP } from "@/config/config.js";
   import { userOrgString } from "$lib/api/documents";
+  import Portal from "$lib/components/common/Portal.svelte";
+  import Modal from "$lib/components/layouts/Modal.svelte";
 
   export let document: Document;
 
-  const modal: ModalContext = getContext(MODAL);
+  let editOpen = false;
 
   function dateFormat(date: Date | string) {
     return new Date(date).toLocaleDateString();
-  }
-
-  function openEdit() {
-    $modal = {
-      title: $_("edit.title"),
-      component: Edit,
-      props: { document },
-    };
   }
 </script>
 
@@ -51,7 +40,15 @@
       {document.title}
     </h1>
     {#if document.edit_access}
-      <Action icon={Pencil16} on:click={openEdit}>{$_("sidebar.edit")}</Action>
+      <Action icon={Pencil16} on:click={() => editOpen = true}>{$_("sidebar.edit")}</Action>
+      {#if editOpen}
+      <Portal>
+        <Modal on:close={() => editOpen = false}>
+          <h1 slot="title">{$_("edit.title")}</h1>
+          <Edit {document} on:close={() => editOpen = false}/>
+        </Modal>
+      </Portal>
+      {/if}
     {/if}
   </header>
 


### PR DESCRIPTION
This renders Modals in a new `Portal` component, following the proposal made in #578. This approach to modals does not require global context or any state management. The parent calling component needs to simply track whether it wants the modal to be displayed, or not.

To fix:
- [x] Move `Portal` from `common` to `layouts`
- [x] Cancelling the form does not close the modal