### PR TITLE
Fix Mobile Safari height

### DIFF
--- a/src/lib/components/layouts/AppLayout.svelte
+++ b/src/lib/components/layouts/AppLayout.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <PlausibleTracker>
-  <div class="container">
+  <div class="app">
     <Navigation>
       <div class="inner">
         <slot />
@@ -16,7 +16,7 @@
 </PlausibleTracker>
 
 <style>
-  .container {
+  .app {
     display: flex;
     flex-direction: column;
     width: 100vw;
@@ -29,5 +29,17 @@
     flex: 1 1 0;
     overflow: auto;
     display: flex;
+  }
+
+  @supports (height: 100dvh) {
+    .app {
+      height: 100dvh;
+    }
+  }
+
+  @supports (width: 100dvw) {
+    .app {
+      width: 100dvw;
+    }
   }
 </style>


### PR DESCRIPTION
Closes #694 by using `dvh` to adapt to changing viewport hight

This fixes the positioning of toolbars and elements, but does not go further in collapsing Mobile Safari's toolbar on scroll. That will require additional work, which I've captured as #729.