### PR TITLE
Privacy warning when sharing and embedding non-public documents

### DIFF
--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -1232,6 +1232,7 @@
     "save": "Save Settings",
     "customize": "Customize Embed",
     "privateWarning": "This {type} is private.",
+    "orgWarning": "This {type} is only visible within your organization.",
     "privateFix": "Edit metadata",
     "fields": {
       "page": "Pick page",

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -879,7 +879,7 @@
     "close": "Close Drawer"
   },
   "titleHeader": {
-    "contributedBy": "Contributed by {name}"
+    "contributedBy": "Contributed by"
   },
   "annotatePane": {
     "annotateDocument": "Add Note",

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -869,7 +869,11 @@
   "embed": {
     "download": "Download",
     "enterFullscreen": "Fullscreen",
-    "exitFullscreen": "Exit Fullscreen"
+    "exitFullscreen": "Exit Fullscreen",
+    "document": {
+      "privacyWarning": "This document is not public.",
+      "privacyFix": "Edit privacy settings"
+    }
   },
   "drawer": {
     "close": "Close Drawer"

--- a/src/lib/components/documents/Share.svelte
+++ b/src/lib/components/documents/Share.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-  import type { Document } from "@/lib/api/types";
+  import type { Document } from "$lib/api/types";
 
   interface NoteOption {
     value: string | number;
@@ -21,28 +21,29 @@
   } from "svelte-octicons";
 
   import Button from "../common/Button.svelte";
+  import CustomizeEmbed, { embedSettings } from "./CustomizeEmbed.svelte";
   import Field from "../common/Field.svelte";
   import FieldLabel from "../common/FieldLabel.svelte";
+  import Number from "../inputs/Number.svelte";
+  import Select from "../inputs/Select.svelte";
   import Tab from "../common/Tab.svelte";
   import Text from "../inputs/Text.svelte";
   import TextArea from "../inputs/TextArea.svelte";
-  import Select from "../inputs/Select.svelte";
-  import Number from "../inputs/Number.svelte";
-  import CustomizeEmbed, { embedSettings } from "./CustomizeEmbed.svelte";
+  import Tip from "../common/Tip.svelte";
 
-  import { createEmbedSearchParams } from "@/lib/utils/embed";
+  import Portal from "../layouts/Portal.svelte";
+  import Modal from "../layouts/Modal.svelte";
+  import Edit from "../forms/Edit.svelte";
+
+  import { toast } from "../layouts/Toaster.svelte";
+  import { createEmbedSearchParams } from "$lib/utils/embed";
   import {
     canonicalPageUrl,
     canonicalUrl,
     embedUrl,
     pageUrl,
-  } from "@/lib/api/documents";
-  import { canonicalNoteUrl, noteUrl } from "@/lib/api/notes";
-  import { toast } from "../layouts/Toaster.svelte";
-  import Tip from "../common/Tip.svelte";
-  import Portal from "../layouts/Portal.svelte";
-  import Modal from "../layouts/Modal.svelte";
-  import Edit from "../forms/Edit.svelte";
+  } from "$lib/api/documents";
+  import { canonicalNoteUrl, noteUrl } from "$lib/api/notes";
 
   export let document: Document;
   export let page: number = 1;

--- a/src/lib/components/documents/Share.svelte
+++ b/src/lib/components/documents/Share.svelte
@@ -16,6 +16,8 @@
     Hash16,
     Note16,
     Sliders16,
+    ShieldLock24,
+    Organization24,
   } from "svelte-octicons";
 
   import Button from "../common/Button.svelte";
@@ -37,6 +39,10 @@
   } from "@/lib/api/documents";
   import { canonicalNoteUrl, noteUrl } from "@/lib/api/notes";
   import { toast } from "../layouts/Toaster.svelte";
+  import Tip from "../common/Tip.svelte";
+  import Portal from "../layouts/Portal.svelte";
+  import Modal from "../layouts/Modal.svelte";
+  import Edit from "../forms/Edit.svelte";
 
   export let document: Document;
   export let page: number = 1;
@@ -63,6 +69,10 @@
   // let wpShortcode: string; is broken in WordPress
 
   let customizeEmbedOpen = false;
