### PR TITLE
Tooltip enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@babel/core": "^7.8.3",
         "@babel/preset-env": "^7.21.4",
         "@babel/preset-typescript": "^7.21.4",
+        "@floating-ui/dom": "^1.6.11",
         "@sentry/svelte": "^7.66.0",
         "@sentry/sveltekit": "^8.25.0",
         "@sveltejs/adapter-auto": "^3.0.0",
@@ -2603,7 +2604,6 @@
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
       "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
         "@floating-ui/utils": "^0.2.8"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@babel/core": "^7.8.3",
     "@babel/preset-env": "^7.21.4",
     "@babel/preset-typescript": "^7.21.4",
+    "@floating-ui/dom": "^1.6.11",
     "@sentry/svelte": "^7.66.0",
     "@sentry/sveltekit": "^8.25.0",
     "@sveltejs/adapter-auto": "^3.0.0",

--- a/src/common/AccessIcon.svelte
+++ b/src/common/AccessIcon.svelte
@@ -13,7 +13,7 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
   import { Globe16, Organization16, Lock16 } from "svelte-octicons";
-  import Tooltip from "./Tooltip.svelte";
+  import Tooltip from "../lib/components/common/Tooltip.svelte";
 
   export let access: AccessType;
   export let editable = false;

--- a/src/common/Button.svelte
+++ b/src/common/Button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Tooltip from "./Tooltip.svelte";
+  import Tooltip from "../lib/components/common/Tooltip.svelte";
 
   export let href: string | null = null;
   export let external = false;

--- a/src/common/Button.svelte
+++ b/src/common/Button.svelte
@@ -26,7 +26,7 @@
   export let disabledReason = null;
 </script>
 
