### PR TITLE
Fix section logic

### DIFF
--- a/src/lib/components/forms/EditSectionRow.svelte
+++ b/src/lib/components/forms/EditSectionRow.svelte
@@ -1,0 +1,138 @@
+<!-- @component
+One row of the `EditSections.svelte` form, to encapsulate logic.
+-->
+<script lang="ts">
+  import type { Document, Section } from "$lib/api/types";
+
+  import { invalidate } from "$app/navigation";
+
+  import { _ } from "svelte-i18n";
+  import {
+    CheckCircle16,
+    PlusCircle16,
+    Trash16,
+    XCircle16,
+  } from "svelte-octicons";
+
+  import Button from "../common/Button.svelte";
+  import Number from "../inputs/Number.svelte";
+  import Text from "../inputs/Text.svelte";
+
+  import { create, update, remove } from "$lib/api/sections";
+
+  export let csrftoken: string;
+  export let disabled = false;
+  export let document: Document;
+  export let id: number | string = undefined;
+  export let page_number: number = undefined;
+  export let title: string = "";
+
+  $: mode = id ? "edit" : "create";
+</script>
+
+<tr class="section {mode}" id="section-{id ?? 'new'}">
+  <td class="page_number">
+    <!-- svelte-ignore a11y-label-has-associated-control -->
+    <label>
+      <span class="sr-only">{$_("sections.page")}</span>
+      <Number
+        name="page_number"
+        value={page_number + 1}
+        min={1}
+        max={document.page_count}
+        required
+      />
+    </label>
+  </td>
+  <td class="title">
+    <!-- svelte-ignore a11y-label-has-associated-control -->
+    <label>
+      <span class="sr-only">{$_("sections.title")}</span>
+      <Text name="title" bind:value={title} required />
+    </label>
+  </td>
+  <td class="action">
+    {#if id}
+      <Button
+        mode="ghost"
+        title={$_("sections.update")}
+        minW={false}
+        name="action"
+        value="update"
+        {disabled}
+        on:click={async (e) => {
+          const section = { id, page_number, title };
+          await update(document.id, id, section, csrftoken);
+          await invalidate(`document:${document.id}`);
+        }}
+      >
+        <CheckCircle16 />
+      </Button>
+      <Button
+        mode="ghost"
+        title={$_("sections.delete")}
+        minW={false}
+        name="action"
+        value="delete"
+        on:click={async (e) => {
+          await remove(document.id, id, csrftoken);
+          await invalidate(`document:${document.id}`);
+        }}
+      >
+        <Trash16 fill="var(--caution)" />
+      </Button>
+    {:else}
+      <Button
+        mode="ghost"
+        title={$_("sections.new")}
+        minW={false}
+        name="action"
+        value="add"
+        {disabled}
+        on:click={async (e) => {
+          await create(
+            document.id,
+            { title, page_number: page_number - 1 },
+            csrftoken,
+          );
+          await invalidate(`document:${document.id}`);
+        }}
+      >
+        <PlusCircle16 />
+      </Button>
+
+      <Button
+        mode="ghost"
+        title={$_("sections.clear")}
+        minW={false}
+        on:click={(e) => {}}
+      >
+        <XCircle16 />
+      </Button>
+    {/if}
+  </td>
+</tr>
+
+<style>
+  td {
+    padding: 0 0.5rem 0.5rem 0;
+    --font-size: var(--font-s);
+  }
+
+  td.page_number {
+    min-width: 5ch;
+  }
+
+  td.title {
+    min-width: 10ch;
+  }
+
+  td.action {
+    max-width: 10ch;
+    display: flex;
+  }
+
+  tr.section {
+    padding: 0.125rem;
+  }
+</style>

--- a/src/lib/components/forms/EditSectionRow.svelte
+++ b/src/lib/components/forms/EditSectionRow.svelte
@@ -27,7 +27,16 @@ One row of the `EditSections.svelte` form, to encapsulate logic.
   export let page_number: number = undefined;
   export let title: string = "";
 
+  // store separately to deal with zero-indexed section pages
+  let display_number: number = (page_number || 0) + 1;
+
   $: mode = id ? "edit" : "create";
+
+  function reset() {
+    title = "";
+    page_number = undefined;
+    display_number = undefined;
+  }
 </script>
 
 <tr class="section {mode}" id="section-{id ?? 'new'}">
@@ -35,12 +44,14 @@ One row of the `EditSections.svelte` form, to encapsulate logic.
     <!-- svelte-ignore a11y-label-has-associated-control -->
     <label>
       <span class="sr-only">{$_("sections.page")}</span>
-      <Number
+      <input
+        type="number"
         name="page_number"
-        value={page_number + 1}
+        bind:value={display_number}
         min={1}
         max={document.page_count}
         required
+        on:input={(e) => (page_number = display_number - 1)}
       />
     </label>
   </td>
@@ -90,12 +101,9 @@ One row of the `EditSections.svelte` form, to encapsulate logic.
         value="add"
         {disabled}
         on:click={async (e) => {
-          await create(
-            document.id,
-            { title, page_number: page_number - 1 },
-            csrftoken,
-          );
+          await create(document.id, { title, page_number }, csrftoken);
           await invalidate(`document:${document.id}`);
+          reset();
         }}
       >
         <PlusCircle16 />
@@ -105,7 +113,7 @@ One row of the `EditSections.svelte` form, to encapsulate logic.
         mode="ghost"
         title={$_("sections.clear")}
         minW={false}
-        on:click={(e) => {}}
+        on:click={reset}
       >
         <XCircle16 />
       </Button>
@@ -134,5 +142,31 @@ One row of the `EditSections.svelte` form, to encapsulate logic.
 
   tr.section {
     padding: 0.125rem;
+  }
+
+  input[type="number"] {
+    display: flex;
+    padding: 0.375rem 0.75rem;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+
+    border-radius: 0.5rem;
+    border: 1px solid var(--gray-3, hwb(205 60% 30%));
+    background: var(--white, #fff);
+    box-shadow: 0px 2px 0px 0px var(--gray-2, #d8dee2) inset;
+
+    color: var(--gray-5, #233944);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: "Source Sans Pro";
+    font-size: var(--font-size, 1rem);
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+  }
+  input::placeholder {
+    color: var(--gray-3, #99a8b3);
   }
 </style>

--- a/src/lib/components/forms/EditSections.svelte
+++ b/src/lib/components/forms/EditSections.svelte
@@ -23,7 +23,6 @@ This form is entirely client-side.
 
   $: sections = document.sections ?? [];
   $: existing_pages = new Set(sections.map((s) => s.page_number));
-  $: console.log(section);
 
   beforeUpdate(() => {
     // updating, so remove new section data
@@ -67,6 +66,7 @@ This form is entirely client-side.
         {csrftoken}
         title={section.title}
         page_number={section.page_number}
+        disabled={existing_pages.has(section.page_number)}
       />
 
       {#if existing_pages.has(section.page_number)}

--- a/src/lib/components/forms/EditSections.svelte
+++ b/src/lib/components/forms/EditSections.svelte
@@ -5,22 +5,12 @@ This form is entirely client-side.
 <script lang="ts">
   import type { Document, Section } from "$lib/api/types";
 
-  import { invalidate } from "$app/navigation";
-
   import { beforeUpdate, createEventDispatcher, onMount } from "svelte";
   import { _ } from "svelte-i18n";
-  import {
-    CheckCircle16,
-    PlusCircle16,
-    Trash16,
-    XCircle16,
-  } from "svelte-octicons";
 
   import Button from "../common/Button.svelte";
-  import Text from "../inputs/Text.svelte";
-  import Number from "../inputs/Number.svelte";
+  import EditSectionRow from "./EditSectionRow.svelte";
 
-  import { create, update, remove } from "$lib/api/sections";
   import { getCsrfToken } from "$lib/utils/api";
 
   export let document: Document;
@@ -33,6 +23,7 @@ This form is entirely client-side.
 
   $: sections = document.sections ?? [];
   $: existing_pages = new Set(sections.map((s) => s.page_number));
+  $: console.log(section);
 
   beforeUpdate(() => {
     // updating, so remove new section data
@@ -44,12 +35,6 @@ This form is entirely client-side.
   onMount(() => {
     csrftoken = getCsrfToken();
   });
-
-  // for typescript
-  function fixValue(e: Event) {
-    const target = e.currentTarget as HTMLInputElement;
-    return +target.value - 1;
-  }
 </script>
 
 <form method="post">
@@ -68,59 +53,7 @@ This form is entirely client-side.
     {/if}
     <tbody>
       {#each sections as section}
-        <tr class="section edit" id="section-{section.id}">
-          <td class="page_number">
-            <!-- svelte-ignore a11y-label-has-associated-control -->
-            <label>
-              <span class="sr-only">{$_("sections.page")}</span>
-              <Number
-                name="page_number"
-                value={section.page_number + 1}
-                min={1}
-                max={document.page_count}
-                required
-                on:input={(e) => (section.page_number = fixValue(e))}
-              />
-            </label>
-          </td>
-          <td class="title">
-            <!-- svelte-ignore a11y-label-has-associated-control -->
-            <label>
-              <span class="sr-only">{$_("sections.title")}</span>
-              <Text name="title" bind:value={section.title} required />
-            </label>
-          </td>
-          <td class="action">
-            <Button
-              mode="ghost"
-              title={$_("sections.update")}
-              minW={false}
-              name="action"
-              value="update"
-              on:click={async (e) => {
-                await update(document.id, section.id, section, csrftoken);
-                await invalidate(`document:${document.id}`);
-              }}
-            >
-              <CheckCircle16 />
-            </Button>
-            <Button
-              mode="ghost"
-              title={$_("sections.delete")}
-              minW={false}
-              name="action"
-              value="delete"
-              on:click={async (e) => {
-                await remove(document.id, section.id, csrftoken);
-                await invalidate(`document:${document.id}`);
-              }}
-              --fill="var(--caution)"
-              --background="var(--orange-light)"
-            >
-              <Trash16 />
-            </Button>
-          </td>
-        </tr>
+        <EditSectionRow {document} {...section} {csrftoken} />
       {/each}
     </tbody>
     <tfoot>
@@ -129,69 +62,13 @@ This form is entirely client-side.
           {$_("sections.new")}
         </th>
       </tr>
-      <tr class="section create">
-        <td class="page_number">
-          <!-- svelte-ignore a11y-label-has-associated-control -->
-          <label>
-            <span class="sr-only">{$_("sections.page")}</span>
-            <Number
-              name="page_number"
-              placeholder={$_("sections.page")}
-              min={1}
-              max={document.page_count}
-              required
-              value={section.page_number + 1}
-              on:input={(e) => (section.page_number = fixValue(e))}
-            />
-          </label>
-        </td>
-        <td class="title">
-          <!-- svelte-ignore a11y-label-has-associated-control -->
-          <label>
-            <span class="sr-only">{$_("sections.title")}</span>
-            <Text
-              name="title"
-              placeholder={$_("sections.title")}
-              required
-              bind:value={section.title}
-            />
-          </label>
-        </td>
-        <td class="action">
-          <Button
-            mode="ghost"
-            title={$_("sections.new")}
-            minW={false}
-            name="action"
-            value="add"
-            disabled={existing_pages.has(section.page_number)}
-            on:click={async (e) => {
-              await create(
-                document.id,
-                { title: section.title, page_number: section.page_number - 1 },
-                csrftoken,
-              );
-              await invalidate(`document:${document.id}`);
-              section = {};
-            }}
-          >
-            <PlusCircle16 />
-          </Button>
+      <EditSectionRow
+        {document}
+        {csrftoken}
+        title={section.title}
+        page_number={section.page_number}
+      />
 
-          <Button
-            mode="ghost"
-            title={$_("sections.clear")}
-            minW={false}
-            on:click={(e) => {
-              section = { title: "" };
-            }}
-            --fill="var(--gray-3)"
-            --background="var(--gray-1)"
-          >
-            <XCircle16 />
-          </Button>
-        </td>
-      </tr>
       {#if existing_pages.has(section.page_number)}
         <tr class="warning">
           <td colspan="2">
@@ -204,7 +81,9 @@ This form is entirely client-side.
     </tfoot>
   </table>
   <div class="buttons">
-    <Button mode="primary" on:click={() => dispatch("close")}>{$_("dialog.done")}</Button>
+    <Button mode="primary" on:click={() => dispatch("close")}>
+      {$_("dialog.done")}
+    </Button>
   </div>
 </form>
 
@@ -217,6 +96,7 @@ This form is entirely client-side.
 
   form {
     padding: 1rem;
+    width: 100%;
   }
 
   td,
@@ -230,23 +110,6 @@ This form is entirely client-side.
     text-align: start;
     font-size: var(--font-m);
     font-weight: var(--font-semibold);
-  }
-
-  td.page_number {
-    min-width: 10ch;
-  }
-
-  td.title {
-    min-width: 10ch;
-  }
-
-  td.action {
-    max-width: 10ch;
-    display: flex;
-  }
-
-  tr.section {
-    padding: 0.125rem;
   }
 
   .warning {

--- a/src/routes/documents/[id]-[slug]/annotate/+page.server.ts
+++ b/src/routes/documents/[id]-[slug]/annotate/+page.server.ts
@@ -33,7 +33,7 @@ export const actions = {
         note: created,
       };
     } catch (e) {
-      return fail(400, { error: e });
+      return fail(400, { error: e.message });
     }
   },
 
@@ -63,7 +63,7 @@ export const actions = {
         note: updated,
       };
     } catch (e) {
-      return fail(400, { error: e });
+      return fail(400, { error: e.message });
     }
   },
 


### PR DESCRIPTION
Adds a new `EditSectionRow.svelte` component to wrap the logic for creating, updating and removing sections. This also deals with the problem of zero-indexed page numbers.