### PR TITLE
Stabilize Chromatic snapshots

### DIFF
--- a/src/lib/components/inputs/TextArea.svelte
+++ b/src/lib/components/inputs/TextArea.svelte
@@ -1,50 +1,55 @@
 <!-- @component
 A text area for writing text
 -->
-<script lang="ts">
-  import { textAreaResize } from "@/util/textareaResize.js";
+<script lang="ts" context="module">
+  /**
+   * Determines the height of the textarea by collapsing it,
+   * and then measuring the amount of overflow.
+   */
+  export function autoResize(textarea: HTMLTextAreaElement, offset = 2) {
+    const resize = () => {
+      textarea.style.height = "auto"; // reset the height
+      textarea.style.height = `${textarea.scrollHeight + offset}px`;
+    };
 
-  export let name: string = null;
-  export let value = "";
-  export let placeholder = "";
-  export let required = false;
-  export let disabled = false;
-  export let readonly = false;
+    textarea.style.overflow = "hidden";
+    textarea.style.boxSizing = "border-box";
+
+    textarea.addEventListener("input", resize);
+    window.addEventListener("resize", resize);
+    window.addEventListener("loadingdone", resize);
+
+    return {
+      destroy: () => {
+        textarea.removeEventListener("input", resize);
+        window.removeEventListener("resize", resize);
+      },
+    };
+  }
 </script>
 
-<textarea
-  bind:value
-  {name}
-  {required}
-  {disabled}
-  {placeholder}
-  {readonly}
-  use:textAreaResize
-/>
+<script lang="ts">
+  export let value = "";
+</script>
+
+<textarea bind:value use:autoResize {...$$restProps} />
 
 <style>
   textarea {
-    display: flex;
-    padding: 0.375rem 0.75rem;
-    justify-content: center;
-    align-items: center;
-    gap: 0.5rem;
     width: 100%;
+    padding: 0.375rem 0.75rem;
 
     border-radius: 0.5rem;
     border: 1px solid var(--gray-3, hwb(205 60% 30%));
     background: var(--white, #fff);
-    box-shadow: 0px 2px 0px 0px var(--gray-2, #d8dee2) inset;
+    box-shadow: 0px 2px 2px 0px var(--gray-2, #d8dee2) inset;
 
     color: var(--gray-5, #233944);
-    overflow: hidden;
-    text-overflow: ellipsis;
     font-family: var(--font-family, var(--font-sans, "Source Sans Pro"));
     font-size: var(--font-size, var(--font-md, 1rem));
     font-style: normal;
     font-weight: 400;
-    line-height: normal;
 
-    resize: var(--resize, both);
+    resize: var(--resize, none);
   }
 </style>

--- a/src/lib/components/inputs/TextArea.svelte
+++ b/src/lib/components/inputs/TextArea.svelte
@@ -2,12 +2,14 @@
 A text area for writing text
 -->
 <script lang="ts" context="module">
+  import { browser } from "$app/environment";
+
   /**
    * Determines the height of the textarea by collapsing it,
    * and then measuring the amount of overflow.
    */
   export function autoResize(textarea: HTMLTextAreaElement, offset = 2) {
-    if (CSS.supports("field-sizing", "content")) return;
+    if (browser && CSS.supports("field-sizing", "content")) return;
     const resize = () => {
       textarea.style.height = "auto"; // reset the height
       textarea.style.height = `${textarea.scrollHeight + offset}px`;
@@ -22,7 +24,7 @@ A text area for writing text
 
     return {
       destroy: () => {
-        if (CSS.supports("field-sizing", "content")) return;
+        if (browser && CSS.supports("field-sizing", "content")) return;
         textarea.removeEventListener("input", resize);
         window.removeEventListener("resize", resize);
       },

--- a/src/lib/components/inputs/TextArea.svelte
+++ b/src/lib/components/inputs/TextArea.svelte
@@ -7,6 +7,7 @@ A text area for writing text
    * and then measuring the amount of overflow.
    */
   export function autoResize(textarea: HTMLTextAreaElement, offset = 2) {
+    if (CSS.supports("field-sizing", "content")) return;
     const resize = () => {
       textarea.style.height = "auto"; // reset the height
       textarea.style.height = `${textarea.scrollHeight + offset}px`;
@@ -21,6 +22,7 @@ A text area for writing text
 
     return {
       destroy: () => {
+        if (CSS.supports("field-sizing", "content")) return;
         textarea.removeEventListener("input", resize);
         window.removeEventListener("resize", resize);
       },
@@ -51,5 +53,6 @@ A text area for writing text
     font-weight: 400;
 
     resize: var(--resize, none);
+    field-sizing: content;
   }
 </style>

--- a/src/lib/components/inputs/stories/Textarea.stories.svelte
+++ b/src/lib/components/inputs/stories/Textarea.stories.svelte
@@ -11,6 +11,7 @@
 
   let args = {
     name: "textInput",
+    value: "",
   };
 </script>
 
@@ -20,4 +21,13 @@
 
 <Story name="Empty" {args} />
 
-<Story name="With content" args={{ ...args, value: "This is some text…" }} />
+<Story
+  name="With content"
+  args={{ ...args, value: "This is some text\nwith multiple lines" }}
+/>
+
+<style>
+  div {
+    width: 24rem;
+  }
+</style>

--- a/src/lib/components/processing/stories/Process.stories.svelte
+++ b/src/lib/components/processing/stories/Process.stories.svelte
@@ -27,7 +27,13 @@
   </Process>
 </Template>
 
-<Story name="In-Progress" args={{ ...args, status: "in_progress" }} />
+<Story
+  name="In-Progress"
+  args={{ ...args, status: "in_progress" }}
+  parameters={{
+    chromatic: { disableSnapshot: true },
+  }}
+/>
 <Story
   name="With Progress"
   args={{ ...args, status: "in_progress", progress: ".7" }}


### PR DESCRIPTION
Fixes #672

This attempts to fix inconsistent snapshots in Chromatic snapshots.
This usually occurs when rendering an element with autoresizing textareas. 

Unfortunately, we won't know if it works until our usage resets on October 30!

- Uses experimental CSS rule `field-sizing: content` to automatically resize text areas in Chromium browsers
- Polyfills functionality with existing auto-resizing function, adjusted to wait until webfonts finish loading before running initial resize.

This prevents the textarea from resizing until the window is fully loaded, hopefully preveting inconsistent snapshots.

In addition, it excludes the "Process / In-Progress" story from snapshots, since it uses an animated, indeterminate progress indicator. This serves as an example for how to remove other animated or indeterminate stories from snapshots moving forward.