### PR TITLE
Handles undefined user.name

### DIFF
--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -23,7 +23,7 @@ import type {
 
 import { writable, type Writable } from "svelte/store";
 import { DEFAULT_EXPAND } from "@/api/common.js";
-import { isOrg } from "./accounts";
+import { getUserName, isOrg } from "./accounts";
 import {
   APP_URL,
   BASE_API_URL,
@@ -623,12 +623,12 @@ export function pdfUrl(document: Document): URL {
 export function userOrgString(document: Document): string {
   // we have an org and user
   if (isOrg(document.organization) && typeof document.user === "object") {
-    return `${document.user.name} (${document.organization.name})`;
+    return `${getUserName(document.user)} (${document.organization.name})`;
   }
 
   // just a user
   if (typeof document.user === "object") {
-    return document.user.name;
+    return getUserName(document.user);
   }
 
   // nothing, so return nothing

--- a/src/lib/components/accounts/UserMenu.svelte
+++ b/src/lib/components/accounts/UserMenu.svelte
@@ -19,6 +19,7 @@
   import { SQUARELET_BASE, SIGN_OUT_URL } from "@/config/config.js";
   import Avatar from "./Avatar.svelte";
   import { remToPx } from "@/lib/utils/layout";
+  import { getUserName } from "@/lib/api/accounts";
 
   export let user: User;
   export let position = "bottom right";
@@ -42,7 +43,7 @@
   <SidebarItem slot="title" title="Open Menu">
     <Avatar {user} slot="start" />
     {#if width > remToPx(48)}
-      <span class="name">{user.name ?? user.username}</span>
+      <span class="name">{getUserName(user)}</span>
     {/if}
     <div class="dropdownArrow" slot="end">
       {#if position.includes("bottom")}

--- a/src/lib/components/documents/Note.svelte
+++ b/src/lib/components/documents/Note.svelte
@@ -28,6 +28,7 @@
   import Portal from "../layouts/Portal.svelte";
   import Modal from "../layouts/Modal.svelte";
   import Share from "./Share.svelte";
+  import { getUserName } from "@/lib/api/accounts";
   // import { getPrivateAsset } from "$lib/utils/api";
 
   export let document: Document;
@@ -206,7 +207,7 @@
 
     {#if user}
       <p class="author">
-        {$_("annotation.by", { values: { name: user.name } })}
+        {$_("annotation.by", { values: { name: getUserName(user) } })}
       </p>
     {/if}
   </footer>

--- a/src/lib/components/embeds/DocumentEmbed.svelte
+++ b/src/lib/components/embeds/DocumentEmbed.svelte
@@ -8,7 +8,7 @@
   import Metadata from "../common/Metadata.svelte";
   import Viewer from "../documents/Viewer.svelte";
 
-  import { isOrg, isUser } from "$lib/api/accounts";
+  import { getUserName, isOrg, isUser } from "$lib/api/accounts";
 
   export let document: Document;
   export let text: Promise<DocumentText> | DocumentText;
@@ -17,7 +17,7 @@
   // if we're using this layout, we're embedded
   setContext("embed", true);
 
-  $: user = isUser(document.user) ? document.user.name : undefined;
+  $: user = isUser(document.user) ? getUserName(document.user) : undefined;
   $: org = isOrg(document.organization)
     ? document.organization.name
     : undefined;

--- a/src/lib/components/forms/ManageCollaborators.svelte
+++ b/src/lib/components/forms/ManageCollaborators.svelte
@@ -25,6 +25,7 @@ They might get separated later.
   import Avatar from "../accounts/Avatar.svelte";
 
   import { canonicalUrl } from "$lib/api/projects";
+  import { getUserName } from "@/lib/api/accounts";
 
   export let project: Project;
   export let users: ProjectUser[];
@@ -93,7 +94,7 @@ They might get separated later.
               </tr>
               {#each sort(group) as user}
                 <tr>
-                  <td><Flex><Avatar {user} /> {user.name}</Flex></td>
+                  <td><Flex><Avatar {user} /> {getUserName(user)}</Flex></td>
                   <td>
                     <input type="hidden" name="user" value={user.id} />
                     <Field title={$_("collaborators.change")} sronly>

--- a/src/lib/components/forms/UserFeedback.svelte
+++ b/src/lib/components/forms/UserFeedback.svelte
@@ -9,6 +9,7 @@
   import Avatar from "../accounts/Avatar.svelte";
   import { toast } from "../layouts/Toaster.svelte";
   import { APP_URL } from "@/config/config";
+  import { getUserName } from "@/lib/api/accounts";
 
   export let user: User = undefined;
 
@@ -102,7 +103,7 @@
       {:else}
         <Flex align="center">
           <Avatar {user} />
-          <span class="name">{user.name ?? user.username}</span>
+          <span class="name">{getUserName(user)}</span>
           <input type="hidden" name="user" value={user.email} />
         </Flex>
       {/if}

--- a/src/lib/components/navigation/OrgMenu.svelte
+++ b/src/lib/components/navigation/OrgMenu.svelte
@@ -15,7 +15,7 @@
   import SidebarItem from "../sidebar/SidebarItem.svelte";
   import PremiumIcon from "@/common/icons/Premium.svelte";
 
-  import { getUpgradeUrl, setOrg } from "$lib/api/accounts";
+  import { getUpgradeUrl, getUserName, setOrg } from "$lib/api/accounts";
   import { searchUrl, userDocs } from "$lib/utils/search";
   import { getCsrfToken } from "$lib/utils/api";
   import { remToPx } from "@/lib/utils/layout";
@@ -129,7 +129,7 @@
                     <span class="icon"><Person16 /></span>
                   {/if}
                 </svelte:fragment>
-                <span class="username">{user.name}</span>
+                <span class="username">{getUserName(user)}</span>
                 {#if user.admin_organizations.includes(active_org.id)}
                   <span class="badge">{$_("authSection.org.adminRole")}</span>
                 {/if}

--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -2,6 +2,7 @@ import type { User } from "@/api/types";
 import type { Access } from "../api/types";
 import { APP_URL } from "@/config/config.js";
 import { slugify } from "@/util/string.js";
+import { getUserName } from "../api/accounts";
 
 export function searchUrl(query: string): URL {
   const href = new URL("documents/", APP_URL);
@@ -19,11 +20,12 @@ export function projectSearchUrl(project): string {
  * @param access
  */
 export function userDocs(user: User, access: Access = undefined): string {
+  const username = getUserName(user);
   if (access) {
-    return `+user:${slugify(user.name)}-${user.id} access:${access}`;
+    return `+user:${slugify(username)}-${user.id} access:${access}`;
   }
 
-  return `+user:${slugify(user.name)}-${user.id}`;
+  return `+user:${slugify(username)}-${user.id}`;
 }
 
 /**


### PR DESCRIPTION
Closes #706

Uses our `getUserName` helper function to avoid directly accessing `user.name` and always return a string.