### PR TITLE
Fix mobile viewer toolbars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "prettier-plugin-svelte": "^3.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "resize-observer-polyfill": "^1.5.1",
         "serve": "^14.2.0",
         "storybook": "7.6.10",
         "storybook-addon-cookie": "^3.2.0",
@@ -25443,6 +25444,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "license": "MIT"
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "storybook-addon-cookie": "^3.2.0",
         "storybook-mock-date-decorator": "^1.0.1",
         "svelte-check": "^3.6.0",
+        "svelte-fast-dimension": "^1.1.0",
         "vite": "^5.2.13",
         "vitest": "^1.6.0"
       }
@@ -26702,6 +26703,22 @@
         "svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0 || ^5.0.0-next.0"
       }
     },
+    "node_modules/svelte-fast-dimension": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/svelte-fast-dimension/-/svelte-fast-dimension-1.1.0.tgz",
+      "integrity": "sha512-TsuRGa2B6iLXns8Jp2XORyZG1LlWVV9d4NeQgjpPvgosmOElDpDSf6rE/GS6NCEp4K31q8K2MltoePCcY7kMqg==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.0",
+        "svelte-parse-markup": "^0.1.2"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      },
+      "peerDependencies": {
+        "svelte": "^3.44.1 || ^4.0.0"
+      }
+    },
     "node_modules/svelte-floating-ui": {
       "version": "1.5.8",
       "resolved": "https://registry.npmjs.org/svelte-floating-ui/-/svelte-floating-ui-1.5.8.tgz",
@@ -27165,6 +27182,18 @@
       "resolved": "https://registry.npmjs.org/svelte-octicons/-/svelte-octicons-18.9.0.tgz",
       "integrity": "sha512-d/J3Jcfw3iMwV8/4aq0tej4nrWyMGqXIobZHSV0UAMOsD3UfDG7fSsdc+4lT7kJPBwrdaxoAZNIbR/v64KQqAQ==",
       "license": "MIT"
+    },
+    "node_modules/svelte-parse-markup": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/svelte-parse-markup/-/svelte-parse-markup-0.1.5.tgz",
+      "integrity": "sha512-T6mqZrySltPCDwfKXWQ6zehipVLk4GWfH1zCMGgRtLlOIFPuw58ZxVYxVvotMJgJaurKi1i14viB2GIRKXeJTQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      },
+      "peerDependencies": {
+        "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0-next.1"
+      }
     },
     "node_modules/svelte-preprocess": {
       "version": "5.1.4",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "prettier-plugin-svelte": "^3.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "resize-observer-polyfill": "^1.5.1",
     "serve": "^14.2.0",
     "storybook": "7.6.10",
     "storybook-addon-cookie": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "storybook-addon-cookie": "^3.2.0",
     "storybook-mock-date-decorator": "^1.0.1",
     "svelte-check": "^3.6.0",
+    "svelte-fast-dimension": "^1.1.0",
     "vite": "^5.2.13",
     "vitest": "^1.6.0"
   },

--- a/src/common/Dropdown2.svelte
+++ b/src/common/Dropdown2.svelte
@@ -130,8 +130,6 @@
     position: relative;
     display: flex;
     align-items: center;
-  }
-  .dropdownContainer.open {
     z-index: var(--z-dropdown);
   }
   .title {
@@ -209,6 +207,7 @@
       left: 0;
       right: 0;
       width: 100vw;
+      z-index: var(--z-dropdown);
     }
   }
 </style>

--- a/src/lib/components/accounts/tests/__snapshots__/UserMenu.test.ts.snap
+++ b/src/lib/components/accounts/tests/__snapshots__/UserMenu.test.ts.snap
@@ -4,11 +4,11 @@ exports[`UserMenu 1`] = `
 <div>
    
   <div
-    class="dropdownContainer svelte-1w62t89"
+    class="dropdownContainer svelte-1oyth"
     id="user-menu"
   >
     <div
-      class="title primary svelte-1w62t89"
+      class="title primary svelte-1oyth"
       role="button"
       tabindex="0"
     >
@@ -60,7 +60,7 @@ exports[`UserMenu 1`] = `
     </div>
      
     <div
-      class="dropdown svelte-1w62t89 bottom right"
+      class="dropdown svelte-1oyth bottom right"
     >
       <div
         class="menu svelte-18fuj21"

