### PR TITLE
Adds donate page to help dropdown menu

### DIFF
--- a/src/langs/json/de.json
+++ b/src/langs/json/de.json
@@ -347,7 +347,8 @@
     "changeOrg": "Organisation ändern",
     "personalAcct": "Persönliches Konto",
     "signIn": "Anmelden",
-    "uploadEmail": "Hochladen per E-Mail"
+    "uploadEmail": "Hochladen per E-Mail",
+    "donate": "Spenden",
   },
   "documents": {
     "yourDocuments": "Ihre Dokumente",

--- a/src/langs/json/de.json
+++ b/src/langs/json/de.json
@@ -348,7 +348,7 @@
     "personalAcct": "Persönliches Konto",
     "signIn": "Anmelden",
     "uploadEmail": "Hochladen per E-Mail",
-    "donate": "Spenden",
+    "donate": "Spenden"
   },
   "documents": {
     "yourDocuments": "Ihre Dokumente",

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -377,6 +377,7 @@
       "apiDocs": "API Documentation",
       "addOns": "Add-Ons",
       "premium": "DocumentCloud Premium",
+      "donate": "Donate to support DocumentCloud",
       "emailUs": "Email Us"
     },
     "language": {

--- a/src/langs/json/es.json
+++ b/src/langs/json/es.json
@@ -338,7 +338,8 @@
     "signOut": "Cerrar sesión",
     "changeOrg": "Cambiar la organización",
     "personalAcct": "Cuenta personal",
-    "signIn": "Iniciar sesión"
+    "signIn": "Iniciar sesión",
+    "donate": "Hacer una donación"
   },
   "documents": {
     "yourDocuments": "Sus documentos",

--- a/src/langs/json/fr.json
+++ b/src/langs/json/fr.json
@@ -339,7 +339,7 @@
     "changeOrg": "Changer l'organisation",
     "personalAcct": "Compte personnel",
     "signIn": "Se connecter",
-    "donate": "Faire un don", 
+    "donate": "Faire un don"
   },
   "documents": {
     "yourDocuments": "Vos Documents",

--- a/src/langs/json/fr.json
+++ b/src/langs/json/fr.json
@@ -338,7 +338,8 @@
     "signOut": "Se déconnecter",
     "changeOrg": "Changer l'organisation",
     "personalAcct": "Compte personnel",
-    "signIn": "Se connecter"
+    "signIn": "Se connecter",
+    "donate": "Faire un don", 
   },
   "documents": {
     "yourDocuments": "Vos Documents",

--- a/src/langs/json/ru.json
+++ b/src/langs/json/ru.json
@@ -347,7 +347,8 @@
     "changeOrg": "Изменить организацию",
     "personalAcct": "Личный аккаунт",
     "signIn": "Войти",
-    "uploadEmail": "Загрузить через e-mail"
+    "uploadEmail": "Загрузить через e-mail",
+    "donate": "Поддержите нас",
   },
   "documents": {
     "yourDocuments": "Ваши документы",

--- a/src/langs/json/ru.json
+++ b/src/langs/json/ru.json
@@ -348,7 +348,7 @@
     "personalAcct": "Личный аккаунт",
     "signIn": "Войти",
     "uploadEmail": "Загрузить через e-mail",
-    "donate": "Поддержите нас",
+    "donate": "Поддержите нас"
   },
   "documents": {
     "yourDocuments": "Ваши документы",

--- a/src/langs/json/uk.json
+++ b/src/langs/json/uk.json
@@ -347,7 +347,8 @@
     "changeOrg": "Змінити організацію",
     "personalAcct": "Особистий акаунт",
     "signIn": "Увійти",
-    "uploadEmail": "Вивантажити через email"
+    "uploadEmail": "Вивантажити через email",
+    "donate": "Пiдтримати"
   },
   "documents": {
     "yourDocuments": "Ваші документи",

--- a/src/pages/app/accounts/HelpMenu.svelte
+++ b/src/pages/app/accounts/HelpMenu.svelte
@@ -15,6 +15,7 @@
     Zap16,
     Mail16,
     Question16,
+    Gift16,
   } from "svelte-octicons";
 </script>
 
@@ -52,6 +53,12 @@
       <MenuItem>
         <Zap16 slot="icon" />
         {$_("authSection.help.premium")}
+      </MenuItem>
+    </Link>
+    <Link toUrl="https://www.muckrock.com/donate/" color={true}>
+      <MenuItem>
+        <Gift16 slot="icon" />
+        {$_("authSection.help.donate")}
       </MenuItem>
     </Link>
     <a href="mailto:info@documentcloud.org" class="color" target="_blank">

--- a/src/pages/app/accounts/HelpMenu.svelte
+++ b/src/pages/app/accounts/HelpMenu.svelte
@@ -55,12 +55,12 @@
         {$_("authSection.help.premium")}
       </MenuItem>
     </Link>
-    <Link toUrl="https://www.muckrock.com/donate/" color={true}>
+    <a href="https://www.muckrock.com/donate/" class="color">
       <MenuItem>
         <Gift16 slot="icon" />
         {$_("authSection.help.donate")}
       </MenuItem>
-    </Link>
+    </a>
     <a href="mailto:info@documentcloud.org" class="color" target="_blank">
       <MenuItem>
         <Mail16 slot="icon" />


### PR DESCRIPTION
I added a link to https://www.muckrock.com/donate/ in the drop down with the correct icon. 
![Donate](https://github.com/user-attachments/assets/a79b37b3-8ce4-4f7e-9d6a-60829fb1023d)

Clicking on the link locally leads to a page not found error, but the link is definitely there and clicking "Open link in new tab" works as expected. Going to see if different behavior happens during staging deploy
