### PR TITLE
Adds permissions utilities

### DIFF
--- a/src/lib/components/common/PlausibleTracker.svelte
+++ b/src/lib/components/common/PlausibleTracker.svelte
@@ -5,11 +5,10 @@
   import type { Writable } from "svelte/store";
   import { afterNavigate } from "$app/navigation";
   import { browser } from "$app/environment";
-  import type { User } from "@/lib/api/types";
-  import type { Maybe } from "@/api/types/common";
+  import { getCurrentUser } from "@/lib/utils/permissions";
 
   let plausible;
-  const user: Writable<Maybe<User>> = getContext("me");
+  const user = getCurrentUser();
   const embed: Writable<boolean> = getContext("embed");
 
   onMount(() => {

--- a/src/lib/components/common/SignedIn.svelte
+++ b/src/lib/components/common/SignedIn.svelte
@@ -7,11 +7,12 @@
   import { getContext } from "svelte";
   import type { Writable } from "svelte/store";
   import type { User } from "@/api/types";
+  import { isSignedIn } from "@/lib/utils/permissions";
 
   const me = getContext<Writable<User>>("me");
 </script>
 
-{#if $me}
+{#if isSignedIn($me)}
   <slot />
 {:else}
   <slot name="signedOut" />

--- a/src/lib/components/common/SignedIn.svelte
+++ b/src/lib/components/common/SignedIn.svelte
@@ -4,12 +4,9 @@
   The "signedOut" slot is available as a fallback.
 -->
 <script lang="ts">
-  import { getContext } from "svelte";
-  import type { Writable } from "svelte/store";
-  import type { User } from "@/api/types";
-  import { isSignedIn } from "@/lib/utils/permissions";
+  import { getCurrentUser, isSignedIn } from "@/lib/utils/permissions";
 
-  const me = getContext<Writable<User>>("me");
+  const me = getCurrentUser();
 </script>
 
 {#if isSignedIn($me)}

--- a/src/lib/components/forms/DocumentUpload.svelte
+++ b/src/lib/components/forms/DocumentUpload.svelte
@@ -107,7 +107,6 @@
 </script>
 
 <script lang="ts">
-  import type { Writable } from "svelte/store";
   import type {
     Access,
     Document,
@@ -120,7 +119,7 @@
   import { applyAction } from "$app/forms";
   import { goto } from "$app/navigation";
   import { filesize } from "filesize";
-  import { afterUpdate, getContext } from "svelte";
+  import { afterUpdate } from "svelte";
   import { _ } from "svelte-i18n";
   import {
     Alert16,
@@ -154,12 +153,13 @@
     isWithinSizeLimit,
   } from "@/lib/utils/files";
   import Tooltip from "@/common/Tooltip.svelte";
+  import { getCurrentUser } from "@/lib/utils/permissions";
 
   export let csrf_token = "";
   export let files: File[] = getFilesToUpload();
   export let projects: Project[] = [];
 
-  const me: Writable<User> = getContext("me");
+  const me = getCurrentUser();
 
   let loading = false;
   let uploader: HTMLInputElement;

--- a/src/lib/components/forms/Projects.svelte
+++ b/src/lib/components/forms/Projects.svelte
@@ -24,12 +24,13 @@ and we don't want to do that everywhere.
   import { getForUser, add, remove } from "$lib/api/projects";
   import { getCsrfToken } from "$lib/utils/api";
   import { intersection } from "@/util/array.js";
+  import { getCurrentUser } from "@/lib/utils/permissions";
 
   export let documents: Document[] = [];
   export let projects: Project[] = [];
 
   const dispatch = createEventDispatcher();
-  const me: Writable<User> = getContext("me");
+  const me = getCurrentUser();
 
   let common: Set<number>;
 

--- a/src/lib/components/layouts/DocumentBrowser.svelte
+++ b/src/lib/components/layouts/DocumentBrowser.svelte
@@ -1,15 +1,9 @@
 <script lang="ts">
-  import type { Writable } from "svelte/store";
-  import type {
-    DocumentResults,
-    Pending,
-    Project,
-    User,
-  } from "@/lib/api/types";
+  import type { DocumentResults, Pending, Project } from "@/lib/api/types";
 
   import { goto } from "$app/navigation";
 
-  import { getContext, setContext } from "svelte";
+  import { setContext } from "svelte";
   import { _ } from "svelte-i18n";
   import { FileDirectory24, Hourglass24, Upload24 } from "svelte-octicons";
 
@@ -33,11 +27,11 @@
   } from "../forms/DocumentUpload.svelte";
 
   import { isSupported } from "@/lib/utils/files";
-  import { canUploadFiles } from "@/lib/utils/permissions";
+  import { canUploadFiles, getCurrentUser } from "@/lib/utils/permissions";
 
   setContext("selected", selected);
 
-  const me: Writable<User> = getContext("me");
+  const me = getCurrentUser();
 
   interface UITextProps {
     loading: string;

--- a/src/lib/components/layouts/DocumentBrowser.svelte
+++ b/src/lib/components/layouts/DocumentBrowser.svelte
@@ -33,6 +33,7 @@
   } from "../forms/DocumentUpload.svelte";
 
   import { isSupported } from "@/lib/utils/files";
+  import { canUploadFiles } from "@/lib/utils/permissions";
 
   setContext("selected", selected);
 
@@ -65,7 +66,7 @@
   }
 
   function onDrop(files: FileList) {
-    if ($me?.verified_journalist) {
+    if (canUploadFiles($me)) {
       $filesToUpload = Array.from(files).filter(isSupported);
       $uploadToProject = project;
       goto("/upload/");
@@ -73,7 +74,7 @@
   }
 </script>
 
-<Dropzone {onDrop} disabled={!$me?.verified_journalist} let:active let:disabled>
+<Dropzone {onDrop} disabled={!canUploadFiles($me)} let:active let:disabled>
   <div class:active class:disabled class="dropOverlay">
     <Empty
       icon={Upload24}

--- a/src/lib/components/layouts/DocumentLayout.svelte
+++ b/src/lib/components/layouts/DocumentLayout.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-  import type { Writable } from "svelte/store";
-  import type { Document, DocumentText, Project, User } from "$lib/api/types";
-
-  import { getContext } from "svelte";
+  import type { Document, DocumentText, Project } from "$lib/api/types";
 
   import Access from "../documents/Access.svelte";
   import Actions from "../documents/Actions.svelte";
@@ -15,8 +12,9 @@
   import Viewer from "../documents/Viewer.svelte";
 
   import { pdfUrl } from "$lib/api/documents";
+  import { getCurrentUser } from "@/lib/utils/permissions";
 
-  const me: Writable<User> = getContext("me");
+  const me = getCurrentUser();
 
   export let document: Document;
   export let asset_url: URL = pdfUrl(document);

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -1,0 +1,11 @@
+/** Checks whether users have permission to view, update, or delete resources. */
+
+import type { User } from "@/api/types";
+
+export function isSignedIn(user?: User | null): user is User {
+  return Boolean(user);
+}
+
+export function canUploadFiles(user: User) {
+  return user.verified_journalist || user.is_staff;
+}

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -1,11 +1,23 @@
 /** Checks whether users have permission to view, update, or delete resources. */
 
+import { getContext } from "svelte";
+import type { Writable } from "svelte/store";
 import type { User } from "@/api/types";
 
+/** A helper that returns the signed-in user.
+ *  @returns the signed in user from context.
+ *  @throws if called outside component initialization.
+ */
+export function getCurrentUser(): Writable<User | null> {
+  return getContext("me");
+}
+
+/** Checks if the provided user exists. If they do, they are signed in. */
 export function isSignedIn(user?: User | null): user is User {
   return Boolean(user);
 }
 
+/* Checks if the user can upload file. Must be verified journalist or staff. */
 export function canUploadFiles(user: User) {
   return user.verified_journalist || user.is_staff;
 }

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -1,12 +1,14 @@
 /** Checks whether users have permission to view, update, or delete resources. */
 
-import { getContext } from "svelte";
 import type { Writable } from "svelte/store";
 import type { User } from "@/api/types";
 
-/** A helper that returns the signed-in user.
- *  @returns the signed in user from context.
- *  @throws if called outside component initialization.
+import { getContext } from "svelte";
+
+/**
+ * A helper that returns the signed-in user.
+ * @returns the signed in user from context.
+ * @throws if called outside component initialization.
  */
 export function getCurrentUser(): Writable<User | null> {
   return getContext("me");

--- a/src/lib/utils/tests/permissions.test.ts
+++ b/src/lib/utils/tests/permissions.test.ts
@@ -1,22 +1,26 @@
-import { describe, it, test, expect } from "vitest";
 import { render, screen } from "@testing-library/svelte";
-import { me } from "@/test/fixtures/accounts";
-import UserContextDemo from "@/test/components/UserContext.demo.svelte";
+import { describe, it, test, expect } from "vitest";
+
 import { canUploadFiles, isSignedIn } from "../permissions";
 
-test("isSignedIn", () => {
-  expect(isSignedIn()).toBe(false);
-  expect(isSignedIn(null)).toBe(false);
-  expect(isSignedIn(me)).toBe(true);
-});
+import { me } from "@/test/fixtures/accounts";
+import UserContextDemo from "@/test/components/UserContext.demo.svelte";
 
-test("canUploadFiles", () => {
-  const unauthorized = { ...me, verified_journalist: false, is_staff: false };
-  expect(canUploadFiles(unauthorized)).toBe(false);
-  expect(canUploadFiles({ ...unauthorized, verified_journalist: true })).toBe(
-    true,
-  );
-  expect(canUploadFiles({ ...unauthorized, is_staff: true })).toBe(true);
+describe("permission checks", () => {
+  test("isSignedIn", () => {
+    expect(isSignedIn()).toBe(false);
+    expect(isSignedIn(null)).toBe(false);
+    expect(isSignedIn(me)).toBe(true);
+  });
+
+  test("canUploadFiles", () => {
+    const unauthorized = { ...me, verified_journalist: false, is_staff: false };
+    expect(canUploadFiles(unauthorized)).toBe(false);
+    expect(canUploadFiles({ ...unauthorized, verified_journalist: true })).toBe(
+      true,
+    );
+    expect(canUploadFiles({ ...unauthorized, is_staff: true })).toBe(true);
+  });
 });
 
 // Test the getCurrentUser function

--- a/src/lib/utils/tests/permissions.test.ts
+++ b/src/lib/utils/tests/permissions.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, test, expect } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import { me } from "@/test/fixtures/accounts";
+import UserContextDemo from "@/test/components/UserContext.demo.svelte";
+import { canUploadFiles, isSignedIn } from "../permissions";
+
+test("isSignedIn", () => {
+  expect(isSignedIn()).toBe(false);
+  expect(isSignedIn(null)).toBe(false);
+  expect(isSignedIn(me)).toBe(true);
+});
+
+test("canUploadFiles", () => {
+  const unauthorized = { ...me, verified_journalist: false, is_staff: false };
+  expect(canUploadFiles(unauthorized)).toBe(false);
+  expect(canUploadFiles({ ...unauthorized, verified_journalist: true })).toBe(
+    true,
+  );
+  expect(canUploadFiles({ ...unauthorized, is_staff: true })).toBe(true);
+});
+
+// Test the getCurrentUser function
+describe("getCurrentUser", () => {
+  it("should return the current user from context", () => {
+    // Render the mock component to set the context
+    render(UserContextDemo);
+    expect(screen.getByText(me.name)).toBeInTheDocument();
+  });
+});

--- a/src/routes/(pages)/home/+page.svelte
+++ b/src/routes/(pages)/home/+page.svelte
@@ -1,9 +1,4 @@
 <script lang="ts">
-  // types
-  import type { Writable } from "svelte/store";
-  import type { User } from "@/api/types/orgAndUser.d.ts";
-
-  import { getContext } from "svelte";
   import { _ } from "svelte-i18n";
   import { page } from "$app/stores";
 
@@ -16,13 +11,14 @@
 
   // Authentication
   import { SIGN_IN_URL, SIGN_UP_URL, SIGN_OUT_URL } from "@/config/config.js";
+  import { getCurrentUser } from "@/lib/utils/permissions.js";
 
   // Show the login controls
   const showLogin = true;
 
   export let data;
 
-  const me: Writable<User> = getContext("me");
+  const me = getCurrentUser();
 </script>
 
 <svelte:head>

--- a/src/routes/add-ons/[owner]/[repo]/+page.svelte
+++ b/src/routes/add-ons/[owner]/[repo]/+page.svelte
@@ -1,17 +1,14 @@
 <script lang="ts">
-  import type { Writable } from "svelte/store";
-  import type { User } from "@/api/types/orgAndUser";
-
-  import { getContext } from "svelte";
   import { _ } from "svelte-i18n";
 
   import { isPremiumOrg, getCreditBalance } from "$lib/api/accounts";
   import AddOnLayout from "@/lib/components/layouts/AddOnLayout.svelte";
+  import { getCurrentUser } from "@/lib/utils/permissions.js";
 
   export let data;
   export let form;
 
-  const me: Writable<User> = getContext("me");
+  const me = getCurrentUser();
 
   $: addon = data.addon;
   $: query = data.query;

--- a/src/routes/add-ons/[owner]/[repo]/[event]/+page.svelte
+++ b/src/routes/add-ons/[owner]/[repo]/[event]/+page.svelte
@@ -1,18 +1,15 @@
 <script lang="ts">
-  import type { Writable } from "svelte/store";
-  import type { User } from "@/api/types/orgAndUser";
-
-  import { getContext } from "svelte";
   import { _ } from "svelte-i18n";
 
   import AddOnLayout from "@/lib/components/layouts/AddOnLayout.svelte";
 
   import { isPremiumOrg, getCreditBalance } from "$lib/api/accounts";
+  import { getCurrentUser } from "@/lib/utils/permissions.js";
 
   export let data;
   export let form;
 
-  const me: Writable<User> = getContext("me");
+  const me = getCurrentUser();
 
   $: event = data.event;
   $: addon = data.event.addon;

--- a/src/routes/documents/+page.svelte
+++ b/src/routes/documents/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { DocumentResults, User } from "$lib/api/types";
+  import type { DocumentResults } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
   import { PlusCircle16 } from "svelte-octicons";
@@ -16,13 +16,15 @@
   import DocumentBrowser from "@/lib/components/layouts/DocumentBrowser.svelte";
 
   import { deleted } from "$lib/api/documents";
-  import { canUploadFiles, isSignedIn } from "@/lib/utils/permissions";
-  import type { Writable } from "svelte/store";
-  import { getContext } from "svelte";
+  import {
+    canUploadFiles,
+    getCurrentUser,
+    isSignedIn,
+  } from "@/lib/utils/permissions";
 
   export let data;
 
-  const me: Writable<User> = getContext("me");
+  const me = getCurrentUser();
 
   $: searchResults =
     $deleted.size > 0

--- a/src/routes/documents/+page.svelte
+++ b/src/routes/documents/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { DocumentResults } from "$lib/api/types";
+  import type { DocumentResults, User } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
   import { PlusCircle16 } from "svelte-octicons";
@@ -16,8 +16,13 @@
   import DocumentBrowser from "@/lib/components/layouts/DocumentBrowser.svelte";
 
   import { deleted } from "$lib/api/documents";
+  import { canUploadFiles, isSignedIn } from "@/lib/utils/permissions";
+  import type { Writable } from "svelte/store";
+  import { getContext } from "svelte";
 
   export let data;
+
+  const me: Writable<User> = getContext("me");
 
   $: searchResults =
     $deleted.size > 0
@@ -54,12 +59,14 @@
   <DocumentBrowser slot="content" documents={searchResults} {query} {pending} />
 
   <svelte:fragment slot="action">
-    <SignedIn>
-      <Button mode="primary" href="/upload/">
-        <PlusCircle16 />{$_("sidebar.upload")}
-      </Button>
+    {#if isSignedIn($me)}
+      {#if canUploadFiles($me)}
+        <Button mode="primary" href="/upload/">
+          <PlusCircle16 />{$_("sidebar.upload")}
+        </Button>
+      {/if}
       <Actions />
       <AddOns pinnedAddOns={data.pinnedAddons} />
-    </SignedIn>
+    {/if}
   </svelte:fragment>
 </SidebarLayout>

--- a/src/routes/documents/sidebar/Documents.svelte
+++ b/src/routes/documents/sidebar/Documents.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { User, Org } from "@/api/types/orgAndUser";
+  import type { Org } from "@/api/types/orgAndUser";
   import type { Writable } from "svelte/store";
 
   import { getContext } from "svelte";
@@ -15,8 +15,9 @@
   import { APP_URL } from "@/config/config";
   import { slugify } from "@/util/string.js";
   import { userDocs } from "$lib/utils/search";
+  import { getCurrentUser } from "@/lib/utils/permissions";
 
-  const me: Writable<User> = getContext("me");
+  const me = getCurrentUser();
   const org: Writable<Org> = getContext("org");
 
   $: query = $page.url.searchParams.get("q") || "";

--- a/src/test/components/UserContext.demo.svelte
+++ b/src/test/components/UserContext.demo.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { setContext } from "svelte";
+  import { writable } from "svelte/store";
+  import { me } from "../fixtures/accounts";
+  import { getCurrentUser } from "@/lib/utils/permissions";
+
+  const mockUser = writable(me);
+  setContext("me", mockUser);
+
+  const user = getCurrentUser();
+</script>
+
+<p>{$user.name}</p>


### PR DESCRIPTION
- Adds utility functions for checking user permissions
- Adds a `getCurrentUser` helper that simplifies imports when getting `me` from context.
- Creates dedicated directory for storing our `*.demo.svelte` components.

This raises a design question: should we continue to use `<SignedIn>` and compose our permissions checks (expanding permission components to include `<CanUploadFiles>`), is an inline `{#if isSignedIn($me)}…{:else}…{/if}` a better approach, or are both valid?