### PR TITLE
Display PDF loading progress in header toolbar

### DIFF
--- a/src/lib/components/viewer/LoadingToolbar.svelte
+++ b/src/lib/components/viewer/LoadingToolbar.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import type { Nullable } from "$lib/api/types";
+  import PageToolbar from "../common/PageToolbar.svelte";
+
+  export let progress: Nullable<number> = null;
+</script>
+
+<PageToolbar>
+  <div class="container" slot="center">
+    <p>Loading PDF…</p>
+    {#if progress}
+      <progress value={progress} />
+    {:else}
+      <progress />
+    {/if}
+  </div>
+</PageToolbar>
+
+<style>
+  .container {
+    padding: 0 0.5rem;
+    display: flex;
+    gap: 2rem;
+    align-items: center;
+  }
+  p {
+    flex: 0 1 auto;
+    font-weight: var(--font-semibold);
+    color: var(--gray-4);
+  }
+  progress {
+    flex: 1 1 auto;
+  }
+</style>

--- a/src/lib/components/viewer/ReadingToolbar.svelte
+++ b/src/lib/components/viewer/ReadingToolbar.svelte
@@ -43,10 +43,8 @@ Assumes it's a child of a ViewerContext
   const query = getQuery();
   const mode = getCurrentMode();
   const embed = isEmbedded();
-  const progress = getPDFProgress();
 
   $: document = $documentStore;
-  $: loading = $progress.total > 0 ? $progress.loaded / $progress.total : null;
   $: canWrite = !embed && document.edit_access;
   $: BREAKPOINTS = {
     READ_MENU: width > remToPx(52),
@@ -76,37 +74,40 @@ Assumes it's a child of a ViewerContext
   };
 </script>
 
-{#if loading && loading < 1}
-  <PageToolbar bind:width>
-    <svelte:fragment slot="center">
-      <p>Loading…</p>
-      <progress value={loading} />
-    </svelte:fragment>
-  </PageToolbar>
-{:else}
-  <PageToolbar bind:width>
-    <svelte:fragment slot="left">
-      {#if BREAKPOINTS.READ_MENU}
-        <div class="tabs" role="tablist">
+<PageToolbar bind:width>
+  <svelte:fragment slot="left">
+    {#if BREAKPOINTS.READ_MENU}
+      <div class="tabs" role="tablist">
+        {#each readModes.entries() as [value, name]}
+          <Tab
+            active={$mode === value}
+            href={getViewerHref({ document, mode: value, embed })}
+          >
+            <svelte:component this={icons[value]} />
+            {name}
+          </Tab>
+        {/each}
+      </div>
+    {:else}
+      <Dropdown position="bottom-start">
+        <SidebarItem slot="anchor">
+          <svelte:component this={icons[$mode]} slot="start" />
+          {Array.from(readModes).find(([value]) => value === $mode)[1]}
+          <ChevronDown12 slot="end" />
+        </SidebarItem>
+        <Menu slot="default" let:close>
           {#each readModes.entries() as [value, name]}
-            <Tab
-              active={$mode === value}
+            <MenuItem
+              selected={$mode === value}
               href={getViewerHref({ document, mode: value, embed })}
+              on:click={close}
             >
-              <svelte:component this={icons[value]} />
+              <svelte:component this={icons[value]} slot="icon" />
               {name}
-            </Tab>
+            </MenuItem>
           {/each}
-        </div>
-      {:else}
-        <Dropdown position="bottom-start">
-          <SidebarItem slot="anchor">
-            <svelte:component this={icons[$mode]} slot="start" />
-            {Array.from(readModes).find(([value]) => value === $mode)[1]}
-            <ChevronDown12 slot="end" />
-          </SidebarItem>
-          <Menu slot="default" let:close>
-            {#each readModes.entries() as [value, name]}
+          {#if BREAKPOINTS.WRITE_MENU && canWrite}
+            {#each writeModes as [value, name]}
               <MenuItem
                 selected={$mode === value}
                 href={getViewerHref({ document, mode: value, embed })}
@@ -116,47 +117,35 @@ Assumes it's a child of a ViewerContext
                 {name}
               </MenuItem>
             {/each}
-            {#if BREAKPOINTS.WRITE_MENU && canWrite}
-              {#each writeModes as [value, name]}
-                <MenuItem
-                  selected={$mode === value}
-                  href={getViewerHref({ document, mode: value, embed })}
-                  on:click={close}
-                >
-                  <svelte:component this={icons[value]} slot="icon" />
-                  {name}
-                </MenuItem>
-              {/each}
-            {/if}
-          </Menu>
-        </Dropdown>
-      {/if}
-    </svelte:fragment>
-    <Flex justify="end" slot="right">
-      {#if !BREAKPOINTS.WRITE_MENU && canWrite}
-        {#each writeModes as [value, name]}
-          <Button ghost href={getViewerHref({ document, mode: value, embed })}>
-            <span class="icon"><svelte:component this={icons[value]} /></span>
-            {name}
-          </Button>
-        {/each}
-      {/if}
-      {#if BREAKPOINTS.SEARCH_MENU}
-        <Dropdown position="bottom-end">
-          <Button minW={false} ghost slot="anchor">
-            <Search16 />
-            {$_("common.search")}
-          </Button>
-          <Menu>
-            <Search name="q" {query} />
-          </Menu>
-        </Dropdown>
-      {:else}
-        <Search name="q" {query} />
-      {/if}
-    </Flex>
-  </PageToolbar>
-{/if}
+          {/if}
+        </Menu>
+      </Dropdown>
+    {/if}
+  </svelte:fragment>
+  <Flex justify="end" slot="right">
+    {#if !BREAKPOINTS.WRITE_MENU && canWrite}
+      {#each writeModes as [value, name]}
+        <Button ghost href={getViewerHref({ document, mode: value, embed })}>
+          <span class="icon"><svelte:component this={icons[value]} /></span>
+          {name}
+        </Button>
+      {/each}
+    {/if}
+    {#if BREAKPOINTS.SEARCH_MENU}
+      <Dropdown position="bottom-end">
+        <Button minW={false} ghost slot="anchor">
+          <Search16 />
+          {$_("common.search")}
+        </Button>
+        <Menu>
+          <Search name="q" {query} />
+        </Menu>
+      </Dropdown>
+    {:else}
+      <Search name="q" {query} />
+    {/if}
+  </Flex>
+</PageToolbar>
 
 <style>
   .tabs {

--- a/src/lib/components/viewer/Viewer.svelte
+++ b/src/lib/components/viewer/Viewer.svelte
@@ -25,13 +25,23 @@ Assumes it's a child of a ViewerContext
   import RedactionToolbar from "./RedactionToolbar.svelte";
 
   // utils
-  import { getCurrentMode, isEmbedded } from "./ViewerContext.svelte";
+  import {
+    getCurrentMode,
+    getPDFProgress,
+    isEmbedded,
+  } from "./ViewerContext.svelte";
+  import LoadingToolbar from "./LoadingToolbar.svelte";
 
   const embed = isEmbedded();
   const currentMode = getCurrentMode();
+  const progress = getPDFProgress();
 
   $: mode = $currentMode;
   $: showPDF = ["document", "annotating", "redacting"].includes($currentMode);
+  $: loading = $progress.total > 0 ? $progress.loaded / $progress.total : null;
+  $: {
+    console.log(loading);
+  }
 </script>
 
 <div class="container">
@@ -51,7 +61,9 @@ Assumes it's a child of a ViewerContext
           </Button>
         </div>
       {/if}
-      {#if !embed && mode === "annotating"}
+      {#if loading && loading < 1}
+        <LoadingToolbar progress={loading} />
+      {:else if !embed && mode === "annotating"}
         <AnnotationToolbar />
       {:else if !embed && mode === "redacting"}
         <RedactionToolbar />

--- a/src/lib/components/viewer/Viewer.svelte
+++ b/src/lib/components/viewer/Viewer.svelte
@@ -31,17 +31,23 @@ Assumes it's a child of a ViewerContext
     isEmbedded,
   } from "./ViewerContext.svelte";
   import LoadingToolbar from "./LoadingToolbar.svelte";
+  import { onMount } from "svelte";
 
   const embed = isEmbedded();
   const currentMode = getCurrentMode();
   const progress = getPDFProgress();
 
+  // only show loading for slow-loading pages
+  let showLoading = false;
+
   $: mode = $currentMode;
   $: showPDF = ["document", "annotating", "redacting"].includes($currentMode);
   $: loading = $progress.total > 0 ? $progress.loaded / $progress.total : null;
-  $: {
-    console.log(loading);
-  }
+
+  onMount(() => {
+    const timeout = setTimeout(() => (showLoading = true), 100);
+    return () => clearTimeout(timeout);
+  });
 </script>
 
 <div class="container">
@@ -61,7 +67,7 @@ Assumes it's a child of a ViewerContext
           </Button>
         </div>
       {/if}
-      {#if loading && loading < 1}
+      {#if showLoading && loading && loading < 1}
         <LoadingToolbar progress={loading} />
       {:else if !embed && mode === "annotating"}
         <AnnotationToolbar />

--- a/src/lib/components/viewer/Viewer.svelte
+++ b/src/lib/components/viewer/Viewer.svelte
@@ -45,7 +45,7 @@ Assumes it's a child of a ViewerContext
   $: loading = $progress.total > 0 ? $progress.loaded / $progress.total : null;
 
   onMount(() => {
-    const timeout = setTimeout(() => (showLoading = true), 100);
+    const timeout = setTimeout(() => (showLoading = true), 1000);
     return () => clearTimeout(timeout);
   });
 </script>

--- a/src/lib/components/viewer/Viewer.svelte
+++ b/src/lib/components/viewer/Viewer.svelte
@@ -45,7 +45,7 @@ Assumes it's a child of a ViewerContext
   $: loading = $progress.total > 0 ? $progress.loaded / $progress.total : null;
 
   onMount(() => {
-    const timeout = setTimeout(() => (showLoading = true), 1000);
+    const timeout = setTimeout(() => (showLoading = true), 500);
     return () => clearTimeout(timeout);
   });
 </script>

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -159,12 +159,11 @@ layouts, stories, and tests.
     // we might move this to a load function
     if (!task) {
       task = pdfjs.getDocument({ url: asset_url });
+      task.onProgress = (p: DocumentLoadProgress) => {
+        $progress = p;
+      };
       $pdf = task.promise;
     }
-
-    task.onProgress = (p: DocumentLoadProgress) => {
-      $progress = p;
-    };
   });
 
   afterNavigate(() => {

--- a/src/lib/components/viewer/stories/LoadingToolbar.stories.svelte
+++ b/src/lib/components/viewer/stories/LoadingToolbar.stories.svelte
@@ -1,0 +1,24 @@
+<script lang="ts" context="module">
+  import type { Meta } from "@storybook/svelte";
+  import LoadingToolbar from "../LoadingToolbar.svelte";
+  import { Story, Template } from "@storybook/addon-svelte-csf";
+
+  export const meta: Meta = {
+    title: "Components / Viewer / Toolbars / Loading",
+    component: LoadingToolbar,
+    parameters: {
+      layout: "fullscreen",
+    },
+  };
+
+  let args = {
+    progress: 0.5,
+  };
+</script>
+
+<Template let:args>
+  <LoadingToolbar {...args} />
+</Template>
+
+<Story name="With Progress" {args} />
+<Story name="Indeterminate" args={{ ...args, progress: undefined }} />


### PR DESCRIPTION
Fixes #547

I'm open to alternate placements, but this made sense to me: the viewer isn't fully interactive until the PDF loads.