### PR TITLE
Separate project creation from project form

### DIFF
--- a/src/lib/components/documents/Projects.svelte
+++ b/src/lib/components/documents/Projects.svelte
@@ -56,6 +56,7 @@
 {#if edit}
   <Portal>
     <Modal on:close={hide}>
+      <h1 slot="title">{$_("projects.header")}</h1>
       <Projects documents={[document]} on:close={hide} />
     </Modal>
   </Portal>

--- a/src/lib/components/forms/EditProject.svelte
+++ b/src/lib/components/forms/EditProject.svelte
@@ -34,6 +34,9 @@ Edit project metadata
   function onSubmit({ submitter }) {
     submitter.disabled = true;
     return ({ result, update }) => {
+      if (result.type === "success") {
+        dispatch("success", result);
+      }
       update(result);
       dispatch("close");
     };

--- a/src/lib/components/forms/EditProject.svelte
+++ b/src/lib/components/forms/EditProject.svelte
@@ -35,7 +35,7 @@ Edit project metadata
     submitter.disabled = true;
     return ({ result, update }) => {
       if (result.type === "success") {
-        dispatch("success", result);
+        dispatch("success", result.data?.project?.data);
       }
       update(result);
       dispatch("close");

--- a/src/lib/components/forms/Projects.svelte
+++ b/src/lib/components/forms/Projects.svelte
@@ -14,7 +14,6 @@ and we don't want to do that everywhere.
   import { FileDirectory24 } from "svelte-octicons";
 
   import Button from "../common/Button.svelte";
-  import Flex from "../common/Flex.svelte";
 
   import { getForUser, add, remove } from "$lib/api/projects";
   import { getCsrfToken } from "$lib/utils/api";
@@ -35,6 +34,7 @@ and we don't want to do that everywhere.
   let createProjectOpen = false;
   let common: Set<number>;
 
+  $: sorted = sort(projects);
   $: common = new Set(
     intersection(
       documents.map((d) => d.projects ?? []),
@@ -67,8 +67,8 @@ and we don't want to do that everywhere.
     await invalidateDocs(documents);
   }
 
-  function onCreateSuccess(event: CustomEvent<{ data: { project: Project } }>) {
-    projects = [...projects, event.detail.data.project];
+  function onCreateSuccess(event: CustomEvent<Project>) {
+    projects = [...projects, event.detail];
   }
 
   function sort(projects: Project[]) {
@@ -80,7 +80,7 @@ and we don't want to do that everywhere.
 
 <div class="container">
   <div class="projects">
-    {#each sort(projects) as project}
+    {#each sorted as project}
       <label class="project">
         <input
           type="checkbox"

--- a/src/lib/components/forms/Projects.svelte
+++ b/src/lib/components/forms/Projects.svelte
@@ -5,26 +5,24 @@ because it needs to load all of a user's projects
 and we don't want to do that everywhere.
 -->
 <script lang="ts">
-  import type { Writable } from "svelte/store";
-  import type { Document, Project, User } from "$lib/api/types";
+  import type { Document, Project } from "$lib/api/types";
 
-  import { enhance } from "$app/forms";
   import { invalidate } from "$app/navigation";
 
-  import { createEventDispatcher, getContext, onMount } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
   import { _ } from "svelte-i18n";
 
   import Button from "../common/Button.svelte";
-  import Field from "../inputs/Field.svelte";
   import Flex from "../common/Flex.svelte";
-  import Switch from "../inputs/Switch.svelte";
-  import Text from "../inputs/Text.svelte";
-  import TextArea from "../inputs/TextArea.svelte";
 
   import { getForUser, add, remove } from "$lib/api/projects";
   import { getCsrfToken } from "$lib/utils/api";
   import { intersection } from "@/util/array.js";
   import { getCurrentUser } from "@/lib/utils/permissions";
+  import { PlusCircle16 } from "svelte-octicons";
+  import EditProject from "./EditProject.svelte";
+  import Portal from "../layouts/Portal.svelte";
+  import Modal from "../layouts/Modal.svelte";
 
   export let documents: Document[] = [];
   export let projects: Project[] = [];
@@ -32,6 +30,7 @@ and we don't want to do that everywhere.
   const dispatch = createEventDispatcher();
   const me = getCurrentUser();
 
+  let createProjectOpen = false;
   let common: Set<number>;
 
   $: common = new Set(
@@ -66,15 +65,8 @@ and we don't want to do that everywhere.
     await invalidateDocs(documents);
   }
 
-  function onSubmit({ submitter }) {
-    submitter.disabled = true;
-    return async ({ result, update }) => {
-      if (result.type === "success") {
-        projects = [...projects, result.data.project];
-        update(result);
-      }
-      submitter.disabled = false;
-    };
+  function onCreateSuccess(event: CustomEvent<{ data: { project: Project } }>) {
+    projects = [...projects, event.detail.data.project];
   }
 
   function sort(projects: Project[]) {
@@ -85,33 +77,9 @@ and we don't want to do that everywhere.
 </script>
 
 <div class="container">
-  <form method="post" action="/projects/" use:enhance={onSubmit}>
-    <h2>{$_("projects.create")}</h2>
-    <Field title={$_("projects.fields.title")} required inline>
-      <Text name="title" placeholder={$_("projects.fields.title")} required />
-    </Field>
-
-    <details>
-      <summary>{$_("common.more")} &hellip;</summary>
-      <Flex direction="column">
-        <Field title={$_("projects.fields.description")}>
-          <TextArea name="description" />
-        </Field>
-        <Field title={$_("projects.fields.private")} inline>
-          <Switch name="private" />
-        </Field>
-        <Field title={$_("projects.fields.pinned")} inline>
-          <Switch name="pinned" />
-        </Field>
-      </Flex>
-    </details>
-    <Flex>
-      <Button mode="primary" type="submit">
-        {$_("common.add")} +
-      </Button>
-    </Flex>
-  </form>
-
+  <Button ghost mode="primary" on:click={() => (createProjectOpen = true)}>
+    <PlusCircle16 /> Create Project
+  </Button>
   {#if projects.length}
     <hr class="divider" />
     <Flex direction="column" class="projects">
@@ -139,13 +107,23 @@ and we don't want to do that everywhere.
     <Button on:click={() => dispatch("close")}>{$_("dialog.done")}</Button>
   </Flex>
 </div>
+{#if createProjectOpen}
+  <Portal>
+    <Modal on:close={() => (createProjectOpen = false)}>
+      <h1 slot="title">Create Project</h1>
+      <EditProject
+        on:close={() => (createProjectOpen = false)}
+        on:success={onCreateSuccess}
+      />
+    </Modal>
+  </Portal>
+{/if}
 
 <style>
-  form,
   .container {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.5rem;
     width: 100%;
   }
 

--- a/src/lib/components/forms/Projects.svelte
+++ b/src/lib/components/forms/Projects.svelte
@@ -11,6 +11,7 @@ and we don't want to do that everywhere.
 
   import { createEventDispatcher, onMount } from "svelte";
   import { _ } from "svelte-i18n";
+  import { FileDirectory24 } from "svelte-octicons";
 
   import Button from "../common/Button.svelte";
   import Flex from "../common/Flex.svelte";
@@ -23,6 +24,7 @@ and we don't want to do that everywhere.
   import EditProject from "./EditProject.svelte";
   import Portal from "../layouts/Portal.svelte";
   import Modal from "../layouts/Modal.svelte";
+  import Empty from "../common/Empty.svelte";
 
   export let documents: Document[] = [];
   export let projects: Project[] = [];
@@ -77,35 +79,34 @@ and we don't want to do that everywhere.
 </script>
 
 <div class="container">
-  <Button ghost mode="primary" on:click={() => (createProjectOpen = true)}>
-    <PlusCircle16 /> Create Project
-  </Button>
-  {#if projects.length}
-    <hr class="divider" />
-    <Flex direction="column" class="projects">
-      {#each sort(projects) as project}
-        <label class="project">
-          <input
-            type="checkbox"
-            name="project"
-            value={project.id}
-            checked={common.has(project.id)}
-            on:change={(e) => toggle(project, e)}
-          />
-          {project.title}
-        </label>
-      {/each}
-    </Flex>
-    <hr class="divider" />
-  {/if}
-  <Flex class="buttons">
+  <div class="projects">
+    {#each sort(projects) as project}
+      <label class="project">
+        <input
+          type="checkbox"
+          name="project"
+          value={project.id}
+          checked={common.has(project.id)}
+          on:change={(e) => toggle(project, e)}
+        />
+        {project.title}
+      </label>
+    {:else}
+      <Empty icon={FileDirectory24}>{$_("projects.none")}</Empty>
+    {/each}
+  </div>
+  <footer>
+    <Button ghost mode="primary" on:click={() => (createProjectOpen = true)}>
+      <PlusCircle16 />
+      {$_("projects.create")}
+    </Button>
     <input
       type="hidden"
       name="documents"
       value={documents.map((d) => d.id).join(",")}
     />
     <Button on:click={() => dispatch("close")}>{$_("dialog.done")}</Button>
-  </Flex>
+  </footer>
 </div>
 {#if createProjectOpen}
   <Portal>
@@ -127,18 +128,25 @@ and we don't want to do that everywhere.
     width: 100%;
   }
 
+  .projects {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.5rem;
+  }
+
+  footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    border-top: 1px solid var(--gray-2);
+    padding: 0.5rem;
+  }
+
   label {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-  }
-
-  details {
-    cursor: pointer;
-  }
-
-  summary {
-    cursor: pointer;
-    margin-bottom: 0.5rem;
   }
 </style>

--- a/src/lib/components/forms/Projects.svelte
+++ b/src/lib/components/forms/Projects.svelte
@@ -11,24 +11,25 @@ and we don't want to do that everywhere.
 
   import { createEventDispatcher, onMount } from "svelte";
   import { _ } from "svelte-i18n";
-  import { FileDirectory24 } from "svelte-octicons";
+  import { FileDirectory24, PlusCircle16 } from "svelte-octicons";
 
   import Button from "../common/Button.svelte";
+  import Empty from "../common/Empty.svelte";
 
-  import { getForUser, add, remove } from "$lib/api/projects";
-  import { getCsrfToken } from "$lib/utils/api";
-  import { intersection } from "@/util/array.js";
-  import { getCurrentUser } from "@/lib/utils/permissions";
-  import { PlusCircle16 } from "svelte-octicons";
   import EditProject from "./EditProject.svelte";
   import Portal from "../layouts/Portal.svelte";
   import Modal from "../layouts/Modal.svelte";
-  import Empty from "../common/Empty.svelte";
+
+  import { getForUser, add, remove } from "$lib/api/projects";
+  import { getCsrfToken } from "$lib/utils/api";
+  import { getCurrentUser } from "$lib/utils/permissions";
+  import { intersection } from "@/util/array.js";
 
   export let documents: Document[] = [];
   export let projects: Project[] = [];
 
   const dispatch = createEventDispatcher();
+
   const me = getCurrentUser();
 
   let createProjectOpen = false;
@@ -108,10 +109,11 @@ and we don't want to do that everywhere.
     <Button on:click={() => dispatch("close")}>{$_("dialog.done")}</Button>
   </footer>
 </div>
+
 {#if createProjectOpen}
   <Portal>
     <Modal on:close={() => (createProjectOpen = false)}>
-      <h1 slot="title">Create Project</h1>
+      <h1 slot="title">{$_("projects.create")}</h1>
       <EditProject
         on:close={() => (createProjectOpen = false)}
         on:success={onCreateSuccess}

--- a/src/lib/components/forms/stories/Projects.stories.svelte
+++ b/src/lib/components/forms/stories/Projects.stories.svelte
@@ -12,6 +12,10 @@
   };
 </script>
 
+<Story name="Without Projects">
+  <Projects projects={[]} documents={[document]} />
+</Story>
+
 <Story name="one document">
   <Projects projects={projectList.results} documents={[document]} />
 </Story>


### PR DESCRIPTION
Fixes #653

- Uses existing EditProject form in a modal, instead of inlining a custom form.
- Adds `on:success` event to EditProject form to allow adding created project to list of projects.