### PR TITLE
Adds Plausible to AppLayout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "lucene": "^2.1.1",
         "marked": "^7.0.5",
         "marked-gfm-heading-id": "^3.0.6",
+        "plausible-tracker": "^0.3.9",
         "postcss": "^8.4.25",
         "rlite-router": "^2.0.3",
         "sass": "^1.60.0",
@@ -24378,6 +24379,14 @@
         "confbox": "^0.1.7",
         "mlly": "^1.7.1",
         "pathe": "^1.1.2"
+      }
+    },
+    "node_modules/plausible-tracker": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/plausible-tracker/-/plausible-tracker-0.3.9.tgz",
+      "integrity": "sha512-hMhneYm3GCPyQon88SZrVJx+LlqhM1kZFQbuAgXPoh/Az2YvO1B6bitT9qlhpiTdJlsT5lsr3gPmzoVjb5CDXA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/playwright": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lucene": "^2.1.1",
     "marked": "^7.0.5",
     "marked-gfm-heading-id": "^3.0.6",
+    "plausible-tracker": "^0.3.9",
     "postcss": "^8.4.25",
     "rlite-router": "^2.0.3",
     "sass": "^1.60.0",

--- a/src/lib/components/common/PlausibleTracker.svelte
+++ b/src/lib/components/common/PlausibleTracker.svelte
@@ -10,13 +10,14 @@
 
   let plausible;
   const user: Writable<Maybe<User>> = getContext("me");
+  const embed: Writable<boolean> = getContext("embed");
 
   onMount(() => {
     plausible = Plausible();
   });
 
   afterNavigate(() => {
-    if (user && browser) {
+    if (!embed && user && browser) {
       plausible.trackPageview();
     }
   });

--- a/src/lib/components/common/PlausibleTracker.svelte
+++ b/src/lib/components/common/PlausibleTracker.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import Plausible from "plausible-tracker";
+
+  import { getContext, onMount } from "svelte";
+  import type { Writable } from "svelte/store";
+  import { afterNavigate } from "$app/navigation";
+  import { browser } from "$app/environment";
+  import type { User } from "@/lib/api/types";
+  import type { Maybe } from "@/api/types/common";
+
+  let plausible;
+  const user: Writable<Maybe<User>> = getContext("me");
+
+  onMount(() => {
+    if (browser) {
+      plausible = Plausible();
+    }
+  });
+
+  afterNavigate(() => {
+    if (user && browser) {
+      plausible.trackPageview();
+    }
+  });
+</script>
+
+<slot />

--- a/src/lib/components/common/PlausibleTracker.svelte
+++ b/src/lib/components/common/PlausibleTracker.svelte
@@ -12,9 +12,7 @@
   const user: Writable<Maybe<User>> = getContext("me");
 
   onMount(() => {
-    if (browser) {
-      plausible = Plausible();
-    }
+    plausible = Plausible();
   });
 
   afterNavigate(() => {

--- a/src/lib/components/layouts/AppLayout.svelte
+++ b/src/lib/components/layouts/AppLayout.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
   import Toaster from "./Toaster.svelte";
   import Navigation from "./Navigation.svelte";
+  import PlausibleTracker from "../common/PlausibleTracker.svelte";
 </script>
 
-<div class="container">
-  <Navigation />
-  <div class="inner">
-    <slot />
+<PlausibleTracker>
+  <div class="container">
+    <Navigation />
+    <div class="inner">
+      <slot />
+    </div>
+    <Toaster />
   </div>
-  <Toaster />
-</div>
+</PlausibleTracker>
 
 <style>
   .container {


### PR DESCRIPTION
Closes #630

This should only track pageviews on application routes for signed-in users.

To test, open the DevTools Network panel and check that pageview events are being sent to Plausible. Since we don't have a property set up for preview deployments or `next.www.documentcloud.org`, we don't see these events reported in the Plausible interface.

**Update** We now have a Plausible property for `next.www.documentcloud.org`.