### PR TITLE
Fixes font loading in Storybooks

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,6 +8,7 @@ const config: StorybookConfig = {
     "../src/lib/**/*.stories.@(js|jsx|ts|tsx|svelte)",
     "../src/routes/**/*.stories.@(js|jsx|ts|tsx|svelte)",
   ],
+  staticDirs: ["../public", "../static"],
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",

--- a/src/style/kit.css
+++ b/src/style/kit.css
@@ -6,8 +6,8 @@ Updated variables and styles for new SvelteKit routes
   --app-max-w: 100rem;
 
   /* Font Families */
-  --font-sans: "Source Sans Pro";
-  --font-mono: "Source Code Pro";
+  --font-sans: "Source Sans Pro", sans-serif;
+  --font-mono: "Source Code Pro", monospace;
 
   /* Font Sizes */
   --font-xs: 0.75em;


### PR DESCRIPTION
We needed to specify our static directories in the config. I also tried to ensure if Source Sans Pro is missing, we're falling back to a default `sans-serif` font instead of `serif`.