### PR TITLE
Improve note rendering

### DIFF
--- a/src/lib/components/forms/EditNote.svelte
+++ b/src/lib/components/forms/EditNote.svelte
@@ -46,13 +46,7 @@ Positioning and generating coordinates should happen outside of this form.
   }
 </script>
 
-<form
-  {action}
-  method="post"
-  class:page_level
-  class="card"
-  use:enhance={onSubmit}
->
+<form {action} method="post" class:page_level use:enhance={onSubmit}>
   <Flex direction="column" gap={1}>
     <Field title={$_("annotate.fields.title")} required>
       <Text

--- a/src/lib/components/forms/EditNote.svelte
+++ b/src/lib/components/forms/EditNote.svelte
@@ -98,9 +98,3 @@ Positioning and generating coordinates should happen outside of this form.
     </Flex>
   </Flex>
 </form>
-
-<style>
-  form {
-    box-shadow: var(--shadow-1);
-  }
-</style>

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -128,7 +128,9 @@ Assumes it's a child of a ViewerContext
   }
 
   function positionNote(note: BBox, offset: number) {
-    if (note.y2 > 0.75) {
+    console.log(page_number + 1, document.page_count);
+    const isLastPage = page_number + 1 === document.page_count;
+    if (isLastPage && note.y2 > 0.5) {
       return `bottom: calc(calc(100% - ${note.y1 * 100}%) + ${offset}rem);`;
     } else {
       return `top: calc(${note.y2 * 100}% + ${offset}rem);`;

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -313,7 +313,7 @@ Assumes it's a child of a ViewerContext
     position: absolute;
     pointer-events: all;
 
-    scroll-margin-top: 6rem;
+    scroll-margin-top: 50vh;
   }
 
   .note {

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -43,10 +43,6 @@ Assumes it's a child of a ViewerContext
   const currentNote = getCurrentNote();
   const newNote = getNewNote();
 
-  $: {
-    console.log($newNote);
-  }
-
   let drawStart: Nullable<[x: number, y: number]> = null;
   let drawing = false;
 

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -128,7 +128,6 @@ Assumes it's a child of a ViewerContext
   }
 
   function positionNote(note: BBox, offset: number) {
-    console.log(page_number + 1, document.page_count);
     const isLastPage = page_number + 1 === document.page_count;
     if (isLastPage && note.y2 > 0.5) {
       return `bottom: calc(calc(100% - ${note.y1 * 100}%) + ${offset}rem);`;
@@ -315,7 +314,7 @@ Assumes it's a child of a ViewerContext
     position: absolute;
     pointer-events: all;
 
-    scroll-margin-top: 50vh;
+    scroll-margin-top: 6rem;
   }
 
   .note {

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -334,7 +334,7 @@ Assumes it's a child of a ViewerContext
   .box {
     position: absolute;
     border: 4px solid transparent;
-    border-color: color-mix(in srgb, var(--blue-3), var(--gray-4));
+    border-color: color-mix(in srgb, var(--note-private), var(--gray-4));
     background: var(--note-private);
     opacity: 0.75;
     mix-blend-mode: multiply;
@@ -350,18 +350,18 @@ Assumes it's a child of a ViewerContext
   }
 
   .box.public {
-    border-color: color-mix(in srgb, var(--yellow-3), var(--gray-4));
-    background: var(--yellow-3);
+    border-color: color-mix(in srgb, var(--note-public), var(--gray-4));
+    background: var(--note-public);
   }
 
   .box.organization {
-    border-color: color-mix(in srgb, var(--green-3), var(--gray-4));
-    background: var(--green-3);
+    border-color: color-mix(in srgb, var(--note-org), var(--gray-4));
+    background: var(--note-org);
   }
 
   .box.private {
-    border-color: color-mix(in srgb, var(--blue-3), var(--gray-4));
-    background: var(--blue-3);
+    border-color: color-mix(in srgb, var(--note-private), var(--gray-4));
+    background: var(--note-private);
   }
 
   a.note-highlight {
@@ -376,23 +376,23 @@ Assumes it's a child of a ViewerContext
   }
 
   a.note-highlight.public {
-    background-color: var(--yellow-3);
+    background-color: var(--note-public);
     &.active {
       border-color: color-mix(in srgb, var(--yellow-3), var(--gray-4));
     }
   }
 
   a.note-highlight.private {
-    background-color: var(--blue-3);
+    background-color: var(--note-private);
     &.active {
-      border-color: color-mix(in srgb, var(--blue-3), var(--gray-4));
+      border-color: color-mix(in srgb, var(--note-private), var(--gray-4));
     }
   }
 
   a.note-highlight.organization {
-    background-color: var(--green-3);
+    background-color: var(--note-org);
     &.active {
-      border-color: color-mix(in srgb, var(--green-3), var(--gray-4));
+      border-color: color-mix(in srgb, var(--note-org), var(--gray-4));
     }
   }
 </style>

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -217,7 +217,7 @@ Assumes it's a child of a ViewerContext
     </a>
   {/each}
 
-  {#if $currentNote && !Boolean($newNote)}
+  {#if $currentNote && !Boolean($newNote) && $currentNote.page_number === page_number}
     <div
       class="note card"
       style={positionNote($currentNote, 1.5)}

--- a/src/lib/components/viewer/Note.svelte
+++ b/src/lib/components/viewer/Note.svelte
@@ -305,15 +305,15 @@
   }
 
   .public .highlight {
-    border-color: var(--yellow-3);
+    border-color: var(--note-public);
   }
 
   .private .highlight {
-    border-color: var(--blue-3);
+    border-color: var(--note-private);
   }
 
   .organization .highlight {
-    border-color: var(--green-3);
+    border-color: var(--note-org);
   }
 
   .content {
@@ -347,17 +347,17 @@
   }
 
   span.access.public {
-    fill: var(--yellow-3);
-    color: var(--yellow-4);
+    fill: var(--note-public);
+    color: color-mix(in srgb, var(--note-public), var(--gray-5));
   }
 
   span.access.organization {
-    fill: var(--green-3);
-    color: var(--green-4);
+    fill: var(--note-org);
+    color: color-mix(in srgb, var(--note-org), var(--gray-5));
   }
 
   span.access.private {
-    color: var(--blue-4);
-    fill: var(--blue-3);
+    fill: var(--note-private);
+    color: color-mix(in srgb, var(--note-private), var(--gray-5));
   }
 </style>

--- a/src/lib/components/viewer/Note.svelte
+++ b/src/lib/components/viewer/Note.svelte
@@ -251,43 +251,13 @@
 <style>
   .note {
     display: flex;
-    padding: var(--font-xs, 0.75rem) var(--font-md, 1rem);
     flex-direction: column;
     align-items: flex-start;
     gap: 1rem;
     pointer-events: all;
     position: relative;
-
-    border-radius: 0.5rem;
-    border: 1px solid var(--gray-2, #d8dee2);
-    background: var(--white, #fff);
-
     scroll-margin-top: 6rem;
-
     z-index: var(--z-note);
-
-    /* shadow-2 */
-    box-shadow: var(--shadow-2);
-  }
-
-  /* overlay */
-  .note.document,
-  .note.annotating,
-  .note.redacting {
-    display: flex;
-    padding: 0.75rem 1rem;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.75rem;
-
-    position: absolute;
-    /* shift up to account for the note header */
-    top: calc(var(--y1) * 100% - 3rem);
-    /* left: calc(var(--x1) * 100% - 1px - var(--font-xs)); */
-    left: 0;
-    max-width: 100%; /* maybe should just be width: 100% */
-
-    z-index: 10;
   }
 
   /* page-level */

--- a/src/lib/components/viewer/Notes.svelte
+++ b/src/lib/components/viewer/Notes.svelte
@@ -26,13 +26,13 @@ Assumes it's a child of a ViewerContext
 <div class="pages">
   {#each notes as note}
     <div class="note-wrapper">
-      <Note {note} />
-      <h4>
-        <a href={getViewerHref({ document, note, embed })}>
+      <header>
+        <a class="pageNumber" href={getViewerHref({ document, note, embed })}>
           {$_("documents.page")}
           {note.page_number + 1}
         </a>
-      </h4>
+      </header>
+      <div class="card"><Note {note} /></div>
     </div>
   {:else}
     <Empty icon={ListOrdered24}>
@@ -51,24 +51,39 @@ Assumes it's a child of a ViewerContext
     display: flex;
     flex-flow: column;
     align-items: center;
-    gap: 3rem;
+    gap: 2rem;
     margin: 0 auto;
     max-width: 38.0625rem;
+    padding: 2rem 0;
+  }
+
+  .card {
+    border: 1px solid var(--gray-2);
+    box-shadow: var(--shadow-2);
   }
 
   .note-wrapper {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
   }
 
-  h4,
-  h4 a {
-    text-decoration: none;
+  header {
+    display: flex;
+    padding: 0.5rem;
+    gap: 1rem;
+    justify-content: space-between;
+    align-items: center;
+    align-self: stretch;
+  }
+
+  a.pageNumber {
+    flex: 0 0 auto;
+    color: var(--gray-4, #5c717c);
+    font-size: var(--font-sm);
     font-weight: var(--font-regular);
-  }
-
-  h4 a:hover {
-    text-decoration: underline;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
   }
 </style>

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -11,6 +11,7 @@ layouts, stories, and tests.
     Note,
     ViewerMode,
     Zoom,
+    BBox,
   } from "$lib/api/types";
 
   import { afterNavigate } from "$app/navigation";
@@ -59,7 +60,11 @@ layouts, stories, and tests.
     return getContext("embed") ?? false;
   }
 
-  export function getCurrentNote(): Readable<Note> {
+  export function getNewNote(): Writable<Nullable<Partial<Note> & BBox>> {
+    return getContext("newNote");
+  }
+
+  export function getCurrentNote(): Writable<Nullable<Note>> {
     return getContext("currentNote");
   }
 
@@ -119,6 +124,7 @@ layouts, stories, and tests.
   setContext("asset_url", asset_url);
   setContext("embed", embed);
   setContext("query", query);
+  setContext("newNote", writable(null));
   setContext("currentNote", writable(note));
   setContext("currentPage", writable(page));
   setContext("currentMode", writable(mode));

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -176,10 +176,10 @@ layouts, stories, and tests.
   afterNavigate(() => {
     // refresh stores from URL state
     const { hash } = $pageStore.url;
+    const hashPage = pageFromHash(hash);
     $currentMode = mode;
     $currentNote = $currentDoc.notes.find(noteMatchingPageHash) ?? null;
-    if (shouldPaginate(mode)) {
-      console.log("scroll");
+    if (shouldPaginate(mode) && $currentPage !== hashPage) {
       scrollToHash(hash);
     }
   });

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -179,6 +179,7 @@ layouts, stories, and tests.
     $currentMode = mode;
     $currentNote = $currentDoc.notes.find(noteMatchingPageHash) ?? null;
     if (shouldPaginate(mode)) {
+      console.log("scroll");
       scrollToHash(hash);
     }
   });

--- a/src/lib/components/viewer/stories/Viewer.stories.svelte
+++ b/src/lib/components/viewer/stories/Viewer.stories.svelte
@@ -65,6 +65,18 @@
 <Story name="Text" args={{ ...args, mode: "text" }} />
 <Story name="Thumbnails" args={{ ...args, mode: "grid" }} />
 <Story name="Notes" args={{ ...args, mode: "notes" }} />
+<Story
+  name="Annotating"
+  args={{
+    ...args,
+    mode: "annotating",
+    document: {
+      ...document,
+      edit_access: true,
+      notes: document.notes.map((note) => ({ ...note, edit_access: true })),
+    },
+  }}
+/>
 
 <style>
   .vh {


### PR DESCRIPTION
Fixes #689

- Save `newNote` to ViewerContext store for consistent `$newNote` value between multiple page AnnotationLayers
- Places a note above or below its highlight box based on how much space is available in the page
- Consistent styling for notes between reading/writing and inline/page
- Improve rendering for `currentNote` by deduplicating note objects