### PR TITLE
Uses generics script attribute

### DIFF
--- a/src/lib/components/common/HighlightGroup.svelte
+++ b/src/lib/components/common/HighlightGroup.svelte
@@ -1,9 +1,7 @@
 <!-- @component A collection of highlights from search results.-->
 
-<script lang="ts">
+<script lang="ts" generics="H">
   import { _ } from "svelte-i18n";
-
-  type H = $$Generic;
 
   export let open = false;
   export let highlights: [string, H][] = [];


### PR DESCRIPTION
Based on the solution described in [this RFC](https://github.com/dummdidumm/rfcs/blob/ts-typedefs-within-svelte-components/text/ts-typing-props-slots-events.md#generics) and [this PR](https://github.com/sveltejs/language-tools/pull/2020), we should prefer defining generic types in a `generics` script tag attribute.
