### PR TITLE
Display OCR engine in Document metadata

### DIFF
--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -957,6 +957,7 @@
     "updated": "Last updated on",
     "language": "Language",
     "delete": "Delete",
+    "ocr_engine": "OCR Engine",
     "addons": {
       "title": "Add-Ons",
       "pinned": "Pinned add-ons will appear here",

--- a/src/lib/components/documents/Metadata.svelte
+++ b/src/lib/components/documents/Metadata.svelte
@@ -8,7 +8,7 @@
   - text language
 -->
 <script lang="ts">
-  import type { Document } from "$lib/api/types";
+  import type { Document, DocumentText } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
 
@@ -17,10 +17,25 @@
   import Metadata from "../common/Metadata.svelte";
 
   export let document: Document;
+  export let text: DocumentText;
 
   function dateFormat(date: Date | string) {
     return new Date(date).toLocaleDateString();
   }
+
+  $: ocrEngine =
+    text.pages
+      .map((page) => page.ocr)
+      .reduce((acc, cur) => (acc = cur ?? acc)) ?? null;
+
+  let ocrEngineMap = {
+    tess4: "Tesseract",
+    textract: "Textract",
+    googlecv: "Google Cloud Vision",
+    ocrspace1: "OCRSpace",
+    azuredi: "Azure Document Intelligence",
+    doctr: "docTR",
+  };
 </script>
 
 <div class="meta">
@@ -36,6 +51,11 @@
   <Metadata key={$_("sidebar.language")}>
     {LANGUAGE_MAP.get(document.language)}
   </Metadata>
+  {#if ocrEngine && Object.keys(ocrEngineMap).includes(ocrEngine)}
+    <Metadata key={$_("sidebar.ocr_engine")}>
+      {ocrEngineMap[ocrEngine]}
+    </Metadata>
+  {/if}
 </div>
 
 <style>

--- a/src/lib/components/documents/Metadata.svelte
+++ b/src/lib/components/documents/Metadata.svelte
@@ -19,16 +19,7 @@
   export let document: Document;
   export let text: DocumentText;
 
-  function dateFormat(date: Date | string) {
-    return new Date(date).toLocaleDateString();
-  }
-
-  $: ocrEngine =
-    text.pages
-      .map((page) => page.ocr)
-      .reduce((acc, cur) => (acc = cur ?? acc)) ?? null;
-
-  let ocrEngineMap = {
+  const ocrEngineMap = {
     tess4: "Tesseract",
     textract: "Textract",
     googlecv: "Google Cloud Vision",
@@ -36,6 +27,22 @@
     azuredi: "Azure Document Intelligence",
     doctr: "docTR",
   };
+
+  const engines = Object.keys(ocrEngineMap);
+
+  let engine: string;
+
+  $: ocrEngine =
+    text?.pages
+      .map((page) => page?.ocr)
+      .reduce((acc, cur) => (acc = cur ?? acc), null) ?? null;
+
+  $: engine = ocrEngine?.split("_")[0];
+  $: console.log(engine, ocrEngine);
+
+  function dateFormat(date: Date | string) {
+    return new Date(date).toLocaleDateString();
+  }
 </script>
 
 <div class="meta">
@@ -51,9 +58,9 @@
   <Metadata key={$_("sidebar.language")}>
     {LANGUAGE_MAP.get(document.language)}
   </Metadata>
-  {#if ocrEngine && Object.keys(ocrEngineMap).includes(ocrEngine)}
+  {#if engine && Object.keys(ocrEngineMap).includes(engine)}
     <Metadata key={$_("sidebar.ocr_engine")}>
-      {ocrEngineMap[ocrEngine]}
+      {ocrEngineMap[engine]}
     </Metadata>
   {/if}
 </div>

--- a/src/lib/components/documents/Text.svelte
+++ b/src/lib/components/documents/Text.svelte
@@ -14,14 +14,13 @@
   import { scrollToPage } from "$lib/utils/scroll";
 
   export let query: string = ""; // search query
-  export let text: Promise<DocumentText> | DocumentText;
+  export let text: DocumentText;
   export let total: number = 0;
   export let zoom: number = 1;
 
   const currentPage: Writable<number> = getContext("currentPage");
 
   onMount(async () => {
-    await text; // wait until it loads
     if ($currentPage > 1) {
       scrollToPage($currentPage);
     }

--- a/src/lib/components/documents/Viewer.svelte
+++ b/src/lib/components/documents/Viewer.svelte
@@ -31,7 +31,7 @@
 
   export let document: Document;
   export let asset_url: URL = pdfUrl(document);
-  export let text: Promise<DocumentText> | DocumentText;
+  export let text: DocumentText;
   export let query: string = "";
 
   $: mode = $currentMode;

--- a/src/lib/components/documents/stories/Text.stories.svelte
+++ b/src/lib/components/documents/stories/Text.stories.svelte
@@ -10,14 +10,8 @@
   };
 
   import txt from "@/test/fixtures/documents/document.txt.json";
-
-  const loading: Promise<DocumentText> = new Promise(() => {});
 </script>
 
 <Story name="default">
   <Text text={txt} />
-</Story>
-
-<Story name="waiting to load">
-  <Text text={loading} total={txt.pages.length} />
 </Story>

--- a/src/lib/components/embeds/DocumentEmbed.svelte
+++ b/src/lib/components/embeds/DocumentEmbed.svelte
@@ -11,7 +11,7 @@
   import { getUserName, isOrg, isUser } from "$lib/api/accounts";
 
   export let document: Document;
-  export let text: Promise<DocumentText> | DocumentText;
+  export let text: DocumentText;
   export let settings: Partial<EmbedSettings> = defaultSettings;
 
   // if we're using this layout, we're embedded

--- a/src/lib/components/layouts/DocumentLayout.svelte
+++ b/src/lib/components/layouts/DocumentLayout.svelte
@@ -66,7 +66,7 @@
 
       <AddOns pinnedAddOns={addons} query="+document:{document.id}" />
     </Flex>
-    <DocumentMetadata {document} />
+    <DocumentMetadata {document} {text} />
   </aside>
 </SidebarLayout>
 

--- a/src/lib/components/layouts/DocumentLayout.svelte
+++ b/src/lib/components/layouts/DocumentLayout.svelte
@@ -30,8 +30,8 @@
   const me = getCurrentUser();
 
   export let document: Document;
+  export let text: DocumentText;
   export let asset_url: URL = pdfUrl(document);
-  export let text: Promise<DocumentText> | DocumentText;
   export let query: string = "";
   export let action: string = "";
   export let addons: Promise<APIResponse<Page<AddOnListItem>>>;

--- a/src/routes/(app)/documents/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.ts
@@ -7,15 +7,8 @@ export async function load({ fetch, parent, url, data, depends }) {
 
   const { document, mode } = await parent();
 
-  // only load text in text mode
-  let text: Promise<DocumentText> = Promise.resolve({
-    updated: 0,
-    pages: [],
-  });
-
-  if (mode === "text") {
-    text = documents.text(document, fetch);
-  }
+  // load text
+  let text = await documents.text(document, fetch);
 
   const asset_url = await documents.assetUrl(document, fetch);
 

--- a/src/routes/embed/documents/[id]-[slug]/+page.ts
+++ b/src/routes/embed/documents/[id]-[slug]/+page.ts
@@ -5,21 +5,13 @@ import * as notesApi from "$lib/api/notes";
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ parent, fetch, url }) {
-  const { document, mode } = await parent();
+  const { document } = await parent();
 
   const query = url.searchParams.get("q") ?? "";
 
+  // load text
+  const text = await documents.text(document, fetch);
   const asset_url = await documents.assetUrl(document, fetch);
-
-  // only load text in text mode
-  let text: Promise<DocumentText> = Promise.resolve({
-    updated: 0,
-    pages: [],
-  });
-
-  if (mode === "text") {
-    text = documents.text(document, fetch);
-  }
 
   return {
     asset_url,


### PR DESCRIPTION
Closes #713

This changes document loading to load text by default. This way, we don't need to `await` the data to render text-dependent information. Happy to reconsider this, but our current approach may load the text multiple times since we depend on it now in more than one place.
