### PR TITLE
Run `test` CI sequentially to avoid segmentation faults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm run build
         env:
           NODE_ENV: production
-      - run: npm test
+      - run: npm test -- --run
 
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We've observed segmentation faults when running `vitest` in GitHub Actions. This may be because vitest runs multithreaded by default, and it uses too much memory in the task runner.

This adds the `--run` flag to our GitHub test workflow, which forces vitest to run sequentially. It may add a few seconds to overall test execution, but should be more stable.