### PR TITLE
Constrain tall document thumbnails

### DIFF
--- a/src/lib/components/documents/DocumentListItem.svelte
+++ b/src/lib/components/documents/DocumentListItem.svelte
@@ -167,6 +167,10 @@ If we're in an embed, we want to open links to documents in new tabs and hide th
     border: 1px solid var(--gray-2, #cbcbcb);
     background: var(--white, #fff);
     box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.1);
+    /* Constrain tall documents */
+    max-height: 4.875rem;
+    object-fit: cover;
+    object-fit: top center;
   }
 
   .thumbnail .tabs {

--- a/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
+++ b/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`DocumentListItem > renders 1`] = `
 <div>
   <a
-    class="document-list-item svelte-u1blcs"
+    class="document-list-item svelte-1bq7dbe"
     href="https://www.dev.documentcloud.org/documents/24002098-quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018/"
   >
     <div
-      class="thumbnail svelte-u1blcs"
+      class="thumbnail svelte-1bq7dbe"
     >
       <img
         alt="Page 1, Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018"
-        class="svelte-u1blcs"
+        class="svelte-1bq7dbe"
         height="77.64705882352942px"
         loading="lazy"
         src="https://s3.documentcloud.org/documents/24002098/pages/quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018-p1-thumbnail.gif"
@@ -21,16 +21,16 @@ exports[`DocumentListItem > renders 1`] = `
     </div>
      
     <div
-      class="documentInfo svelte-u1blcs"
+      class="documentInfo svelte-1bq7dbe"
     >
       <h3
-        class="svelte-u1blcs"
+        class="svelte-1bq7dbe"
       >
         Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018
       </h3>
        
       <p
-        class="meta svelte-u1blcs"
+        class="meta svelte-1bq7dbe"
       >
         20 pages
          -


### PR DESCRIPTION
Closes #669 

To test, upload [Learn How To Do Isochrones In A Minute.pdf](https://github.com/user-attachments/files/17101212/Learn.How.To.Do.Isochrones.In.A.Minute.pdf) to the preview deployment. It should have a thumbnail the same size as other documents.