-<Tooltip delay={500} show={disabledReason != null} caption={disabledReason}>
+<Tooltip caption={disabledReason}>
   {#if href}
     <a
       {href}

--- a/src/common/RevisionIcon.svelte
+++ b/src/common/RevisionIcon.svelte
@@ -10,7 +10,7 @@
 
 <script lang="ts">
   import { _ } from "svelte-i18n";
-  import Tooltip from "./Tooltip.svelte";
+  import Tooltip from "../lib/components/common/Tooltip.svelte";
 
   // SVG assets
   import History16 from "svelte-octicons/lib/History16.svelte";

--- a/src/common/dialog/DocumentInformationDialog.svelte
+++ b/src/common/dialog/DocumentInformationDialog.svelte
@@ -2,7 +2,7 @@
   import { _ } from "svelte-i18n";
 
   import Button from "@/common/Button.svelte";
-  import Tooltip from "@/common/Tooltip.svelte";
+  import Tooltip from "../lib/components/common/Tooltip.svelte";
   import HtmlEditor from "@/common/HtmlEditor.svelte";
 
   import { metaDialogs } from "./metaDialogs.js";

--- a/src/common/dialog/MetaFieldDialog.svelte
+++ b/src/common/dialog/MetaFieldDialog.svelte
@@ -3,7 +3,7 @@
   import { onMount } from "svelte";
 
   import Button from "@/common/Button.svelte";
-  import Tooltip from "@/common/Tooltip.svelte";
+  import Tooltip from "../lib/components/common/Tooltip.svelte";
   import HtmlEditor from "@/common/HtmlEditor.svelte";
   import { editSelectedDocumentInfo } from "@/manager/documents.js";
   import emitter from "@/emit.js";

--- a/src/lib/components/common/AddOns.svelte
+++ b/src/lib/components/common/AddOns.svelte
@@ -20,7 +20,7 @@
   import SidebarGroup from "$lib/components/sidebar/SidebarGroup.svelte";
   import Pin from "@/common/Pin.svelte";
   import Error from "./Error.svelte";
-  import Tooltip from "@/common/Tooltip.svelte";
+  import Tooltip from "$lib/components/common/Tooltip.svelte";
 
   export let pinnedAddOns: Promise<APIResponse<Page<AddOnListItem>>>;
   export let query: string = "";

--- a/src/lib/components/common/Tooltip.svelte
+++ b/src/lib/components/common/Tooltip.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { ComponentType } from "svelte";
+  import { writable } from "svelte/store";
   import {
     computePosition,
     flip,
@@ -8,8 +10,6 @@
     type Placement,
     type MiddlewareData,
   } from "@floating-ui/dom";
-  import { type ComponentType } from "svelte";
-  import { writable } from "svelte/store";
 
   export let caption: string | ComponentType;
   export let placement: Placement = "bottom";
@@ -17,8 +17,8 @@
   export let arrow = false;
 
   let anchor: HTMLDivElement;
-  let tooltip: HTMLDivElement;
   let arrowRef: HTMLDivElement;
+  let tooltip: HTMLDivElement;
   let tooltipCoords = writable({ x: 0, y: 0 });
 
   function positionArrow(placement: Placement, middlewareData: MiddlewareData) {

--- a/src/lib/components/common/Tooltip.svelte
+++ b/src/lib/components/common/Tooltip.svelte
@@ -113,7 +113,7 @@
     padding: 0.25rem 0.5rem;
     border-radius: 0.25rem;
     box-shadow: var(--shadow-1);
-    z-index: var(--z-toast, 19);
+    z-index: var(--z-tooltip, 21);
     max-width: 16rem;
   }
 </style>

--- a/src/lib/components/common/Tooltip.svelte
+++ b/src/lib/components/common/Tooltip.svelte
@@ -98,13 +98,12 @@
   }
 
   .tooltip {
-    position: fixed;
     font-weight: normal;
     font-size: 14px;
     opacity: 0;
     pointer-events: none;
-    background: rgba(0, 0, 0, 0.8);
-    color: white;
+    background: var(--gray-5);
+    color: var(--gray-1);
     line-height: 1.2em;
     padding: 0.3em 0.8em;
     border-radius: 3px;

--- a/src/lib/components/common/Tooltip.svelte
+++ b/src/lib/components/common/Tooltip.svelte
@@ -90,7 +90,7 @@
 
 <style>
   .anchor {
-    display: inline-block;
+    display: flex;
   }
   .arrow {
     position: absolute;

--- a/src/lib/components/common/stories/Tooltip.stories.svelte
+++ b/src/lib/components/common/stories/Tooltip.stories.svelte
@@ -7,6 +7,7 @@
     title: "Components / Common / Tooltip",
     component: Tooltip,
     tags: ["autodocs"],
+    parameters: { layout: "centered" },
   };
 
   let args = {

--- a/src/lib/components/common/stories/Tooltip.stories.svelte
+++ b/src/lib/components/common/stories/Tooltip.stories.svelte
@@ -1,0 +1,35 @@
+<script context="module" lang="ts">
+  import { Story } from "@storybook/addon-svelte-csf";
+  import Button from "../Button.svelte";
+  import Tooltip from "../Tooltip.svelte";
+
+  export const meta = {
+    title: "Components / Common / Tooltip",
+    component: Tooltip,
+    tags: ["autodocs"],
+  };
+
+  let args = {
+    mode: "normal",
+  };
+</script>
+
+<Story name="Basic" let:args>
+  <Tooltip caption="I'm a tooltip">
+    <Button>Hover me</Button>
+  </Tooltip>
+</Story>
+
+<Story name="Long Message" let:args>
+  <Tooltip
+    caption="I'm a tooltip with a really long message that may overflow the anchor position"
+  >
+    <Button>Hover me</Button>
+  </Tooltip>
+</Story>
+
+<Story name="With Arrow" let:args>
+  <Tooltip caption="I'm a tooltip with an arrow" arrow>
+    <Button>Hover me</Button>
+  </Tooltip>
+</Story>

--- a/src/lib/components/forms/DocumentUpload.svelte
+++ b/src/lib/components/forms/DocumentUpload.svelte
@@ -150,7 +150,7 @@
     isSupported,
     isWithinSizeLimit,
   } from "$lib/utils/files";
-  import Tooltip from "@/common/Tooltip.svelte";
+  import Tooltip from "$lib/components/common/Tooltip.svelte";
   import { getCurrentUser } from "$lib/utils/permissions";
 
   export let csrf_token = "";

--- a/src/lib/components/layouts/EmbedLayout.svelte
+++ b/src/lib/components/layouts/EmbedLayout.svelte
@@ -8,7 +8,7 @@
   import Button from "../common/Button.svelte";
   import Flex from "../common/Flex.svelte";
   import Logo from "../common/Logo.svelte";
-  import Tooltip from "@/common/Tooltip.svelte";
+  import Tooltip from "$lib/components/common/Tooltip.svelte";
 
   export let canonicalUrl: string;
   export let downloadUrl: string = "";

--- a/src/lib/components/processing/Documents.svelte
+++ b/src/lib/components/processing/Documents.svelte
@@ -46,7 +46,7 @@ so we can invalidate documents as they finish processing.
   import Portal from "../layouts/Portal.svelte";
   import Process from "./Process.svelte";
   import Reprocess from "../forms/Reprocess.svelte";
-  import Tooltip from "@/common/Tooltip.svelte";
+  import Tooltip from "$lib/components/common/Tooltip.svelte";
 
   import { POLL_INTERVAL } from "@/config/config";
   import { canonicalUrl, list, pending } from "$lib/api/documents";

--- a/src/lib/components/viewer/toolbars/AnnotationToolbar.svelte
+++ b/src/lib/components/viewer/toolbars/AnnotationToolbar.svelte
@@ -4,7 +4,7 @@
 
   import Button from "$lib/components/common/Button.svelte";
   import Flex from "$lib/components/common/Flex.svelte";
-  import Tooltip from "@/common/Tooltip.svelte";
+  import Tooltip from "$lib/components/common/Tooltip.svelte";
   import { getViewerHref } from "@/lib/utils/viewer";
 
   let width: number;

--- a/src/lib/components/viewer/toolbars/RedactionToolbar.svelte
+++ b/src/lib/components/viewer/toolbars/RedactionToolbar.svelte
@@ -15,7 +15,7 @@
   import Button from "$lib/components/common/Button.svelte";
   import Flex from "$lib/components/common/Flex.svelte";
   import { redactions, undo, clear } from "../RedactionPane.svelte";
-  import Tooltip from "@/common/Tooltip.svelte";
+  import Tooltip from "$lib/components/common/Tooltip.svelte";
 
   import ConfirmRedaction from "$lib/components/forms/ConfirmRedaction.svelte";
   import Portal from "$lib/components/layouts/Portal.svelte";

--- a/src/pages/app/ActionBar.svelte
+++ b/src/pages/app/ActionBar.svelte
@@ -2,7 +2,7 @@
   import { _ } from "svelte-i18n";
   import Checkbox from "../../common/Checkbox.svelte";
   import Flex from "../../common/Flex.svelte";
-  import Tooltip from "../../common/Tooltip.svelte";
+  import Tooltip from "../lib/components/common/Tooltip.svelte";
   import Dropdown from "../../common/Dropdown.svelte";
   import Paginator from "../../lib/components/common/Paginator.svelte";
 

--- a/src/pages/app/ActionBar.svelte
+++ b/src/pages/app/ActionBar.svelte
@@ -2,9 +2,9 @@
   import { _ } from "svelte-i18n";
   import Checkbox from "../../common/Checkbox.svelte";
   import Flex from "../../common/Flex.svelte";
-  import Tooltip from "../lib/components/common/Tooltip.svelte";
   import Dropdown from "../../common/Dropdown.svelte";
   import Paginator from "../../lib/components/common/Paginator.svelte";
+  import Tooltip from "../../lib/components/common/Tooltip.svelte";
 
   // Menus
   import EditMenu from "./menus/EditMenu.svelte";

--- a/src/pages/app/DocumentThumbnail.svelte
+++ b/src/pages/app/DocumentThumbnail.svelte
@@ -4,7 +4,7 @@
 
   import Image from "@/common/Image.svelte";
   import Loader from "@/common/Loader.svelte";
-  import Tooltip from "@/common/Tooltip.svelte";
+  import Tooltip from "$lib/components/common/Tooltip.svelte";
 
   // SVG assets
   import errorIconSvg from "@/assets/error_icon.svg?raw";

--- a/src/pages/app/menus/ProjectMenuItem.svelte
+++ b/src/pages/app/menus/ProjectMenuItem.svelte
@@ -2,7 +2,7 @@
   import { _ } from "svelte-i18n";
 
   import MenuItem from "@/common/MenuItem.svelte";
-  import Tooltip from "@/common/Tooltip.svelte";
+  import Tooltip from "$lib/components/common/Tooltip.svelte";
   import { layout } from "@/manager/layout.js";
 
   import {

--- a/src/style/kit.css
+++ b/src/style/kit.css
@@ -98,6 +98,7 @@ Updated variables and styles for new SvelteKit routes
   --z-dropdownBackdrop: 11;
   --z-dropdown: 12;
   --z-toast: 20;
+  --z-tooltip: 21;
 }
 
 html,


### PR DESCRIPTION
- Moves `Tooltip.svelte` from `src/common` to `src/lib/components/common`
- Adds stories for Tooltip
- Uses [Floating UI](https://floating-ui.com/) to compute tooltip position

I opted to replace the custom logic with Floating UI for a few reasons:
- We get more reliable functionality for shifting position and respecting window boundaries, with a well-tested and widely used library.
- We can use Floating UI in other components, like Dropdowns, without rewriting the logic.
- We can use Floating UI with `<canvas>` in the document viewer to enhance the interface (see #204)

