### PR TITLE
Display persistent messages in navigation 

### DIFF
--- a/.storybook/decorators/TipOfDayContextDecorator.svelte
+++ b/.storybook/decorators/TipOfDayContextDecorator.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { setContext } from "svelte";
+  import type { Flatpage } from "$lib/api/types";
+  const tipOfDay: Flatpage = {
+    url: "/tipofday/",
+    title: "Tip of the Day",
+    content:
+      '<p>Welcome to DocumentCloud, the <a href="#">SvelteKit</a> rewrite!</p>',
+  };
+  setContext("tipOfDay", tipOfDay);
+</script>
+
+<slot />

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,7 @@ import { initialize, mswLoader } from "msw-storybook-addon";
 import { mockDateDecorator } from "storybook-mock-date-decorator";
 import UserContextDecorator from "./decorators/UserContextDecorator.svelte";
 import OrgContextDecorator from "./decorators/OrgContextDecorator.svelte";
+import TipOfDayContextDecorator from "./decorators/TipOfDayContextDecorator.svelte";
 
 import "@/style/kit.css";
 import "@/lib/i18n/index.js";
@@ -45,6 +46,7 @@ export let decorators = [
   mockDateDecorator,
   () => UserContextDecorator,
   () => OrgContextDecorator,
+  () => TipOfDayContextDecorator,
 ];
 
 export default preview;

--- a/src/lib/api/flatpages.ts
+++ b/src/lib/api/flatpages.ts
@@ -1,0 +1,13 @@
+import { BASE_API_URL } from "@/config/config";
+import type { Flatpage } from "./types";
+
+export async function getTipOfDay(fetch = globalThis.fetch): Promise<Flatpage> {
+  const endpoint = new URL("flatpages/tipofday/", BASE_API_URL);
+  try {
+    const resp = await fetch(endpoint, { credentials: "include" });
+    if (!resp.ok) return;
+    return resp.json();
+  } catch (e) {
+    return;
+  }
+}

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -258,3 +258,9 @@ export interface Redaction extends BBox {
 export type Bounds = [number, number, number, number];
 
 export type ProjectMembershipList = Page<ProjectMembershipItem>;
+
+export interface Flatpage {
+  url: string;
+  title: string;
+  content: string; // Could be HTML or Markdown
+}

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -9,7 +9,8 @@ import type { User, Org } from "@/api/types/orgAndUser";
 import type { Project } from "@/api/types/project";
 import type { Page } from "@/api/types/common";
 
-export type { Page } from "@/api/types/common";
+// re-export these for convenience
+export type { Page, User, Org, Project };
 
 export type Access = "public" | "private" | "organization"; // https://www.documentcloud.org/help/api#access-levels
 
@@ -205,9 +206,6 @@ export interface OEmbed {
   html: string;
   type: "rich";
 }
-
-// re-export for consistency
-export type { Project };
 
 export type ProjectResults = Page<Project>;
 

--- a/src/lib/components/common/TipOfDay.svelte
+++ b/src/lib/components/common/TipOfDay.svelte
@@ -1,0 +1,82 @@
+<script lang="ts" context="module">
+  import { writable } from "svelte/store";
+  import { StorageManager } from "@/lib/utils/storage";
+
+  let show = writable(false);
+
+  const storage = new StorageManager("tip-of-day");
+
+  export function showTip(message: string) {
+    return message === storage.get("message")
+      ? storage.get<boolean, boolean>("show", true)
+      : true;
+  }
+
+  function hideTip(message) {
+    show.set(false);
+    storage.set("message", message);
+    storage.set("show", false);
+  }
+</script>
+
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { X12 } from "svelte-octicons";
+
+  export let message: string;
+
+  onMount(() => {
+    $show = showTip(message);
+  });
+</script>
+
+{#if $show}
+  <div class="container">
+    <div class="message">
+      {@html message}
+    </div>
+    <button class="close" title="Hide Tip" on:click={() => hideTip(message)}>
+      <X12 />
+    </button>
+  </div>
+{/if}
+
+<style>
+  .container {
+    padding: 0.25rem 1rem;
+    text-align: center;
+    font-size: var(--font-s);
+    background: var(--green-1);
+    color: var(--green-5);
+    display: flex;
+    justify-content: center;
+    align-items: baseline;
+    position: relative;
+  }
+  .message {
+    flex: 1 1 auto;
+    line-height: 1.5;
+    max-width: 48rem;
+    padding: 0 1.5rem;
+  }
+  .close {
+    position: absolute;
+    right: 1rem;
+    appearance: none;
+    border: none;
+    background: none;
+    color: var(--green-4);
+    fill: var(--green-4);
+    height: 1.5rem;
+    width: 1.5rem;
+    border-radius: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  }
+  .close:hover,
+  .close:focus {
+    background: var(--green-2);
+  }
+</style>

--- a/src/lib/components/documents/ResultsList.svelte
+++ b/src/lib/components/documents/ResultsList.svelte
@@ -60,7 +60,7 @@
       entries.forEach(async (entry) => {
         if (entry.isIntersecting && next) {
           await load(new URL(next));
-          observer.unobserve(el);
+          observer?.unobserve(el);
         }
       });
     });