--- a/src/lib/components/common/PageToolbar.svelte
+++ b/src/lib/components/common/PageToolbar.svelte
@@ -29,12 +29,14 @@
   .toolbar {
     display: flex;
     width: 100%;
+    position: unset;
   }
 
   .left,
   .center,
   .right {
     flex: 1 0 0;
+    min-width: 0;
   }
 
   .left {

--- a/src/lib/components/documents/toolbars/ReadingToolbar.svelte
+++ b/src/lib/components/documents/toolbars/ReadingToolbar.svelte
@@ -128,7 +128,7 @@
       {/each}
     {/if}
     {#if BREAKPOINTS.SEARCH_MENU}
-      <Dropdown2 id="document-search" position="top left">
+      <Dropdown2 id="document-search" position="bottom right">
         <Button minW={false} ghost slot="title"
           ><Search16 /> {$_("common.search")}</Button
         >

--- a/src/lib/components/documents/toolbars/ReadingToolbar.svelte
+++ b/src/lib/components/documents/toolbars/ReadingToolbar.svelte
@@ -18,6 +18,7 @@
     Apps16,
     Note16,
     ChevronDown12,
+    Search16,
   } from "svelte-octicons";
 
   import Button from "$lib/components/common/Button.svelte";
@@ -45,6 +46,7 @@
   $: BREAKPOINTS = {
     READ_MENU: width > remToPx(52),
     WRITE_MENU: width < remToPx(37),
+    SEARCH_MENU: width < remToPx(24),
   };
 
   const readModes: Map<ReadMode, string> = new Map([
@@ -125,7 +127,18 @@
         </Button>
       {/each}
     {/if}
-    <Search name="q" {query} />
+    {#if BREAKPOINTS.SEARCH_MENU}
+      <Dropdown2 id="document-search" position="top left">
+        <Button minW={false} ghost slot="title"
+          ><Search16 /> {$_("common.search")}</Button
+        >
+        <Menu>
+          <Search name="q" {query} />
+        </Menu>
+      </Dropdown2>
+    {:else}
+      <Search name="q" {query} />
+    {/if}
   </Flex>
 </PageToolbar>
 

--- a/src/lib/components/forms/Search.svelte
+++ b/src/lib/components/forms/Search.svelte
@@ -63,6 +63,7 @@
     appearance: none;
     padding: 0.25rem;
     border: none;
+    background: var(--white);
     font-family: var(--font-sans, "Source Sans Pro");
     font-weight: var(--font-regular, 400);
     font-size: var(--font-md, 1rem);

--- a/src/style/kit.css
+++ b/src/style/kit.css
@@ -92,11 +92,11 @@ Updated variables and styles for new SvelteKit routes
 
   /* Z-Index Layers */
   --z-toolbar: 2;
-  --z-dropdownBackdrop: 4;
-  --z-dropdown: 5;
   --z-navigation: 7;
   --z-drawer: 9;
   --z-modal: 10;
+  --z-dropdownBackdrop: 11;
+  --z-dropdown: 12;
   --z-toast: 20;
 }
 
@@ -228,5 +228,4 @@ hr.divider {
   border: 1px solid var(--gray-2, #d8dee2);
   box-shadow: var(--shadow-2);
   background: var(--white);
-  z-index: var(--z-toolbar);
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,6 +3,7 @@ import url from "node:url";
 
 import adapter from "@sveltejs/adapter-netlify";
 import sveltePreprocess from "svelte-preprocess";
+import { fastDimension } from "svelte-fast-dimension";
 import autoprefixer from "autoprefixer";
 
 const __filename = url.fileURLToPath(import.meta.url);
@@ -41,23 +42,26 @@ export default {
 
   // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
   // for more information about preprocessors
-  preprocess: sveltePreprocess({
-    scss: {
-      includePaths: ["./src"],
-      importer: [
-        scssAliases({
-          "@": path.resolve(__dirname, "src"),
-        }),
-      ],
-      prependData: '@import "@/style/variables.scss";',
-    },
-    postcss: {
-      plugins: [autoprefixer],
-    },
-    typescript: {
-      compilerOptions: {
-        target: "es2020",
+  preprocess: [
+    fastDimension(),
+    sveltePreprocess({
+      scss: {
+        includePaths: ["./src"],
+        importer: [
+          scssAliases({
+            "@": path.resolve(__dirname, "src"),
+          }),
+        ],
+        prependData: '@import "@/style/variables.scss";',
       },
-    },
-  }),
+      postcss: {
+        plugins: [autoprefixer],
+      },
+      typescript: {
+        compilerOptions: {
+          target: "es2020",
+        },
+      },
+    }),
+  ],
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,6 +37,7 @@ export default defineConfig({
     esbuildOptions: {
       target: "esnext",
     },
+    include: ["svelte-fast-dimension/action"],
   },
 
   resolve: {

--- a/vitest-setup.js
+++ b/vitest-setup.js
@@ -1,3 +1,8 @@
 import "@testing-library/svelte/vitest";
 import "@testing-library/jest-dom/vitest";
 import "./src/lib/i18n/index.js";
+
+import { vi } from "vitest";
+import ResizeObserver from "resize-observer-polyfill";
+
+vi.stubGlobal("ResizeObserver", ResizeObserver);


### PR DESCRIPTION
This adds responsive logic for the viewer's search input, disclosing it inside a dropdown when on mobile. This prevents the viewer's top toolbar from overflowing the viewport at narrow screen widths.

In addition, this adds a preprocessor to modify the behavior of `bind:clientWidth`. [The default behavior adds `style="position: relative"`](https://github.com/sveltejs/svelte/issues/4776), which is undesirable for our toolbars, which rely on definite placement within the stacking context for correct menu behavior and sticky positioning. This preprocessor also uses a more performant method of binding to clientWidth by using `ResizeObserver` instead of `iframe` hackery. This might be fixed in Svelte 5.