### PR TITLE
Set pinned to true by default when a new project is created

### DIFF
--- a/src/api/project.ts
+++ b/src/api/project.ts
@@ -14,6 +14,7 @@ export async function newProject(
   title: string,
   description: string,
   isPrivate: boolean,
+  pinned: boolean = true,
 ): Promise<Project> {
   const { data } = await session.post(apiUrl("projects/"), {
     title,


### PR DESCRIPTION
Resolves https://github.com/MuckRock/documentcloud/issues/229
Works locally. Just need to test a new build to test on a staging deploy