@@ -70,7 +70,7 @@
   }
 
   function unwatch(io: IntersectionObserver, el: HTMLElement) {
-    io.unobserve(el);
+    io?.unobserve(el);
   }
 
   onMount(() => {

--- a/src/lib/components/layouts/MainLayout.svelte
+++ b/src/lib/components/layouts/MainLayout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Writable } from "svelte/store";
-  import type { Org, User } from "@/api/types";
+  import type { Org, User, Flatpage } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
   import { page } from "$app/stores";
@@ -19,9 +19,11 @@
   import LanguageMenu from "../navigation/LanguageMenu.svelte";
   import HelpMenu from "../navigation/HelpMenu.svelte";
   import Toaster from "./Toaster.svelte";
+  import TipOfDay from "../common/TipOfDay.svelte";
 
   const me = getContext<Writable<User>>("me");
   const org = getContext<Writable<Org>>("org");
+  const tipOfDay = getContext<Flatpage>("tipOfDay");
 
   const user_orgs = getContext<Writable<Promise<Org[]>>>("user_orgs");
   const org_users = getContext<Writable<Promise<User[]>>>("org_users");
@@ -40,6 +42,7 @@
 </script>
 
 <div class="container">
+  {#if tipOfDay}<TipOfDay message={tipOfDay.content} />{/if}
   <header>
     {#if $$slots.navigation}
       <div class="small openPane">

--- a/src/routes/(embed)/stories/note-embed.stories.svelte
+++ b/src/routes/(embed)/stories/note-embed.stories.svelte
@@ -30,6 +30,7 @@
     user_orgs: Promise.resolve([]),
     org_users: Promise.resolve([]),
     breadcrumbs: [],
+    tipOfDay: null,
   };
 </script>
 

--- a/src/routes/(embed)/stories/page-embed.stories.svelte
+++ b/src/routes/(embed)/stories/page-embed.stories.svelte
@@ -29,6 +29,7 @@
     user_orgs: Promise.resolve([]),
     org_users: Promise.resolve([]),
     breadcrumbs: [],
+    tipOfDay: null,
   };
 </script>
 

--- a/src/routes/(embed)/stories/project-embed.stories.svelte
+++ b/src/routes/(embed)/stories/project-embed.stories.svelte
@@ -27,6 +27,7 @@
     user_orgs: Promise.resolve([]),
     org_users: Promise.resolve([]),
     breadcrumbs: [],
+    tipOfDay: null,
   };
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -27,6 +27,7 @@
   setContext("user_orgs", user_orgs);
   setContext("org_users", org_users);
   setContext("embed", data.embed);
+  setContext("tipOfDay", data.tipOfDay);
 </script>
 
 <slot />

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -4,6 +4,7 @@ import { browser } from "$app/environment";
 import { getMe, orgUsers, userOrgs } from "$lib/api/accounts";
 
 import "$lib/i18n/index.js"; // Import to initialize. Important :)
+import { getTipOfDay } from "@/lib/api/flatpages.js";
 
 export const trailingSlash = "always";
 
@@ -19,6 +20,7 @@ export async function load({ fetch, url }) {
   // todo: ensure this doesn't load for embeds
   const me = await getMe(fetch);
   const org = me?.organization as Org;
+  const tipOfDay = me ? await getTipOfDay(fetch) : null;
 
   let user_orgs: Promise<Org[]>, org_users: Promise<User[]>;
   if (me && org) {
@@ -32,5 +34,5 @@ export async function load({ fetch, url }) {
     });
   }
 
-  return { me, org, embed, breadcrumbs: [], user_orgs, org_users };
+  return { me, org, tipOfDay, embed, breadcrumbs: [], user_orgs, org_users };
 }


### PR DESCRIPTION
Fixes #596

This loads the "Tip of the Day" flatpage content and renders it at the top of the main layout.

It now provides a "hide" action, which will keep the tip hidden as long as:
- the user keeps their browser's localStorage
- the tip's content hasn't changed

If there is a new tip from the last time a user hid it, the TipOfTheDay will reappear with the new information.
