### PR TITLE
SidebarGroup can remember collapsed state

### DIFF
--- a/src/lib/components/sidebar/SidebarGroup.svelte
+++ b/src/lib/components/sidebar/SidebarGroup.svelte
@@ -1,13 +1,24 @@
 <script lang="ts">
+  import { browser } from "$app/environment";
+  import { onMount } from "svelte";
   import { ChevronDown16 } from "svelte-octicons";
 
-  let collapsed = false;
+  export let collapsed = false;
+  export let name: string = undefined;
+
+  $: key = `SidebarGroup:${name}`;
+
   function toggle(val: boolean) {
     collapsed = !val;
+    if (name && browser) {
+      localStorage.setItem(key, String(collapsed));
+    }
   }
+
   function onClick() {
     toggle(collapsed);
   }
+
   function onKeydown({ key }) {
     if (["Enter", " "].includes(key)) {
       toggle(collapsed);
@@ -17,6 +28,12 @@
       collapsed = true;
     }
   }
+
+  onMount(() => {
+    if (name) {
+      collapsed = localStorage.getItem(key) === "true";
+    }
+  });
 </script>
 
 <div class="container">

--- a/src/lib/components/sidebar/stories/SidebarGroup.stories.svelte
+++ b/src/lib/components/sidebar/stories/SidebarGroup.stories.svelte
@@ -54,3 +54,22 @@
     </SidebarGroup>
   </div>
 </Story>
+
+<Story name="Remember collapsed state">
+  <p>Refresh to check that <code>collapsed</code> state persists</p>
+  <SidebarGroup name="storybook-files">
+    <SidebarItem slot="title"><FileDirectory16 /> Project</SidebarItem>
+    <Action slot="action" icon={Book16}>Explore</Action>
+    <Flex direction="column" gap={0}>
+      <SidebarItem small href="/project/1">
+        <Pin active /> Oldest Computer
+      </SidebarItem>
+      <SidebarItem small href="/project/2">
+        <Pin active /> FBI Files
+      </SidebarItem>
+      <SidebarItem small href="/project/3">
+        <Pin active /> 1033 Project
+      </SidebarItem>
+    </Flex>
+  </SidebarGroup>
+</Story>

--- a/src/routes/documents/[id]-[slug]/annotate/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/annotate/+page.svelte
@@ -74,7 +74,7 @@
 </svelte:head>
 
 <ContentLayout>
-  <Tip slot="header" --background-color="var(--yellow-bright)">
+  <Tip slot="header" --background-color="var(--yellow-3)">
     <Comment24 slot="icon" />
     <h3>{$_("annotate.title")}</h3>
     <p>{$_("annotate.instructions")}</p>

--- a/src/routes/documents/[id]-[slug]/redact/+page.svelte
+++ b/src/routes/documents/[id]-[slug]/redact/+page.svelte
@@ -89,7 +89,7 @@
 
 <ContentLayout>
   <svelte:fragment slot="header">
-    <Tip --background-color="var(--yellow-bright)">
+    <Tip --background-color="var(--yellow-3)">
       <SquareFill24 slot="icon" />
       <h3>{$_("redact.title")}</h3>
       <p>{$_("redact.instructions")}</p>
@@ -101,7 +101,7 @@
   <PageToolbar slot="footer">
     <Flex slot="left">
       <!-- additional controls here -->
-      <Button mode="primary" size="small" on:click={() => confirmOpen = true}>
+      <Button mode="primary" size="small" on:click={() => (confirmOpen = true)}>
         <Check16 />
         {$_("redact.confirm")}
       </Button>