+  let editOpen = false;
+  const closeEditing = () => (editOpen = false);
+  const openEditing = () => (editOpen = true);
+  $: isPrivate = document.access === "private";
   $: embedUrlParams = createEmbedSearchParams($embedSettings);
   $: {
     switch (currentTab) {
@@ -116,6 +126,39 @@
 </script>
 
 <div class="container">
+  {#if isPrivate}
+    <div class="banner">
+      <Tip mode="danger">
+        <ShieldLock24 slot="icon" />
+        <div class="privateWarning">
+          <div style:flex="1 1 auto">
+            {$_("share.privateWarning", { values: { type: "document" } })}
+          </div>
+          {#if document.edit_access}
+            <Button mode="danger" size="small" on:click={openEditing}>
+              {$_("share.privateFix")}
+            </Button>
+          {/if}
+        </div>
+      </Tip>
+    </div>
+  {:else if document.access === "organization"}
+    <div class="banner">
+      <Tip mode="premium">
+        <Organization24 slot="icon" />
+        <div class="privateWarning">
+          <div style:flex="1 1 auto">
+            {$_("share.orgWarning", { values: { type: "document" } })}
+          </div>
+          {#if document.edit_access}
+            <Button mode="danger" size="small" on:click={openEditing}>
+              {$_("share.privateFix")}
+            </Button>
+          {/if}
+        </div>
+      </Tip>
+    </div>
+  {/if}
   <div class="left">
     <div class="tabs" role="tablist">
       <Tab
@@ -265,12 +308,33 @@
     </main>
   </div>
 </div>
+{#if editOpen}
+  <Portal>
+    <Modal on:close={closeEditing}>
+      <h1 slot="title">{$_("documents.edit")}</h1>
+      <Edit {document} on:close={closeEditing} />
+    </Modal>
+  </Portal>
+{/if}
 
 <style>
   .container {
     width: 100%;
     height: 32rem;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto 1fr;
+    gap: 0 1rem;
+  }
+  .banner {
+    grid-column: 1/3;
+    grid-row: 1/2;
+    margin-bottom: 1rem;
+  }
+  .privateWarning {
+    width: 100%;
     display: flex;
+    align-items: center;
     gap: 1rem;
   }
   .tabs {
@@ -297,6 +361,7 @@
     display: flex;
     flex-direction: column;
     flex: 1 1 12rem;
+    grid-row: 2/3;
   }
   .right {
     flex: 2 1 24rem;

--- a/src/lib/components/documents/stories/Share.stories.svelte
+++ b/src/lib/components/documents/stories/Share.stories.svelte
@@ -22,6 +22,28 @@
 
 <Story name="Document" args={{ ...args, document }} />
 
+<Story
+  name="Private Document"
+  args={{
+    ...args,
+    document: { ...document, access: "private", edit_access: false },
+  }}
+/>
+<Story
+  name="Organization Document"
+  args={{
+    ...args,
+    document: { ...document, access: "organization", edit_access: false },
+  }}
+/>
+<Story
+  name="Private Document with Edit Access"
+  args={{
+    ...args,
+    document: { ...document, access: "private", edit_access: true },
+  }}
+/>
+
 <Story name="Page" args={{ ...args, document, currentTab: "page" }} />
 
 <Story name="Note" args={{ ...args, document, currentTab: "note" }} />

--- a/src/lib/components/embeds/DocumentEmbed.svelte
+++ b/src/lib/components/embeds/DocumentEmbed.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
   import type { Document, DocumentText } from "$lib/api/types";
+  import { type EmbedSettings, defaultSettings } from "$lib/utils/embed";
 
   import { setContext } from "svelte";
   import { _ } from "svelte-i18n";
+  import { Alert16 } from "svelte-octicons";
 
-  import { type EmbedSettings, defaultSettings } from "$lib/utils/embed";
   import Metadata from "../common/Metadata.svelte";
   import Viewer from "../viewer/Viewer.svelte";
 
   import { getUserName, isOrg, isUser } from "$lib/api/accounts";
-  import { Alert16 } from "svelte-octicons";
-  import { canonicalUrl } from "@/lib/api/documents";
+  import { canonicalUrl } from "$lib/api/documents";
 
   export let document: Document;
   export let text: DocumentText;
@@ -31,15 +31,15 @@
     <div class="banner">
       <Alert16 />
       {$_("embed.document.privacyWarning")}
-      <a href={canonicalUrl(document)} target="_blank"
-        >{$_("embed.document.privacyFix")}</a
-      >
+      <a href={canonicalUrl(document)} target="_blank">
+        {$_("embed.document.privacyFix")}
+      </a>
     </div>
   {/if}
   {#if Boolean(settings.title)}
     <header>
       <h1>{document.title}</h1>
-      <Metadata key="Contributed by">{contributedBy}</Metadata>
+      <Metadata key={$_("titleHeader.contributedBy")}>{contributedBy}</Metadata>
     </header>
   {/if}
   <main>

--- a/src/lib/components/embeds/DocumentEmbed.svelte
+++ b/src/lib/components/embeds/DocumentEmbed.svelte
@@ -9,6 +9,8 @@
   import Viewer from "../viewer/Viewer.svelte";
 
   import { getUserName, isOrg, isUser } from "$lib/api/accounts";
+  import { Alert16 } from "svelte-octicons";
+  import { canonicalUrl } from "@/lib/api/documents";
 
   export let document: Document;
   export let text: DocumentText;
@@ -25,6 +27,15 @@
 </script>
 
 <div class="container">
+  {#if document.access !== "public"}
+    <div class="banner">
+      <Alert16 />
+      {$_("embed.document.privacyWarning")}
+      <a href={canonicalUrl(document)} target="_blank"
+        >{$_("embed.document.privacyFix")}</a
+      >
+    </div>
+  {/if}
   {#if Boolean(settings.title)}
     <header>
       <h1>{document.title}</h1>
@@ -60,5 +71,21 @@
     font-size: var(--font-md);
     font-weight: var(--font-semibold);
     max-width: 24rem;
+    margin: 0;
+  }
+  .banner {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    background: var(--orange-1);
+    color: var(--orange-5);
+    fill: var(--orange-3);
+  }
+  .banner a {
+    color: inherit;
+    text-decoration: underline;
   }
 </style>

--- a/src/lib/components/embeds/stories/DocumentEmbed.stories.svelte
+++ b/src/lib/components/embeds/stories/DocumentEmbed.stories.svelte
@@ -1,0 +1,42 @@
+<script context="module" lang="ts">
+  import { Template, Story } from "@storybook/addon-svelte-csf";
+  import DocumentEmbed from "../DocumentEmbed.svelte";
+
+  import doc from "@/test/fixtures/documents/document-expanded.json";
+  import EmbedLayout from "../../layouts/EmbedLayout.svelte";
+  import { canonicalUrl } from "@/lib/api/documents";
+  import type { Document } from "@/lib/api/types";
+
+  const document = doc as Document;
+
+  let args = {
+    document,
+    currentTab: "document",
+  };
+
+  export const meta = {
+    title: "Embed / Document",
+    component: DocumentEmbed,
+    parameters: { layout: "fullscreen" },
+  };
+</script>
+
+<Template let:args>
+  <div class="vh-100">
+    <EmbedLayout canonicalUrl={canonicalUrl(document).href}>
+      <DocumentEmbed {...args} />
+    </EmbedLayout>
+  </div>
+</Template>
+
+<Story name="Public" {args} />
+<Story
+  name="Private"
+  args={{ ...args, document: { ...document, access: "private" } }}
+/>
+
+<style>
+  .vh-100 {
+    height: 100vh;
+  }
+</style>

--- a/src/lib/components/projects/ProjectHeader.svelte
+++ b/src/lib/components/projects/ProjectHeader.svelte
@@ -52,6 +52,7 @@
     flex: 1 1 100%;
   }
   h1 {
+    margin: 0;
     flex: 1 0 0;
     color: var(--gray-5);
     font-size: var(--font-xl);


### PR DESCRIPTION
Fixes #684

- When sharing a document, we notify the user if the access is `private` or `organization`. If the user can edit the document, then we give them an action to adjust the visibility settings.
- When embedding a document, we place a warning  in the embed if its access is not `public`. We give them a link to the document page to take action.