### PR TITLE
Project layout

### DIFF
--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -960,7 +960,8 @@
     "addons": {
       "title": "Add-Ons",
       "pinned": "Pinned add-ons will appear here",
-      "runs": "Schedule & history"
+      "runs": "Schedule & history",
+      "documents": "This add-on runs on documents"
     },
     "data": {
       "title": "Tags & Data",

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -713,7 +713,10 @@
     "add": "Add {n, plural, one {this document} other {# documents}} to a project",
     "access": {
       "public": "Public",
-      "private": "Private"
+      "private": "Private",
+      "admin": "Admin",
+      "edit": "Editor",
+      "view": "Viewer"
     },
     "delete": {
       "action": "Delete project",
@@ -726,6 +729,7 @@
     },
     "collaborators": {
       "title": "Collaborators",
+      "edit": "Manage",
       "manage": "Change access",
       "empty": "No collaborators",
       "add": "Invite users to this project"

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -1212,11 +1212,14 @@
     "page": "Page",
     "note": "Note",
     "copy": "Copy",
+    "copiedToClipboard": "Copied to clipboard",
     "permalink": "Permalink",
     "iframe": "Embed HTML iFrame",
     "preview": "Embed Preview",
     "save": "Save Settings",
     "customize": "Customize Embed",
+    "privateWarning": "This {type} is private.",
+    "privateFix": "Edit metadata",
     "fields": {
       "page": "Pick page",
       "note": "Pick note"

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -711,6 +711,10 @@
     "share": "Share & embed this project",
     "users": "Manage Collaborators",
     "add": "Add {n, plural, one {this document} other {# documents}} to a project",
+    "access": {
+      "public": "Public",
+      "private": "Private"
+    },
     "delete": {
       "action": "Delete project",
       "confirm": "Confirm delete",

--- a/src/lib/api/accounts.ts
+++ b/src/lib/api/accounts.ts
@@ -96,7 +96,11 @@ export async function setOrg(
   return resp.json();
 }
 
-export function getUpgradeUrl(org: Org = null): URL {
+export function getUserName(user: User): string {
+  return user.name ?? user.username;
+}
+
+export function getUpgradeUrl(org: Nullable<Org> = null): URL {
   if (!org || org.individual) {
     // Redirect the user to their Squarelet account settings
     return new URL("/users/~payment/", SQUARELET_BASE);
@@ -121,7 +125,7 @@ export function isPremiumOrg(org: Org): boolean {
 
 export function getCreditBalance(org: Org): number | null {
   if (!org) return null;
-  return org.monthly_credits + org.purchased_credits;
+  return (org.monthly_credits ?? 0) + (org.purchased_credits ?? 0);
 }
 
 export async function createMailkey(

--- a/src/lib/api/projects.ts
+++ b/src/lib/api/projects.ts
@@ -360,3 +360,7 @@ export async function documents(
 export function canonicalUrl(project: Project): URL {
   return new URL(`documents/projects/${project.id}-${project.slug}/`, APP_URL);
 }
+
+export function embedUrl(project: Project): URL {
+  return new URL(`embed/projects/${project.id}/?embed=1`, APP_URL);
+}

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -7,10 +7,10 @@
 
 import type { User, Org } from "@/api/types/orgAndUser";
 import type { Project } from "@/api/types/project";
-import type { Page } from "@/api/types/common";
+import type { Page, Maybe, Nullable } from "@/api/types/common";
 
 // re-export these for convenience
-export type { Page, User, Org, Project };
+export type { Maybe, Nullable, Page, User, Org, Project };
 
 export type Access = "public" | "private" | "organization"; // https://www.documentcloud.org/help/api#access-levels
 

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -49,11 +49,14 @@ type AddOnCategory = "premium" | string;
 
 interface AddOnProperty {
   type: string;
-  title: string;
+  title?: string;
   description?: string;
-  default?: string;
+  default?: string | string[] | number;
   format?: string;
-  enum?: string[];
+  enum?: (string | boolean)[];
+  items?: AddOnProperty;
+  maximum?: number;
+  minimum?: number;
 }
 
 interface AddOnParameters {
@@ -68,11 +71,11 @@ interface AddOnParameters {
   properties: Record<string, AddOnProperty>;
   cost: {
     amount: number;
-    price: number;
+    price?: number;
     unit: string;
   };
   eventOptions: {
-    name: string;
+    name?: string;
     events: string[];
   };
 }

--- a/src/lib/components/accounts/tests/__snapshots__/Mailkey.test.ts.snap
+++ b/src/lib/components/accounts/tests/__snapshots__/Mailkey.test.ts.snap
@@ -12,7 +12,7 @@ exports[`Mailkey 1`] = `
         class="svelte-65lbzd"
       >
         <button
-          class="primary normal svelte-164ighu ghost"
+          class="primary normal svelte-1v0zkv ghost"
           title=""
           type="button"
           value="undefined"
@@ -75,7 +75,7 @@ exports[`Mailkey 1`] = `
           style="display: flex; flex-direction: row; flex-wrap: wrap; align-items: stretch; justify-content: center; gap: 1rem;"
         >
           <button
-            class="primary normal svelte-164ighu minW"
+            class="primary normal svelte-1v0zkv minW"
             title=""
             type="button"
             value="undefined"
@@ -85,7 +85,7 @@ exports[`Mailkey 1`] = `
           
            
           <button
-            class="danger normal svelte-164ighu minW"
+            class="danger normal svelte-1v0zkv minW"
             title=""
             type="button"
             value="undefined"
@@ -112,7 +112,7 @@ exports[`Mailkey 2`] = `
         class="svelte-65lbzd"
       >
         <button
-          class="primary normal svelte-164ighu ghost"
+          class="primary normal svelte-1v0zkv ghost"
           title=""
           type="button"
           value="undefined"
@@ -180,7 +180,7 @@ exports[`Mailkey 2`] = `
           style="display: flex; flex-direction: row; flex-wrap: wrap; align-items: stretch; justify-content: center; gap: 1rem;"
         >
           <button
-            class="primary normal svelte-164ighu minW"
+            class="primary normal svelte-1v0zkv minW"
             title=""
             type="button"
             value="undefined"
@@ -190,7 +190,7 @@ exports[`Mailkey 2`] = `
           
            
           <button
-            class="danger normal svelte-164ighu minW"
+            class="danger normal svelte-1v0zkv minW"
             title=""
             type="button"
             value="undefined"

--- a/src/lib/components/accounts/tests/__snapshots__/UserMenu.test.ts.snap
+++ b/src/lib/components/accounts/tests/__snapshots__/UserMenu.test.ts.snap
@@ -13,7 +13,7 @@ exports[`UserMenu 1`] = `
       tabindex="0"
     >
       <span
-        class="sidebarItem container svelte-xb9fwu"
+        class="sidebarItem container svelte-1i964q1"
         role="button"
         tabindex="0"
         title="Open Menu"
@@ -30,7 +30,7 @@ exports[`UserMenu 1`] = `
         </div>
          
         <span
-          class="label svelte-xb9fwu"
+          class="label svelte-1i964q1"
         >
           <span
             class="name"
@@ -68,7 +68,7 @@ exports[`UserMenu 1`] = `
         role="menu"
       >
         <a
-          class="sidebarItem container svelte-xb9fwu"
+          class="sidebarItem container svelte-1i964q1"
           href="https://dev.squarelet.com"
           target="_blank"
           title=""
@@ -87,7 +87,7 @@ exports[`UserMenu 1`] = `
           </svg>
            
           <span
-            class="label svelte-xb9fwu"
+            class="label svelte-1i964q1"
           >
             Account settings
           </span>
@@ -96,7 +96,7 @@ exports[`UserMenu 1`] = `
         
          
         <span
-          class="sidebarItem container svelte-xb9fwu hover"
+          class="sidebarItem container svelte-1i964q1 hover"
           role="button"
           tabindex="0"
           title=""
@@ -115,7 +115,7 @@ exports[`UserMenu 1`] = `
           </svg>
            
           <span
-            class="label svelte-xb9fwu"
+            class="label svelte-1i964q1"
           >
             Upload via email
           </span>
@@ -124,7 +124,7 @@ exports[`UserMenu 1`] = `
         
          
         <a
-          class="sidebarItem container svelte-xb9fwu"
+          class="sidebarItem container svelte-1i964q1"
           href="https://api.dev.documentcloud.org/accounts/logout/"
           title=""
         >
@@ -142,7 +142,7 @@ exports[`UserMenu 1`] = `
           </svg>
            
           <span
-            class="label svelte-xb9fwu"
+            class="label svelte-1i964q1"
           >
             Sign out
           </span>

--- a/src/lib/components/addons/tests/__snapshots__/AddOnsNavigation.test.ts.snap
+++ b/src/lib/components/addons/tests/__snapshots__/AddOnsNavigation.test.ts.snap
@@ -24,7 +24,7 @@ exports[`AddOnsNavigation 1`] = `
         style="display: contents; --hover-background: var(--blue-2);"
       >
         <a
-          class="sidebarItem container svelte-xb9fwu active"
+          class="sidebarItem container svelte-1i964q1 active"
           href="/add-ons/"
           title=""
         >
@@ -43,7 +43,7 @@ exports[`AddOnsNavigation 1`] = `
           </svg>
            
           <span
-            class="label svelte-xb9fwu"
+            class="label svelte-1i964q1"
           >
             All
           </span>
@@ -56,7 +56,7 @@ exports[`AddOnsNavigation 1`] = `
         style="display: contents; --hover-background: var(--orange-2);"
       >
         <a
-          class="sidebarItem container svelte-xb9fwu"
+          class="sidebarItem container svelte-1i964q1"
           href="/add-ons/?active=true"
           title=""
         >
@@ -80,7 +80,7 @@ exports[`AddOnsNavigation 1`] = `
           </div>
            
           <span
-            class="label svelte-xb9fwu"
+            class="label svelte-1i964q1"
           >
             Pinned
           </span>
@@ -93,7 +93,7 @@ exports[`AddOnsNavigation 1`] = `
         style="display: contents; --hover-background: var(--yellow-2);"
       >
         <a
-          class="sidebarItem container svelte-xb9fwu"
+          class="sidebarItem container svelte-1i964q1"
           href="/add-ons/?featured=true"
           title=""
         >
@@ -112,7 +112,7 @@ exports[`AddOnsNavigation 1`] = `
           </svg>
            
           <span
-            class="label svelte-xb9fwu"
+            class="label svelte-1i964q1"
           >
             Featured
           </span>
@@ -125,7 +125,7 @@ exports[`AddOnsNavigation 1`] = `
         style="display: contents; --hover-background: var(--green-2);"
       >
         <a
-          class="sidebarItem container svelte-xb9fwu"
+          class="sidebarItem container svelte-1i964q1"
           href="/add-ons/?premium=true"
           title=""
         >
@@ -155,7 +155,7 @@ exports[`AddOnsNavigation 1`] = `
           </div>
            
           <span
-            class="label svelte-xb9fwu"
+            class="label svelte-1i964q1"
           >
             Premium
           </span>
@@ -172,14 +172,14 @@ exports[`AddOnsNavigation 1`] = `
         style="display: contents; --color: var(--gray-4);"
       >
         <span
-          class="sidebarItem container svelte-xb9fwu small"
+          class="sidebarItem container svelte-1i964q1 small"
           role="button"
           tabindex="0"
           title=""
         >
            
           <span
-            class="label svelte-xb9fwu"
+            class="label svelte-1i964q1"
           >
             Collections
           </span>
@@ -189,13 +189,13 @@ exports[`AddOnsNavigation 1`] = `
       </div>
        
       <a
-        class="sidebarItem container svelte-xb9fwu"
+        class="sidebarItem container svelte-1i964q1"
         href="/add-ons/?category=ai"
         title=""
       >
          
         <span
-          class="label svelte-xb9fwu"
+          class="label svelte-1i964q1"
         >
           AI
            
@@ -204,13 +204,13 @@ exports[`AddOnsNavigation 1`] = `
       </a>
       
       <a
-        class="sidebarItem container svelte-xb9fwu"
+        class="sidebarItem container svelte-1i964q1"
         href="/add-ons/?category=statistical"
         title=""
       >
          
         <span
-          class="label svelte-xb9fwu"
+          class="label svelte-1i964q1"
         >
           Analyze
            
@@ -219,13 +219,13 @@ exports[`AddOnsNavigation 1`] = `
       </a>
       
       <a
-        class="sidebarItem container svelte-xb9fwu"
+        class="sidebarItem container svelte-1i964q1"
         href="/add-ons/?category=bulk"
         title=""
       >
          
         <span
-          class="label svelte-xb9fwu"
+          class="label svelte-1i964q1"
         >
           Bulk
            
@@ -234,13 +234,13 @@ exports[`AddOnsNavigation 1`] = `
       </a>
       
       <a
-        class="sidebarItem container svelte-xb9fwu"
+        class="sidebarItem container svelte-1i964q1"
         href="/add-ons/?category=export"
         title=""
       >
          
         <span
-          class="label svelte-xb9fwu"
+          class="label svelte-1i964q1"
         >
           Export
            
@@ -249,13 +249,13 @@ exports[`AddOnsNavigation 1`] = `
       </a>
       
       <a
-        class="sidebarItem container svelte-xb9fwu"
+        class="sidebarItem container svelte-1i964q1"
         href="/add-ons/?category=extraction"
         title=""
       >
          
         <span
-          class="label svelte-xb9fwu"
+          class="label svelte-1i964q1"
         >
           Extract
            
@@ -264,13 +264,13 @@ exports[`AddOnsNavigation 1`] = `
       </a>
       
       <a
-        class="sidebarItem container svelte-xb9fwu"
+        class="sidebarItem container svelte-1i964q1"
         href="/add-ons/?category=file"
         title=""
       >
          
         <span
-          class="label svelte-xb9fwu"
+          class="label svelte-1i964q1"
         >
           File
            
@@ -279,13 +279,13 @@ exports[`AddOnsNavigation 1`] = `
       </a>
       
       <a
-        class="sidebarItem container svelte-xb9fwu"
+        class="sidebarItem container svelte-1i964q1"
         href="/add-ons/?category=monitor"
         title=""
       >
          
         <span
-          class="label svelte-xb9fwu"
+          class="label svelte-1i964q1"
         >
           Monitor
            

--- a/src/lib/components/common/AddOns.svelte
+++ b/src/lib/components/common/AddOns.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
+  import { APP_URL } from "@/config/config";
   import type { Page } from "@/api/types/common";
   import type { AddOnListItem } from "@/addons/types";
 
-  import { Book16, Hourglass24, Pin24, Plug16 } from "svelte-octicons";
+  import {
+    Book16,
+    Hourglass24,
+    Pin24,
+    Plug16,
+    FileCode16,
+  } from "svelte-octicons";
   import { _ } from "svelte-i18n";
 
   import Action from "$lib/components/common/Action.svelte";
@@ -11,15 +18,31 @@
   import SidebarItem from "$lib/components/sidebar/SidebarItem.svelte";
   import SidebarGroup from "$lib/components/sidebar/SidebarGroup.svelte";
   import Pin from "@/common/Pin.svelte";
+  import Error from "./Error.svelte";
+  import Tooltip from "@/common/Tooltip.svelte";
 
   export let pinnedAddOns: Promise<Page<AddOnListItem>>;
+  export let query: string = "";
+
+  function getHref(query: string, addon?: AddOnListItem): string {
+    let path = "/add-ons/";
+    if (addon) {
+      path += `${addon.repository}/`;
+    }
+    let url = new URL(path, APP_URL);
+    // We only see the browser on addons that process documents
+    if (addon?.parameters.documents) {
+      url.searchParams.set("q", query);
+    }
+    return url.toString();
+  }
 </script>
 
 <SidebarGroup name="addons">
   <SidebarItem slot="title"
     ><Plug16 slot="start" />{$_("sidebar.addons.title")}</SidebarItem
   >
-  <a href="/add-ons/" slot="action">
+  <a href={getHref(query)} slot="action">
     <Action icon={Book16}>{$_("common.explore")}</Action>
   </a>
   <Flex direction="column" gap={0}>
@@ -27,13 +50,22 @@
       <Empty icon={Hourglass24}>{$_("common.loading")}</Empty>
     {:then addons}
       {#each addons.results as addon}
-        <SidebarItem small href="/add-ons/{addon.repository}/">
+        <SidebarItem small href={getHref(query, addon)}>
           <Pin active={addon.active} slot="start" />
           {addon.name}
+          <svelte:fragment slot="end">
+            {#if addon.parameters.documents}
+              <Tooltip caption={$_("sidebar.addons.documents")}>
+                <FileCode16 />
+              </Tooltip>
+            {/if}
+          </svelte:fragment>
         </SidebarItem>
       {:else}
         <Empty icon={Pin24}>{$_("sidebar.addons.pinned")}</Empty>
       {/each}
+    {:catch error}
+      <Error>{error}</Error>
     {/await}
     <!-- not using this route, for the moment
       <SidebarItem>

--- a/src/lib/components/common/AddOns.svelte
+++ b/src/lib/components/common/AddOns.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { APP_URL } from "@/config/config";
+  import type { APIResponse } from "@/lib/api/types";
   import type { Page } from "@/api/types/common";
   import type { AddOnListItem } from "@/addons/types";
 
@@ -21,7 +22,7 @@
   import Error from "./Error.svelte";
   import Tooltip from "@/common/Tooltip.svelte";
 
-  export let pinnedAddOns: Promise<Page<AddOnListItem>>;
+  export let pinnedAddOns: Promise<APIResponse<Page<AddOnListItem>>>;
   export let query: string = "";
 
   function getHref(query: string, addon?: AddOnListItem): string {
@@ -48,22 +49,26 @@
   <Flex direction="column" gap={0}>
     {#await pinnedAddOns}
       <Empty icon={Hourglass24}>{$_("common.loading")}</Empty>
-    {:then addons}
-      {#each addons.results as addon}
-        <SidebarItem small href={getHref(query, addon)}>
-          <Pin active={addon.active} slot="start" />
-          {addon.name}
-          <svelte:fragment slot="end">
-            {#if addon.parameters.documents}
-              <Tooltip caption={$_("sidebar.addons.documents")}>
-                <FileCode16 />
-              </Tooltip>
-            {/if}
-          </svelte:fragment>
-        </SidebarItem>
+    {:then { data, error }}
+      {#if error}
+        <Error>{error.message}</Error>
       {:else}
-        <Empty icon={Pin24}>{$_("sidebar.addons.pinned")}</Empty>
-      {/each}
+        {#each data.results as addon}
+          <SidebarItem small href={getHref(query, addon)}>
+            <Pin active={addon.active} slot="start" />
+            {addon.name}
+            <svelte:fragment slot="end">
+              {#if addon.parameters.documents}
+                <Tooltip caption={$_("sidebar.addons.documents")}>
+                  <FileCode16 />
+                </Tooltip>
+              {/if}
+            </svelte:fragment>
+          </SidebarItem>
+        {:else}
+          <Empty icon={Pin24}>{$_("sidebar.addons.pinned")}</Empty>
+        {/each}
+      {/if}
     {:catch error}
       <Error>{error}</Error>
     {/await}

--- a/src/lib/components/common/Button.svelte
+++ b/src/lib/components/common/Button.svelte
@@ -150,7 +150,15 @@
   .small {
     font-size: var(--font-sm, 0.875rem);
     padding: 0.25rem 0.5rem;
+    box-shadow: inset var(--shadow-3);
+  }
+
+  .small:hover {
     box-shadow: none;
+  }
+
+  .small.danger {
+    border-color: var(--orange-3);
   }
 
   @media (hover: none) {

--- a/src/lib/components/common/Button.svelte
+++ b/src/lib/components/common/Button.svelte
@@ -175,6 +175,7 @@
 
   .full {
     display: flex;
+    width: 100%;
   }
 
   .minW {

--- a/src/lib/components/common/Tip.svelte
+++ b/src/lib/components/common/Tip.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
-  import { LightBulb16 } from "svelte-octicons";
-  import Flex from "./Flex.svelte";
+  import { LightBulb24 } from "svelte-octicons";
+
+  export let mode: "normal" | "primary" | "premium" | "danger" = "normal";
 </script>
 
-<aside class="tip">
-  <div class="icon"><slot name="icon"><LightBulb16 /></slot></div>
-  <Flex direction="column" justify="center">
+<aside class="tip {mode}">
+  <div class="icon"><slot name="icon"><LightBulb24 /></slot></div>
+  <div class="inner">
     <slot />
-  </Flex>
+  </div>
 </aside>
 
 <style>
@@ -20,10 +21,45 @@
     fill: var(--fill, var(--gray-4, #5c717c));
     background-color: var(--background-color, var(--gray-1, #f5f6f7));
     border: 1px solid var(--border-color, var(--gray-3, #99a8b3));
-    box-shadow: var(--shadow-1);
+
+    font-weight: var(--font-semibold);
   }
   .icon {
     display: flex;
     align-items: center;
+  }
+  .inner {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  .tip.normal {
+    color: var(--yellow-5);
+    fill: var(--yellow-4);
+    background-color: var(--yellow-3);
+    border-color: var(--yellow-2);
+    background: var(--yellow-1);
+  }
+  .tip.primary {
+    color: var(--blue-5);
+    fill: var(--blue-3);
+    background-color: var(--blue-3);
+    border-color: var(--blue-2);
+    background: var(--blue-1);
+  }
+  .tip.premium {
+    color: var(--green-5);
+    fill: var(--green-3);
+    background-color: var(--green-3);
+    border-color: var(--green-2);
+    background: var(--green-1);
+  }
+  .tip.danger {
+    color: var(--orange-5);
+    fill: var(--orange-3);
+    background-color: var(--orange-3);
+    border-color: var(--orange-2);
+    background: var(--orange-1);
   }
 </style>

--- a/src/lib/components/common/stories/AddOns.stories.svelte
+++ b/src/lib/components/common/stories/AddOns.stories.svelte
@@ -1,0 +1,31 @@
+<script lang="ts" context="module">
+  import { activeAddons } from "@/test/fixtures/addons";
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+  import AddOns from "../AddOns.svelte";
+  import type { Meta } from "@storybook/svelte";
+
+  export const meta: Meta = {
+    title: "Components / Common / Add-Ons",
+    component: AddOns,
+    parameters: { layout: "centered" },
+  };
+
+  let args = {
+    pinnedAddOns: Promise.resolve(activeAddons),
+  };
+</script>
+
+<Template let:args>
+  <AddOns {...args} />
+</Template>
+
+<Story
+  name="Empty"
+  args={{ pinnedAddOns: Promise.resolve({ results: [], count: 0 }) }}
+/>
+<Story name="Loading" args={{ pinnedAddOns: new Promise(() => {}) }} />
+<Story name="With Data" {args} />
+<Story
+  name="With Error"
+  args={{ pinnedAddOns: Promise.reject("Something went wrong") }}
+/>

--- a/src/lib/components/common/stories/Tip.stories.svelte
+++ b/src/lib/components/common/stories/Tip.stories.svelte
@@ -3,7 +3,8 @@
   import Tip from "../Tip.svelte";
   import Pin from "@/common/icons/Pin.svelte";
   import Premium from "@/common/icons/Premium.svelte";
-  import { Info16 } from "svelte-octicons";
+  import { Info24, Alert24 } from "svelte-octicons";
+  import Flex from "../Flex.svelte";
 
   export const meta = {
     title: "Components / Common / Tip",
@@ -11,32 +12,44 @@
     tags: ["autodocs"],
     parameters: { layout: "centered" },
   };
+
+  let args = {
+    mode: "normal",
+  };
 </script>
 
-<Story name="Basic">
-  <Tip>All dogs go to heaven</Tip>
+<Story name="Basic" let:args>
+  <Tip {...args}>All dogs go to heaven</Tip>
 </Story>
 
-<Story name="With Icon">
-  <Tip>
+<Story name="With Icon" let:args>
+  <Tip {...args}>
     <Pin slot="icon" />
     Pinned items will appear here.
   </Tip>
 </Story>
 
-<Story name="With Colors">
-  <Tip
-    --fill="var(--green-4)"
-    --background-color="var(--green-2)"
-    --border-color="var(--green-3)"
-  >
-    <Premium slot="icon" />
-    This feature is for premium users.
-  </Tip>
+<Story name="Modes" let:args>
+  <Flex direction="column" gap={2}>
+    <Tip {...args} mode="normal">This is a helpful tip.</Tip>
+    <Tip {...args} mode="primary">
+      <Info24 slot="icon" />
+      I am important!
+    </Tip>
+    <Tip {...args} mode="premium">
+      <Premium size={1.75} slot="icon" />
+      This feature is for premium users.
+    </Tip>
+    <Tip {...args} mode="danger">
+      <Alert24 slot="icon" />
+      Watch out ahead!
+    </Tip>
+  </Flex>
 </Story>
 
-<Story name="With Large Icon">
+<Story name="With Large Icon" let:args>
   <Tip
+    {...args}
     --color="var(--blue-5)"
     --fill="var(--blue-4)"
     --background-color="var(--blue-1)"

--- a/src/lib/components/common/stories/Tip.stories.svelte
+++ b/src/lib/components/common/stories/Tip.stories.svelte
@@ -55,7 +55,7 @@
     --background-color="var(--blue-1)"
     --border-color="var(--blue-3)"
   >
-    <Info16 height="32" width="32" slot="icon" />
+    <Info24 height="32" width="32" slot="icon" />
     Learn about all the interesting facts
   </Tip>
 </Story>

--- a/src/lib/components/documents/Share.svelte
+++ b/src/lib/components/documents/Share.svelte
@@ -36,6 +36,7 @@
     pageUrl,
   } from "@/lib/api/documents";
   import { canonicalNoteUrl, noteUrl } from "@/lib/api/notes";
+  import { toast } from "../layouts/Toaster.svelte";
 
   export let document: Document;
   export let page: number = 1;
@@ -110,6 +111,7 @@
 
   async function copy(text: string) {
     await navigator.clipboard.writeText(text);
+    toast($_("share.copiedToClipboard"));
   }
 </script>
 

--- a/src/lib/components/documents/sidebar/Notes.svelte
+++ b/src/lib/components/documents/sidebar/Notes.svelte
@@ -29,7 +29,7 @@
       <li>
         <SidebarItem href={noteUrl(document, note).href} small>
           <span class="note_title">{note.title}</span>
-          <span class="page_number">
+          <span class="page_number" slot="start">
             {$_("sidebar.toc.pageAbbrev")}
             {note.page_number + 1}
           </span>

--- a/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
+++ b/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
@@ -52,7 +52,7 @@ exports[`DocumentListItem > renders 1`] = `
             style="display: contents; --color: var(--gray-5); --font-size: inherit;"
           >
             <span
-              class="sidebarItem container svelte-xb9fwu inline"
+              class="sidebarItem container svelte-1i964q1 inline"
               role="button"
               tabindex="0"
               title="Documents will be publicly visible to everyone"
@@ -72,7 +72,7 @@ exports[`DocumentListItem > renders 1`] = `
               
                
               <span
-                class="label svelte-xb9fwu"
+                class="label svelte-1i964q1"
               >
                 Public
               </span>

--- a/src/lib/components/layouts/DocumentBrowser.svelte
+++ b/src/lib/components/layouts/DocumentBrowser.svelte
@@ -197,7 +197,7 @@
 <style>
   .container {
     width: 100%;
-    height: auto;
+    height: 100%;
   }
 
   label.select-all {

--- a/src/lib/components/layouts/DocumentLayout.svelte
+++ b/src/lib/components/layouts/DocumentLayout.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import type { Document, DocumentText, Project } from "$lib/api/types";
+  import type {
+    AddOnListItem,
+    Document,
+    DocumentText,
+    Page,
+    Project,
+  } from "$lib/api/types";
   import { _ } from "svelte-i18n";
 
   import Access, { getLevel } from "../documents/Access.svelte";
@@ -18,6 +24,7 @@
   import SidebarLayout from "./SidebarLayout.svelte";
   import { isOrg } from "@/api/types/orgAndUser";
   import Avatar from "../accounts/Avatar.svelte";
+  import AddOns from "@/lib/components/common/AddOns.svelte";
 
   const me = getCurrentUser();
 
@@ -26,6 +33,7 @@
   export let text: Promise<DocumentText> | DocumentText;
   export let query: string = "";
   export let action: string = "";
+  export let addons: Promise<Page<AddOnListItem>>;
 
   $: projects = (document.projects ?? []) as Project[];
 </script>
@@ -54,6 +62,8 @@
         </Metadata>
       {/if}
       <Actions {document} user={$me} {action} />
+
+      <AddOns pinnedAddOns={addons} query="+document:{document.id}" />
     </Flex>
     <DocumentMetadata {document} />
   </aside>

--- a/src/lib/components/layouts/DocumentLayout.svelte
+++ b/src/lib/components/layouts/DocumentLayout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type {
     AddOnListItem,
+    APIResponse,
     Document,
     DocumentText,
     Page,
@@ -33,7 +34,7 @@
   export let text: Promise<DocumentText> | DocumentText;
   export let query: string = "";
   export let action: string = "";
-  export let addons: Promise<Page<AddOnListItem>>;
+  export let addons: Promise<APIResponse<Page<AddOnListItem>>>;
 
   $: projects = (document.projects ?? []) as Project[];
 </script>

--- a/src/lib/components/layouts/Project.svelte
+++ b/src/lib/components/layouts/Project.svelte
@@ -7,6 +7,7 @@
     ProjectUser,
     DocumentResults,
     AddOnListItem,
+    APIResponse,
   } from "$lib/api/types";
   import AddOns from "$lib/components/common/AddOns.svelte";
   import Collaborators from "$lib/components/projects/Collaborators.svelte";
@@ -17,9 +18,9 @@
 
   export let project: Project;
   export let users: ProjectUser[];
-  export let documents: Promise<DocumentResults>;
+  export let documents: Promise<APIResponse<DocumentResults>>;
   export let query: string = "";
-  export let addons: Promise<Page<AddOnListItem>>;
+  export let addons: Promise<APIResponse<Page<AddOnListItem>>>;
 
   $: projectQuery = `+project:${project.id}`;
 </script>

--- a/src/lib/components/layouts/Project.svelte
+++ b/src/lib/components/layouts/Project.svelte
@@ -64,6 +64,7 @@
     padding: 1rem;
   }
   main {
+    flex: 1 0 0;
     max-height: 100%;
     overflow-y: auto;
     border-radius: 0.25rem;

--- a/src/lib/components/layouts/Project.svelte
+++ b/src/lib/components/layouts/Project.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { _ } from "svelte-i18n";
+
+  import type { Project, ProjectUser, DocumentResults } from "$lib/api/types";
+  import Collaborators from "../projects/Collaborators.svelte";
+  import ProjectActions from "../projects/ProjectActions.svelte";
+  import ProjectHeader from "../projects/ProjectHeader.svelte";
+  import DocumentBrowser from "./DocumentBrowser.svelte";
+  import SidebarLayout from "./SidebarLayout.svelte";
+  import Flex from "../common/Flex.svelte";
+
+  export let project: Project;
+  export let users: ProjectUser[];
+  export let documents: Promise<DocumentResults>;
+  export let query: string = "";
+</script>
+
+<SidebarLayout>
+  <svelte:fragment slot="navigation">
+    <Collaborators {users} {project} />
+  </svelte:fragment>
+
+  <article slot="content">
+    <header><ProjectHeader {project} /></header>
+    <main>
+      <DocumentBrowser
+        {documents}
+        {project}
+        {query}
+        uiText={{
+          empty: $_("projects.empty"),
+          loading: $_("projects.loading"),
+          error: $_("projects.error"),
+          search: $_("projects.placeholder.documents"),
+        }}
+      />
+    </main>
+  </article>
+
+  <ProjectActions slot="action" {project} {users} />
+</SidebarLayout>
+
+<style>
+  article {
+    flex: 1 0 0;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    max-height: 100%;
+  }
+  header {
+    padding: 1rem;
+  }
+  main {
+    max-height: 100%;
+    overflow-y: auto;
+    border-radius: 0.25rem;
+    border: 1px solid var(--gray-2);
+    box-shadow: inset var(--shadow-2);
+  }
+</style>

--- a/src/lib/components/layouts/Project.svelte
+++ b/src/lib/components/layouts/Project.svelte
@@ -1,18 +1,27 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
 
-  import type { Project, ProjectUser, DocumentResults } from "$lib/api/types";
-  import Collaborators from "../projects/Collaborators.svelte";
-  import ProjectActions from "../projects/ProjectActions.svelte";
-  import ProjectHeader from "../projects/ProjectHeader.svelte";
+  import type {
+    Page,
+    Project,
+    ProjectUser,
+    DocumentResults,
+    AddOnListItem,
+  } from "$lib/api/types";
+  import AddOns from "$lib/components/common/AddOns.svelte";
+  import Collaborators from "$lib/components/projects/Collaborators.svelte";
+  import ProjectActions from "$lib/components/projects/ProjectActions.svelte";
+  import ProjectHeader from "$lib/components/projects/ProjectHeader.svelte";
   import DocumentBrowser from "./DocumentBrowser.svelte";
   import SidebarLayout from "./SidebarLayout.svelte";
-  import Flex from "../common/Flex.svelte";
 
   export let project: Project;
   export let users: ProjectUser[];
   export let documents: Promise<DocumentResults>;
   export let query: string = "";
+  export let addons: Promise<Page<AddOnListItem>>;
+
+  $: projectQuery = `+project:${project.id}`;
 </script>
 
 <SidebarLayout>
@@ -37,7 +46,10 @@
     </main>
   </article>
 
-  <ProjectActions slot="action" {project} {users} />
+  <svelte:fragment slot="action">
+    <ProjectActions {project} {users} />
+    <AddOns pinnedAddOns={addons} query={projectQuery} />
+  </svelte:fragment>
 </SidebarLayout>
 
 <style>

--- a/src/lib/components/layouts/Sidebar.svelte
+++ b/src/lib/components/layouts/Sidebar.svelte
@@ -153,7 +153,7 @@
   the appropriate sidebar will move out into a visible position. */
 
   @media (max-width: 64rem) {
-    .container {
+    .sidebarContainer {
       min-width: 33vw;
       max-width: 100vw;
       top: 0;
@@ -162,12 +162,12 @@
       background: var(--white);
       position: fixed;
     }
-    .container.right {
+    .sidebarContainer.right {
       right: 0;
       border-top-left-radius: 1rem;
       border-bottom-left-radius: 1rem;
     }
-    .container.left {
+    .sidebarContainer.left {
       left: 0;
       border-top-right-radius: 1rem;
       border-bottom-right-radius: 1rem;

--- a/src/lib/components/layouts/SidebarLayout.svelte
+++ b/src/lib/components/layouts/SidebarLayout.svelte
@@ -25,6 +25,7 @@
     flex: 1 0 0;
     display: flex;
     flex-direction: row;
+    min-width: 0;
     max-width: var(--app-max-w, 100rem);
     margin: 0 auto;
     height: 100%;

--- a/src/lib/components/layouts/stories/AppLayout.stories.svelte
+++ b/src/lib/components/layouts/stories/AppLayout.stories.svelte
@@ -56,7 +56,7 @@
           <PlusCircle16 />{$_("sidebar.upload")}
         </Button>
         <Actions />
-        <AddOns pinnedAddOns={Promise.resolve(activeAddons)} />
+        <AddOns pinnedAddOns={Promise.resolve({ data: activeAddons })} />
       </svelte:fragment>
     </SidebarLayout>
   </AppLayout>

--- a/src/lib/components/layouts/stories/AppLayout.stories.svelte
+++ b/src/lib/components/layouts/stories/AppLayout.stories.svelte
@@ -11,7 +11,7 @@
   import Button from "../../common/Button.svelte";
   import { PlusCircle16 } from "svelte-octicons";
   import Actions from "@/routes/(app)/documents/sidebar/Actions.svelte";
-  import AddOns from "@/routes/(app)/documents/sidebar/AddOns.svelte";
+  import AddOns from "$lib/components/common/AddOns.svelte";
 
   import { documentsList } from "@/test/fixtures/documents";
   import { addons } from "@/test/handlers/addons";

--- a/src/lib/components/layouts/stories/DocumentLayout.stories.svelte
+++ b/src/lib/components/layouts/stories/DocumentLayout.stories.svelte
@@ -6,6 +6,7 @@
 
   import doc from "@/test/fixtures/documents/document-expanded.json";
   import txt from "@/test/fixtures/documents/document.txt.json";
+  import { activeAddons } from "@/test/fixtures/addons";
   const document = doc as Document;
 
   export const meta = {
@@ -28,6 +29,7 @@
     mode: "document",
     text: txt,
     query: "",
+    addons: Promise.resolve(activeAddons),
   };
 </script>
 

--- a/src/lib/components/layouts/stories/Project.stories.svelte
+++ b/src/lib/components/layouts/stories/Project.stories.svelte
@@ -5,6 +5,7 @@
 
   import { project, projectUsers } from "@/test/fixtures/projects";
   import { documentsList } from "@/test/fixtures/documents";
+  import { activeAddons } from "@/test/fixtures/addons";
 
   export const meta: Meta = {
     title: "Layout / Project",
@@ -18,6 +19,7 @@
     project,
     users: projectUsers.results,
     documents: Promise.resolve(documentsList),
+    addons: Promise.resolve(activeAddons),
   };
 </script>
 

--- a/src/lib/components/layouts/stories/Project.stories.svelte
+++ b/src/lib/components/layouts/stories/Project.stories.svelte
@@ -1,0 +1,47 @@
+<script lang="ts" context="module">
+  import type { Meta } from "@storybook/svelte";
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+  import Project from "../Project.svelte";
+
+  import { project, projectUsers } from "@/test/fixtures/projects";
+  import { documentsList } from "@/test/fixtures/documents";
+
+  export const meta: Meta = {
+    title: "Layout / Project",
+    component: Project,
+    parameters: {
+      layout: "fullscreen",
+    },
+  };
+
+  let args = {
+    project,
+    users: projectUsers.results,
+    documents: Promise.resolve(documentsList),
+  };
+</script>
+
+<Template let:args>
+  <div class="vh-100">
+    <Project {...args} />
+  </div>
+</Template>
+
+<Story name="Viewer" {args} />
+<Story
+  name="Editor"
+  args={{ ...args, project: { ...project, edit_access: true } }}
+/>
+<Story
+  name="Admin"
+  args={{
+    ...args,
+    project: { ...project, edit_access: true, add_remove_access: true },
+  }}
+/>
+
+<style>
+  .vh-100 {
+    height: 100vh;
+  }
+</style>

--- a/src/lib/components/layouts/stories/SidebarLayout.stories.svelte
+++ b/src/lib/components/layouts/stories/SidebarLayout.stories.svelte
@@ -55,7 +55,7 @@
           <PlusCircle16 />{$_("sidebar.upload")}
         </Button>
         <Actions />
-        <AddOns pinnedAddOns={Promise.resolve(activeAddons)} />
+        <AddOns pinnedAddOns={Promise.resolve({ data: activeAddons })} />
       </svelte:fragment>
     </SidebarLayout>
   </div>

--- a/src/lib/components/layouts/stories/SidebarLayout.stories.svelte
+++ b/src/lib/components/layouts/stories/SidebarLayout.stories.svelte
@@ -9,7 +9,7 @@
   import Button from "$lib/components/common/Button.svelte";
 
   import Actions from "@/routes/(app)/documents/sidebar/Actions.svelte";
-  import AddOns from "@/routes/(app)/documents/sidebar/AddOns.svelte";
+  import AddOns from "@/lib/components/common/AddOns.svelte";
   import Documents from "@/routes/(app)/documents/sidebar/Documents.svelte";
   import Projects from "@/routes/(app)/documents/sidebar/Projects.svelte";
 

--- a/src/lib/components/projects/Collaborators.svelte
+++ b/src/lib/components/projects/Collaborators.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import type { Project, ProjectUser } from "$lib/api/types";
+  import { getUserName } from "$lib/api/accounts";
+  import type { Project, ProjectAccess, ProjectUser } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
-  import { Pencil16 } from "svelte-octicons";
+  import { Pencil16, People16 } from "svelte-octicons";
 
   import Action from "../common/Action.svelte";
   import Empty from "../common/Empty.svelte";
@@ -13,42 +14,63 @@
   import ManageCollaborators from "../forms/ManageCollaborators.svelte";
   import Modal from "../layouts/Modal.svelte";
   import Portal from "../layouts/Portal.svelte";
+  import { getCurrentUser } from "@/lib/utils/permissions";
 
   export let project: Project;
   export let users: ProjectUser[];
 
+  const me = getCurrentUser();
+  // Do I belong to this project?
+  $: isProjectUser = users.some((u) => u.user.id === $me?.id);
+
   let edit = false;
+
+  const accessLabels: Record<ProjectAccess, string> = {
+    admin: "projects.access.admin",
+    edit: "projects.access.edit",
+    view: "projects.access.view",
+  };
 
   function sort(users: ProjectUser[]) {
     if (!users) return [];
     return users.sort(
       (a, b) =>
         a.access.localeCompare(b.access) ||
-        a.user.name.localeCompare(b.user.name),
+        getUserName(a.user).localeCompare(getUserName(b.user)),
     );
   }
 </script>
 
 <SidebarGroup name="collaborators">
   <SidebarItem slot="title">
+    <People16 slot="start" />
     {$_("projects.collaborators.title")}
   </SidebarItem>
-  {#if project.add_remove_access}
-    <Action
-      icon={Pencil16}
-      title={$_("projects.manage")}
-      on:click={() => (edit = true)}
-      slot="action"
-    >
-      <span class="sr-only">{$_("projects.manage")}</span>
-    </Action>
-  {/if}
+  <svelte:fragment slot="action"
+    >{#if project.add_remove_access}
+      <Action
+        icon={Pencil16}
+        title={$_("projects.collaborators.edit")}
+        on:click={() => (edit = true)}
+      >
+        {$_("projects.collaborators.edit")}
+      </Action>
+    {/if}</svelte:fragment
+  >
 
   {#each sort(users) as user}
-    <SidebarItem small>
-      <Avatar user={user.user} slot="start" />
-      {user.user.name} ({user.access})
-    </SidebarItem>
+    {#if isProjectUser || project.edit_access}
+      <SidebarItem small>
+        <Avatar user={user.user} slot="start" />
+        {getUserName(user.user)}
+        <span class="badge" slot="end">{$_(accessLabels[user.access])}</span>
+      </SidebarItem>
+    {:else}
+      <SidebarItem small>
+        <Avatar user={user.user} slot="start" />
+        {getUserName(user.user)}
+      </SidebarItem>
+    {/if}
   {:else}
     <Empty>
       {$_("projects.collaborators.empty")}
@@ -62,8 +84,18 @@
 {#if edit}
   <Portal>
     <Modal on:close={() => (edit = false)}>
-      <h1 slot="title">{$_("collaborators.manage")}</h1>
+      <h1 slot="title">{$_("projects.users")}</h1>
       <ManageCollaborators {project} {users} on:close={() => (edit = false)} />
     </Modal>
   </Portal>
 {/if}
+
+<style>
+  .badge {
+    margin-left: 1em;
+    font-size: 0.75em;
+    text-transform: uppercase;
+    letter-spacing: 0.1ch;
+    color: var(--primary);
+  }
+</style>

--- a/src/lib/components/projects/ProjectActions.svelte
+++ b/src/lib/components/projects/ProjectActions.svelte
@@ -38,6 +38,7 @@
     getCurrentUser,
     isSignedIn,
   } from "$lib/utils/permissions";
+  import ProjectShare from "./ProjectShare.svelte";
 
   export let project: Project;
   export let users: ProjectUser[];
@@ -118,10 +119,7 @@
       {/if}
 
       {#if show === "share"}
-        <Empty icon={Share24}
-          >Project sharing coming soon. Use our Feedback form to let us know how
-          you use project sharing.</Empty
-        >
+        <ProjectShare {project} on:close={hide} />
       {/if}
 
       {#if show === "users"}

--- a/src/lib/components/projects/ProjectHeader.svelte
+++ b/src/lib/components/projects/ProjectHeader.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { _ } from "svelte-i18n";
+  import { Globe16, Lock16 } from "svelte-octicons";
+  import type { Project } from "$lib/api/types";
+  import Flex from "$lib/components/common/Flex.svelte";
+  import { remToPx } from "$lib/utils/layout";
+  import ProjectPin from "./ProjectPin.svelte";
+
+  export let project: Project;
+
+  let width: number;
+</script>
+
+<div
+  class="container"
+  bind:clientWidth={width}
+  class:sm={width < remToPx(32)}
+  class:twoColumn={width > remToPx(48)}
+>
+  <Flex align="baseline" wrap justify="between">
+    <ProjectPin {project} />
+    <h1>{project.title}</h1>
+    <div class="access">
+      {#if project.private}
+        <Flex align="center"><Lock16 /> {$_("projects.access.private")}</Flex>
+      {:else}
+        <Flex align="center"><Globe16 /> {$_("projects.access.public")}</Flex>
+      {/if}
+    </div>
+  </Flex>
+  <p class="description">{project.description}</p>
+</div>
+
+<style>
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .sm.container h1 {
+    order: 1;
+    flex: 1 1 100%;
+  }
+  h1 {
+    flex: 1 0 0;
+    color: var(--gray-5);
+    font-size: var(--font-xl);
+    font-weight: var(--font-semibold);
+  }
+  .access {
+    font-weight: var(--font-semibold);
+  }
+  .description {
+    line-height: 1.4;
+  }
+  .twoColumn .description {
+    columns: 2;
+    column-gap: 1rem;
+  }
+</style>

--- a/src/lib/components/projects/ProjectShare.svelte
+++ b/src/lib/components/projects/ProjectShare.svelte
@@ -122,8 +122,8 @@
   }
   .share {
     flex: 1 1 auto;
-    min-height: 50vh;
-    min-width: 70vw;
+    height: min(50vh, 100%);
+    width: min(70vw, 100%);
     display: flex;
     flex-flow: row-reverse wrap-reverse;
     align-items: flex-end;

--- a/src/lib/components/projects/ProjectShare.svelte
+++ b/src/lib/components/projects/ProjectShare.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import { _ } from "svelte-i18n";
+  import { Copy16, ShieldLock24 } from "svelte-octicons";
+
+  import type { Project } from "$lib/api/types";
+  import { canonicalUrl, embedUrl } from "$lib/api/projects";
+
+  import Button from "../common/Button.svelte";
+  import Field from "../common/Field.svelte";
+  import FieldLabel from "../common/FieldLabel.svelte";
+  import Flex from "../common/Flex.svelte";
+  import Text from "../inputs/Text.svelte";
+  import TextArea from "../inputs/TextArea.svelte";
+  import { toast } from "../layouts/Toaster.svelte";
+  import Tip from "../common/Tip.svelte";
+  import Portal from "../layouts/Portal.svelte";
+  import Modal from "../layouts/Modal.svelte";
+  import EditProject from "../forms/EditProject.svelte";
+
+  export let project: Project;
+
+  let editing = false;
+  const closeEditing = () => (editing = false);
+  const openEditing = () => (editing = true);
+
+  $: isPrivate = project.private;
+
+  $: permalink = canonicalUrl(project);
+  $: embedSrc = embedUrl(project);
+  $: iframe = `<iframe src="${embedUrl(project).href}" />`;
+
+  async function copy(text: string) {
+    await navigator.clipboard.writeText(text);
+    toast($_("share.copiedToClipboard"));
+  }
+</script>
+
+<div class="share">
+  <iframe class="embed" title="Embed Preview" src={embedSrc.href} />
+  <div class="fields">
+    {#if isPrivate}
+      <div class="banner">
+        <Tip mode="danger">
+          <ShieldLock24 slot="icon" />
+          <div class="privateWarning">
+            <div style:flex="1 1 auto">
+              {$_("share.privateWarning", { values: { type: "project" } })}
+            </div>
+            {#if project.edit_access}
+              <Button mode="danger" size="small" on:click={openEditing}>
+                {$_("share.privateFix")}
+              </Button>
+            {/if}
+          </div>
+        </Tip>
+      </div>
+    {/if}
+    <Field>
+      <FieldLabel>
+        {$_("share.permalink")}
+        <Button
+          slot="action"
+          size="small"
+          ghost
+          mode="primary"
+          on:click={() => copy(String(permalink))}
+          disabled={!navigator.clipboard}
+        >
+          <Copy16 />
+          {$_("share.copy")}
+        </Button>
+      </FieldLabel>
+      <Text
+        value={String(permalink)}
+        --font-family="var(--font-mono)"
+        --font-size="var(--font-sm)"
+      />
+    </Field>
+    <Field>
+      <FieldLabel>
+        {$_("share.iframe")}
+        <Button
+          slot="action"
+          size="small"
+          ghost
+          mode="primary"
+          on:click={() => copy(iframe)}
+          disabled={!navigator.clipboard}
+        >
+          <Copy16 />
+          {$_("share.copy")}
+        </Button>
+      </FieldLabel>
+      <TextArea
+        value={iframe}
+        --font-family="var(--font-mono)"
+        --font-size="var(--font-sm)"
+        --resize="vertical"
+      />
+    </Field>
+  </div>
+</div>
+{#if editing}
+  <Portal>
+    <Modal on:close={closeEditing}>
+      <h1 slot="title">{$_("projects.edit")}</h1>
+      <EditProject {project} on:close={closeEditing} />
+    </Modal>
+  </Portal>
+{/if}
+
+<style>
+  .banner {
+    flex: 1 1 100%;
+    margin-bottom: 1rem;
+  }
+  .privateWarning {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  .share {
+    flex: 1 1 auto;
+    min-height: 50vh;
+    min-width: 70vw;
+    display: flex;
+    flex-flow: row-reverse wrap-reverse;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 1rem;
+  }
+  .fields {
+    flex: 1 1 auto;
+    max-height: min-content;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .embed {
+    min-height: 32rem;
+    flex: 1 1 26rem;
+    border: 1px solid var(--gray-2);
+    border-radius: 1rem;
+    box-shadow: inset var(--shadow-2);
+    background: var(--gray-1);
+    overflow: hidden;
+  }
+</style>

--- a/src/lib/components/projects/stories/ProjectHeader.stories.svelte
+++ b/src/lib/components/projects/stories/ProjectHeader.stories.svelte
@@ -1,0 +1,36 @@
+<script context="module" lang="ts">
+  import { Template, Story } from "@storybook/addon-svelte-csf";
+  import ProjectHeader from "../ProjectHeader.svelte";
+
+  import { project } from "@/test/fixtures/projects";
+
+  export const meta = {
+    title: "Components / Projects / Header",
+    component: ProjectHeader,
+    parameters: { layout: "centered" },
+  };
+
+  let args = {
+    project: {
+      ...project,
+      description:
+        "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat.",
+    },
+  };
+</script>
+
+<Template let:args>
+  <ProjectHeader {...args} />
+</Template>
+
+<Story name="Public" {args} />
+
+<Story
+  name="Private"
+  args={{
+    project: {
+      ...project,
+      private: true,
+    },
+  }}
+/>

--- a/src/lib/components/projects/stories/ProjectShare.stories.svelte
+++ b/src/lib/components/projects/stories/ProjectShare.stories.svelte
@@ -1,0 +1,49 @@
+<script context="module" lang="ts">
+  import { Template, Story } from "@storybook/addon-svelte-csf";
+  import ProjectShare from "../ProjectShare.svelte";
+
+  import { project } from "@/test/fixtures/projects";
+  import Toaster from "../../layouts/Toaster.svelte";
+
+  export const meta = {
+    title: "Components / Projects / Share",
+    component: ProjectShare,
+    parameters: { layout: "centered" },
+  };
+
+  let args = {
+    project: {
+      ...project,
+      description:
+        "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat.",
+    },
+  };
+</script>
+
+<Template let:args>
+  <ProjectShare {...args} />
+  <Toaster />
+</Template>
+
+<Story name="Public" {args} />
+
+<Story
+  name="Private"
+  args={{
+    project: {
+      ...project,
+      private: true,
+    },
+  }}
+/>
+
+<Story
+  name="Private, Can Edit"
+  args={{
+    project: {
+      ...project,
+      private: true,
+      edit_access: true,
+    },
+  }}
+/>

--- a/src/lib/components/sidebar/SidebarItem.svelte
+++ b/src/lib/components/sidebar/SidebarItem.svelte
@@ -52,6 +52,7 @@
 {/if}
 
 <style>
+  a.container,
   .container {
     min-width: 0;
     display: flex;
@@ -61,8 +62,8 @@
     border-radius: 0.25rem;
     border: none;
 
-    color: var(--color, inherit);
-    fill: var(--fill, inherit);
+    color: var(--color, var(--gray-5, inherit));
+    fill: var(--fill, var(--gray-4, inherit));
     background: var(--background, transparent);
 
     font-family: var(--font-sans, "Source Sans Pro");
@@ -72,20 +73,19 @@
     white-space: nowrap;
     text-overflow: ellipsis;
   }
+  a.container.inline,
   .container.inline {
     display: inline-flex;
     width: auto;
   }
 
   /* Hover */
-  a.container.active,
-  .container.active,
   a.container:hover,
   a.container:focus,
   .container.hover:hover,
   .container.hover:focus {
     cursor: pointer;
-    background: var(--hover-background, var(--gray-2, #d8dee2));
+    background: var(--hover-background, var(--gray-1, #d8dee2));
     color: var(--hover-color, var(--color, inherit));
     fill: var(--hover-fill, var(--fill, inherit));
   }
@@ -105,10 +105,11 @@
   }
 
   /* Active */
+  a.container.active,
   .container.active {
-    background: var(--active-background, var(--blue-2, #b5ceed));
-    color: var(--active-color, var(--color, inherit));
-    fill: var(--active-fill, var(--fill, inherit));
+    background: var(--active-background, var(--blue-1, #b5ceed));
+    color: var(--active-color, var(--blue-5, inherit));
+    fill: var(--active-fill, var(--blue-4, inherit));
   }
 
   /* Small */
@@ -124,6 +125,7 @@
   }
 
   .label {
+    flex: 1 1 auto;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/routes/(app)/documents/+page.svelte
+++ b/src/routes/(app)/documents/+page.svelte
@@ -5,12 +5,12 @@
   import { _ } from "svelte-i18n";
   import { PlusCircle16 } from "svelte-octicons";
 
+  import AddOns from "$lib/components/common/AddOns.svelte";
   import Button from "$lib/components/common/Button.svelte";
   import SignedIn from "$lib/components/common/SignedIn.svelte";
   import SidebarLayout from "$lib/components/layouts/SidebarLayout.svelte";
 
   import Actions from "../documents/sidebar/Actions.svelte";
-  import AddOns from "../documents/sidebar/AddOns.svelte";
   import Documents from "../documents/sidebar/Documents.svelte";
   import Projects from "../documents/sidebar/Projects.svelte";
 

--- a/src/routes/(app)/documents/+page.ts
+++ b/src/routes/(app)/documents/+page.ts
@@ -24,7 +24,7 @@ export async function load({ url, fetch, data }) {
 
   const searchResults = search(query, options, fetch);
 
-  const pinnedAddons = getPinnedAddons(fetch).then((r) => r.data);
+  const pinnedAddons = getPinnedAddons(fetch);
 
   return {
     ...data,

--- a/src/routes/(app)/documents/[id]-[slug]/+page.svelte
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.svelte
@@ -26,6 +26,7 @@
   $: text = data.text;
   $: action = data.action;
   $: $currentMode = data.mode; // set $currentMode from URL search param
+  $: addons = data.pinnedAddons;
 
   function setCurrentNoteFromHash(url: URL) {
     const { hash } = url;
@@ -69,4 +70,4 @@
   {/if}
 </svelte:head>
 
-<DocumentLayout {document} {asset_url} {text} {query} {action} />
+<DocumentLayout {document} {asset_url} {text} {query} {action} {addons} />

--- a/src/routes/(app)/documents/projects/[id]-[slug]/+page.svelte
+++ b/src/routes/(app)/documents/projects/[id]-[slug]/+page.svelte
@@ -1,64 +1,18 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
-  import { Globe16, Lock16 } from "svelte-octicons";
 
-  import Collaborators from "$lib/components/projects/Collaborators.svelte";
-  import ProjectActions from "$lib/components/projects/ProjectActions.svelte";
-  import Flex from "$lib/components/common/Flex.svelte";
-  import ProjectPin from "$lib/components/projects/ProjectPin.svelte";
-  import SidebarLayout from "@/lib/components/layouts/SidebarLayout.svelte";
-  import DocumentBrowser from "@/lib/components/layouts/DocumentBrowser.svelte";
+  import Project from "@/lib/components/layouts/Project.svelte";
 
   export let data;
 
   $: project = data.project;
-  $: documentSearch = data.documents;
+  $: documents = data.documents;
   $: query = data.query;
-  $: users = data.users;
+  $: users = data.users ?? [];
 </script>
 
 <svelte:head>
   <title>{project.title} | DocumentCloud</title>
 </svelte:head>
 
-<SidebarLayout>
-  <svelte:fragment slot="navigation">
-    <Flex direction="column">
-      <h1>
-        {project.title}
-        {#if project.private}
-          <Lock16 />
-        {:else}
-          <Globe16 />
-        {/if}
-        <ProjectPin {project} />
-      </h1>
-      <p>{project.description}</p>
-    </Flex>
-
-    <Collaborators {users} {project} />
-  </svelte:fragment>
-
-  <DocumentBrowser
-    slot="content"
-    documents={documentSearch}
-    {project}
-    {query}
-    uiText={{
-      empty: $_("projects.empty"),
-      loading: $_("projects.loading"),
-      error: $_("projects.error"),
-      search: $_("projects.placeholder.documents"),
-    }}
-  />
-
-  <ProjectActions slot="action" {project} {users} />
-</SidebarLayout>
-
-<style>
-  h1 {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-  }
-</style>
+<Project {project} {users} {documents} {query} />

--- a/src/routes/(app)/documents/projects/[id]-[slug]/+page.svelte
+++ b/src/routes/(app)/documents/projects/[id]-[slug]/+page.svelte
@@ -9,10 +9,11 @@
   $: documents = data.documents;
   $: query = data.query;
   $: users = data.users ?? [];
+  $: addons = data.pinnedAddons;
 </script>
 
 <svelte:head>
   <title>{project.title} | DocumentCloud</title>
 </svelte:head>
 
-<Project {project} {users} {documents} {query} />
+<Project {project} {users} {documents} {query} {addons} />

--- a/src/routes/(app)/documents/projects/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/projects/[id]-[slug]/+page.ts
@@ -6,6 +6,7 @@ import * as collaborators from "$lib/api/collaborators";
 import { search } from "$lib/api/documents";
 import { breadcrumbTrail } from "$lib/utils/navigation";
 import type { Project, ProjectUser, Nullable } from "@/lib/api/types";
+import { getPinnedAddons } from "$lib/api/addons";
 
 export async function load({ params, url, parent, fetch }) {
   const id = parseInt(params.id);
@@ -39,11 +40,15 @@ export async function load({ params, url, parent, fetch }) {
     fetch,
   );
 
+  // stream this
+  const pinnedAddons = getPinnedAddons(fetch);
+
   return {
     breadcrumbs,
     documents,
     query,
     project,
     users,
+    pinnedAddons,
   };
 }

--- a/src/routes/(app)/documents/projects/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/projects/[id]-[slug]/+page.ts
@@ -5,15 +5,17 @@ import * as projects from "$lib/api/projects";
 import * as collaborators from "$lib/api/collaborators";
 import { search } from "$lib/api/documents";
 import { breadcrumbTrail } from "$lib/utils/navigation";
+import type { Project, ProjectUser, Nullable } from "@/lib/api/types";
 
 export async function load({ params, url, parent, fetch }) {
   const id = parseInt(params.id);
-  const [project, users] = await Promise.all([
-    projects.get(id, fetch).catch(console.error),
-    collaborators.list(id, fetch).catch(console.error),
-  ]).catch((e) => {
-    return [];
-  });
+  const [project, users]: [Nullable<Project>, Nullable<ProjectUser[]>] =
+    await Promise.all([
+      projects.get(id, fetch),
+      collaborators.list(id, fetch),
+    ]).catch(() => {
+      return [null, null];
+    });
 
   if (!project) {
     error(404, "Project not found");
@@ -30,7 +32,7 @@ export async function load({ params, url, parent, fetch }) {
 
   const query = url.searchParams.get("q") ?? "";
   const cursor = url.searchParams.get("cursor") ?? "";
-  const per_page = +url.searchParams.get("per_page") || DEFAULT_PER_PAGE;
+  const per_page = +(url.searchParams.get("per_page") || DEFAULT_PER_PAGE);
   const documents = search(
     query,
     { cursor, project: project.id, per_page },

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -105,7 +105,7 @@ a {
 }
 
 a.active {
-  font-weight: normal !important;
+  font-weight: normal;
 }
 
 a.active .project {

--- a/src/test/fixtures/projects.ts
+++ b/src/test/fixtures/projects.ts
@@ -1,3 +1,4 @@
+import type { ProjectUser } from "@/lib/api/types";
 import type { Page, Project } from "../../api/types";
 
 export let project: Project = {
@@ -297,6 +298,256 @@ export const projectList: Page<Project> = {
       title: "Timeout test",
       updated_at: "2023-01-26T20:46:26.668099Z",
       user: 1,
+    },
+  ],
+};
+
+export const projectUsers: Page<ProjectUser> = {
+  next: null,
+  previous: null,
+  results: [
+    {
+      user: {
+        id: 104081,
+        avatar_url:
+          "https://cdn.muckrock.com/media/avatars/dillon-crop-square.jpg",
+        is_staff: false,
+        name: "Dillon Bergin",
+        organization: 51993,
+        organizations: [51989, 51990, 34128, 125, 51993, 46370, 62177],
+        admin_organizations: [51989, 51990, 34128, 51993, 46370, 62177],
+        username: "Dillon-Bergin",
+        uuid: "a274d91b-e497-4391-9352-7fab126b5bbe",
+        verified_journalist: true,
+      },
+      access: "admin",
+    },
+    {
+      user: {
+        id: 105494,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: false,
+        name: "Adriene Hill",
+        organization: 42572,
+        organizations: [35614, 10006, 42572],
+        admin_organizations: [35614, 42572],
+        username: "Adriene",
+        uuid: "b6c2bce5-8fab-44c0-8f9f-d2d345b7ab8c",
+        verified_journalist: true,
+      },
+      access: "admin",
+    },
+    {
+      user: {
+        id: 109298,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: false,
+        name: "Derek Kravitz",
+        organization: 39752,
+        organizations: [10219, 39752],
+        admin_organizations: [10219, 39752],
+        username: "DerekRKravitz",
+        uuid: "70376af4-3258-4bf6-ae2c-3540ebe63d25",
+        verified_journalist: true,
+      },
+      access: "admin",
+    },
+    {
+      user: {
+        id: 101425,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: false,
+        name: "Molly Peterson",
+        organization: 37614,
+        organizations: [10006, 813, 31622, 37614],
+        admin_organizations: [10006, 31622],
+        username: "mollypeterson",
+        uuid: "3b19bacb-e17c-4ef1-b8c8-4df216c3d666",
+        verified_journalist: true,
+      },
+      access: "admin",
+    },
+    {
+      user: {
+        id: 1020,
+        avatar_url:
+          "https://cdn.muckrock.com/media/avatars/20140211-0O1A7147-2.jpg",
+        is_staff: true,
+        name: "Chris Amico",
+        organization: 125,
+        organizations: [19198, 170, 125],
+        admin_organizations: [19198, 170],
+        username: "chrisamico",
+        uuid: "800bbb85-ea7a-46e9-8f56-16f862e66e52",
+        verified_journalist: true,
+      },
+      access: "admin",
+    },
+    {
+      user: {
+        id: 108486,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: false,
+        name: "Mike K",
+        organization: 42572,
+        organizations: [38883, 42572],
+        admin_organizations: [38883],
+        username: "mikekessler213",
+        uuid: "34b645e4-eb32-4ab7-9bc0-d43d5ab16ff8",
+        verified_journalist: false,
+      },
+      access: "admin",
+    },
+    {
+      user: {
+        id: 110708,
+        avatar_url: "https://cdn.muckrock.com/media/avatars/kelly-square.jpg",
+        is_staff: false,
+        name: "Kelly Kauffman",
+        organization: 125,
+        organizations: [41234, 125, 51993, 62177],
+        admin_organizations: [41234, 62177],
+        username: "kellykauffman",
+        uuid: "c918d430-351f-4795-83dc-93d69219150d",
+        verified_journalist: true,
+      },
+      access: "admin",
+    },
+    {
+      user: {
+        id: 111462,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: false,
+        name: "Holly McDede",
+        organization: 813,
+        organizations: [42059, 813],
+        admin_organizations: [42059],
+        username: "hollymcdede",
+        uuid: "5b026426-e75f-4dcc-9c42-438776c3e25b",
+        verified_journalist: true,
+      },
+      access: "edit",
+    },
+    {
+      user: {
+        id: 111662,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: false,
+        name: "Lindsay Shachnow",
+        organization: 42277,
+        organizations: [42277],
+        admin_organizations: [42277],
+        username: "lindsayshachnow",
+        uuid: "64a0a5c1-f059-4861-a165-f918934d766e",
+        verified_journalist: true,
+      },
+      access: "edit",
+    },
+    {
+      user: {
+        id: 20080,
+        avatar_url:
+          "https://cdn.muckrock.com/media/account_images/22_MuckRock_2018_PRELIMANRY_EDITS_DSC_5387_2018_Derek_Kouyoumjian_preview_SfuGGnJ.jpg",
+        is_staff: true,
+        name: "Mitchell Kotler",
+        organization: 125,
+        organizations: [
+          63361, 63362, 10000, 3168, 125, 41248, 63685, 63367, 10002,
+        ],
+        admin_organizations: [
+          63361, 63362, 10000, 3168, 125, 41248, 63685, 63367, 10002,
+        ],
+        username: "mitch",
+        uuid: "8136b9b8-95b9-4302-950d-5402e9065978",
+        verified_journalist: true,
+      },
+      access: "admin",
+    },
+    {
+      user: {
+        id: 113744,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: false,
+        name: "Maanvi",
+        organization: 45125,
+        organizations: [45125],
+        admin_organizations: [45125],
+        username: "maanvi_singh",
+        uuid: "445859b2-3721-4551-a999-e04d34acfbba",
+        verified_journalist: false,
+      },
+      access: "view",
+    },
+    {
+      user: {
+        id: 113353,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: false,
+        name: "John Lippert",
+        organization: 44466,
+        organizations: [44466],
+        admin_organizations: [44466],
+        username: "johnlippert",
+        uuid: "ae7f1b47-ad01-4100-b3f3-fe2a22085d19",
+        verified_journalist: true,
+      },
+      access: "admin",
+    },
+    {
+      user: {
+        id: 102112,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: true,
+        name: "Sanjin Ibrahimovic",
+        organization: 125,
+        organizations: [125, 32363],
+        admin_organizations: [32363],
+        username: "sanjin",
+        uuid: "84859f4e-6757-47dc-8fe4-1976d31828dc",
+        verified_journalist: true,
+      },
+      access: "view",
+    },
+    {
+      user: {
+        id: 100773,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: false,
+        name: "LPL",
+        organization: 30905,
+        organizations: [12037, 30905],
+        admin_organizations: [12037, 30905],
+        username: "LPL",
+        uuid: "813cbf63-0f81-4dc9-bdcb-4b65a664e517",
+        verified_journalist: true,
+      },
+      access: "view",
+    },
+    {
+      user: {
+        id: 114243,
+        avatar_url:
+          "https://cdn.muckrock.com/static/images/avatars/profile.png",
+        is_staff: false,
+        name: "Emily Alpert",
+        organization: 46323,
+        organizations: [46323],
+        admin_organizations: [46323],
+        username: "ealpert",
+        uuid: "8eabeb89-67bd-438f-9ce1-c33763215376",
+        verified_journalist: false,
+      },
+      access: "view",
     },
   ],
 };


### PR DESCRIPTION
Fixes #685: Project sharing dialog
Fixes #708: Shows add-ons in project and document actions

This adds a project layout file and addresses a few issues. It gives projects a similar layout to documents, with header above a paged list of objects. It cleans up the collaborator list and project actions along with pinned add-ons. It adds a project sharing dialog.

To fix:
- [x] Sidebar layout overflows horizontally instead of matching window width
- [x] Project layout height is 100% of content, not 100% of window