@@ -122,11 +122,11 @@
   </PageToolbar>
 
   {#if confirmOpen}
-  <Portal>
-    <Modal on:close={() => confirmOpen = false}>
-      <h1 slot="title">{$_("redact.confirm")}</h1>
-      <ConfirmRedaction {document} on:close={() => confirmOpen = false} />
-    </Modal>
-  </Portal>
+    <Portal>
+      <Modal on:close={() => (confirmOpen = false)}>
+        <h1 slot="title">{$_("redact.confirm")}</h1>
+        <ConfirmRedaction {document} on:close={() => (confirmOpen = false)} />
+      </Modal>
+    </Portal>
   {/if}
 </ContentLayout>

--- a/src/routes/documents/[id]-[slug]/sidebar/Actions.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Actions.svelte
@@ -35,7 +35,7 @@
   $: pdf = pdfUrl(document).toString();
   $: annotate = relative(document, "annotate/");
   $: redact = relative(document, "redact/");
-  $: modify = relative(document, "modify/");
+  // $: modify = relative(document, "modify/");
 
   function relative(document: Document, path: string) {
     return new URL(path, canonicalUrl(document)).href;
@@ -101,12 +101,14 @@
     </SidebarItem>
   {/if}
 
-  {#if document.edit_access}
+  <!--
+    {#if document.edit_access}
     <SidebarItem href={modify} disabled={isProcessing(document.status)}>
       <Apps16 />
       {$_("sidebar.modify")} &hellip;
     </SidebarItem>
-  {/if}
+    {/if}
+  -->
 
   {#if document.edit_access}
     <!-- TODO: Processing component -->

--- a/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Data.svelte
@@ -27,7 +27,7 @@
   $: empty = Object.keys(document.data).length === 0;
 </script>
 
-<SidebarGroup>
+<SidebarGroup name="data">
   <SidebarItem slot="title">
     <Tag16 />
     {$_("sidebar.data.title")}

--- a/src/routes/documents/[id]-[slug]/sidebar/Notes.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Notes.svelte
@@ -17,7 +17,7 @@
   $: annotate = new URL("annotate/", canonicalUrl(document)).href;
 </script>
 
-<SidebarGroup>
+<SidebarGroup name="notes">
   <SidebarItem slot="title">
     <Note16 />
     {$_("sidebar.toc.notes")}

--- a/src/routes/documents/[id]-[slug]/sidebar/Projects.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Projects.svelte
@@ -10,7 +10,7 @@
   export let projects: Project[];
 </script>
 
-<SidebarGroup>
+<SidebarGroup name="projects:viewer">
   <SidebarItem slot="title">
     <FileDirectory16 />
     Projects

--- a/src/routes/documents/[id]-[slug]/sidebar/Sections.svelte
+++ b/src/routes/documents/[id]-[slug]/sidebar/Sections.svelte
@@ -17,7 +17,7 @@
   $: annotate = new URL("annotate/", canonicalUrl(document)).href;
 </script>
 
-<SidebarGroup>
+<SidebarGroup name="sections">
   <SidebarItem slot="title">
     <ListOrdered16 />
     {$_("sidebar.toc.sections")}

--- a/src/routes/documents/sidebar/AddOns.svelte
+++ b/src/routes/documents/sidebar/AddOns.svelte
@@ -11,12 +11,11 @@
   import SidebarItem from "$lib/components/sidebar/SidebarItem.svelte";
   import SidebarGroup from "$lib/components/sidebar/SidebarGroup.svelte";
   import Pin from "@/common/Pin.svelte";
-  import { getPinnedAddons } from "@/lib/api/addons";
 
   export let pinnedAddOns: Promise<Page<AddOnListItem>>;
 </script>
 
-<SidebarGroup>
+<SidebarGroup name="addons">
   <SidebarItem slot="title"><Plug16 />{$_("sidebar.addons.title")}</SidebarItem>
   <a href="/add-ons/" slot="action">
     <Action icon={Book16}>{$_("common.explore")}</Action>

--- a/src/routes/documents/sidebar/Projects.svelte
+++ b/src/routes/documents/sidebar/Projects.svelte
@@ -23,13 +23,13 @@
   $: pinned = $page.data.pinnedProjects || [];
 </script>
 
-<SidebarGroup>
-  <SidebarItem slot="title"
-    ><FileDirectory16 />{$_("sidebar.projects.title")}</SidebarItem
-  >
-  <a href="/documents/projects/" slot="action"
-    ><Action icon={Book16}>{$_("common.explore")}</Action></a
-  >
+<SidebarGroup name="projects">
+  <SidebarItem slot="title">
+    <FileDirectory16 />{$_("sidebar.projects.title")}
+  </SidebarItem>
+  <a href="/documents/projects/" slot="action">
+    <Action icon={Book16}>{$_("common.explore")}</Action>
+  </a>
   <Flex direction="column" gap={0}>
     {#await pinned}
       <Empty icon={Hourglass24}>{$_("common.loading")}</Empty>


### PR DESCRIPTION
Add a unique `name` prop and the sidebar will remember its state.

```svelte
<!-- this will remember -->
<SidebarGroup name="projects">
...
</SidebarGroup>

<!-- this will not -->
<SidebarGroup>
...
</SidebarGroup>
```

Closes #481 