### PR TITLE
Expand projects in document search results

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,7 +4,17 @@
 name: "Chromatic"
 
 # Event for the workflow
-on: push
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "static/**"
+      - "!src/**/*.ts.snap"
+  push:
+    paths:
+      - "src/**"
+      - "static/**"
+      - "!src/**/*.ts.snap"
 
 jobs:
   chromatic-deployment:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,6 +10,11 @@ on:
       - "src/**"
       - "static/**"
       - "!src/**/*.ts.snap"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
     paths:
       - "src/**"
@@ -24,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required to retrieve git history
+          ref: ${{ github.event.pull_request.head.ref }} # Tell the checkout which commit hash to reference
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:

--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -24,7 +24,6 @@ import type {
 } from "./types";
 
 import { writable, type Writable } from "svelte/store";
-import { DEFAULT_EXPAND } from "@/api/common.js";
 import { getUserName, isOrg } from "./accounts";
 import {
   APP_URL,

--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -66,7 +66,9 @@ export async function search(
 ): Promise<APIResponse<DocumentResults, null>> {
   const endpoint = new URL("documents/search/", BASE_API_URL);
 
-  endpoint.searchParams.set("expand", DEFAULT_EXPAND);
+  const expand = ["user", "organization", "projects"].join(",");
+
+  endpoint.searchParams.set("expand", expand);
   endpoint.searchParams.set("q", query);
 
   for (const [k, v] of Object.entries(options)) {

--- a/src/lib/api/tests/documents.test.ts
+++ b/src/lib/api/tests/documents.test.ts
@@ -168,7 +168,7 @@ describe("document fetching", () => {
     expect(results).toStrictEqual(search);
     expect(mockFetch).toBeCalledWith(
       new URL(
-        "documents/search/?expand=user%2Corganization&q=boston&hl=true",
+        "documents/search/?expand=user%2Corganization%2Cprojects&q=boston&hl=true",
         BASE_API_URL,
       ),
       { credentials: "include" },

--- a/src/lib/components/documents/Access.svelte
+++ b/src/lib/components/documents/Access.svelte
@@ -37,12 +37,34 @@
   export let level: Level;
 </script>
 
-<SidebarItem
-  inline
-  title={$_(level.description)}
-  --color="var(--gray-5)"
-  --font-size="inherit"
->
-  <svelte:component this={level.icon} height="1em" width="1em" slot="start" />
+<div class="access {level.value}">
+  <svelte:component this={level.icon} height="1em" width="1em" />
   {$_(level.title)}
-</SidebarItem>
+</div>
+
+<style>
+  .access {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+
+    font-weight: var(--font-semibold);
+    color: var(--color, var(--gray-5));
+    fill: var(--fill, var(--gray-4));
+  }
+
+  .access.public {
+    fill: var(--note-public);
+    color: color-mix(in srgb, var(--note-public), var(--gray-5));
+  }
+
+  .access.organization {
+    fill: var(--note-org);
+    color: color-mix(in srgb, var(--note-org), var(--gray-5));
+  }
+
+  .access.private {
+    fill: var(--note-private);
+    color: color-mix(in srgb, var(--note-private), var(--gray-5));
+  }
+</style>

--- a/src/lib/components/documents/DocumentListItem.svelte
+++ b/src/lib/components/documents/DocumentListItem.svelte
@@ -167,7 +167,6 @@ If we're in an embed, we want to open links to documents in new tabs and hide th
 
   .small .head {
     flex-direction: column;
-    align-items: center;
   }
 
   .small h3 {
@@ -231,9 +230,9 @@ If we're in an embed, we want to open links to documents in new tabs and hide th
     font-style: normal;
     font-weight: var(--font-semibold, 600);
     line-height: normal;
-    /* overflow: hidden;
+    overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap; */
+    /* white-space: nowrap; */
     max-width: 100%;
   }
 

--- a/src/lib/components/documents/DocumentListItem.svelte
+++ b/src/lib/components/documents/DocumentListItem.svelte
@@ -112,7 +112,6 @@ If we're in an embed, we want to open links to documents in new tabs and hide th
         <div class="access">
           <DocAccess {level} />
         </div>
-        <hr class="rule" />
       {/if}
     </div>
     <!-- {#if document.description}
@@ -167,14 +166,14 @@ If we're in an embed, we want to open links to documents in new tabs and hide th
   }
 
   .small .head {
-    flex-wrap: wrap;
-    flex-direction: row-reverse;
+    flex-direction: column;
     align-items: center;
   }
 
   .small h3 {
     flex: 1 1 100%;
     order: 1;
+    font-size: var(--font-md, 1rem);
   }
 
   .document-list-item:hover,
@@ -265,18 +264,8 @@ If we're in an embed, we want to open links to documents in new tabs and hide th
   }
 
   .small .access {
-    align-self: flex-end;
+    align-self: flex-start;
     flex: 0 1 auto;
-  }
-
-  .rule {
-    display: none;
-  }
-
-  .small .rule {
-    display: block;
-    flex: 1 1 auto;
-    border: 1px solid var(--gray-2);
   }
 
   .fallback {

--- a/src/lib/components/documents/DocumentListItem.svelte
+++ b/src/lib/components/documents/DocumentListItem.svelte
@@ -144,7 +144,7 @@ If we're in an embed, we want to open links to documents in new tabs and hide th
     max-width: 100%;
     min-width: 0;
     align-self: stretch;
-    gap: 0.5rem;
+    gap: 1rem;
     padding: 0.75rem;
     border-radius: 0.25rem;
     color: inherit;
@@ -191,7 +191,6 @@ If we're in an embed, we want to open links to documents in new tabs and hide th
     flex-direction: column;
     align-items: center;
     position: relative;
-    margin: 0.5rem 0.5rem 0 0;
   }
 
   .thumbnail img,

--- a/src/lib/components/documents/stories/DocumentListItem.stories.svelte
+++ b/src/lib/components/documents/stories/DocumentListItem.stories.svelte
@@ -5,12 +5,12 @@
   import document from "@/test/fixtures/documents/document.json";
   import expanded from "@/test/fixtures/documents/document-expanded.json";
   import santaanas from "@/test/fixtures/documents/examples/the-santa-anas.json";
+  import { projectList } from "@/test/fixtures/projects";
 
   export const meta = {
     title: "Components / Documents / Document List Item",
     component: DocumentListItem,
     tags: ["autodocs"],
-    parameters: { layout: "centered" },
   };
 </script>
 
@@ -18,7 +18,14 @@
   <DocumentListItem {...args} />
 </Template>
 
-<Story name="default" args={{ document: expanded }} />
+<Story name="Basic" args={{ document: expanded }} />
+
+<Story
+  name="Lots of Projects"
+  args={{
+    document: { ...expanded, projects: projectList.results.slice(0, 7) },
+  }}
+/>
 
 <Story name="minimal" args={{ document }} />
 

--- a/src/lib/components/documents/stories/ResultsList.stories.svelte
+++ b/src/lib/components/documents/stories/ResultsList.stories.svelte
@@ -22,32 +22,27 @@
     title: "Components / Documents / Results list",
     component: ResultsList,
     tags: ["autodocs"],
-    parameters: { layout: "centered" },
   };
 </script>
 
 <Story name="With Results">
-  <div style="width: 36rem"><ResultsList {results} {count} {next} /></div>
+  <ResultsList {results} {count} {next} />
 </Story>
 
 <Story name="Empty">
-  <div style="width: 36rem"><ResultsList /></div>
+  <ResultsList />
 </Story>
 
 <Story name="Infinite">
-  <div style="width: 36rem"><ResultsList {results} {count} {next} auto /></div>
+  <ResultsList {results} {count} {next} auto />
 </Story>
 
 <Story name="Pending documents">
-  <div style="width: 36rem">
-    <ResultsList {results} {count} {next}>
-      <Pending {pending} slot="start" />
-    </ResultsList>
-  </div>
+  <ResultsList {results} {count} {next}>
+    <Pending {pending} slot="start" />
+  </ResultsList>
 </Story>
 
 <Story name="Highlighted">
-  <div style="width: 36rem">
-    <ResultsList results={highlighted} {count} {next} />
-  </div>
+  <ResultsList results={highlighted} {count} {next} />
 </Story>

--- a/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
+++ b/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`DocumentListItem > renders 1`] = `
 <div>
   <a
-    class="document-list-item svelte-o1ttsh"
+    class="document-list-item svelte-6vo7lg"
     href="https://www.dev.documentcloud.org/documents/24002098-quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018/"
   >
     <div
-      class="thumbnail svelte-o1ttsh"
+      class="thumbnail svelte-6vo7lg"
     >
       <img
         alt="Page 1, Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018"
-        class="svelte-o1ttsh"
+        class="svelte-6vo7lg"
         height="77.64705882352942px"
         loading="lazy"
         src="https://s3.documentcloud.org/documents/24002098/pages/quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018-p1-thumbnail.gif"
@@ -21,19 +21,19 @@ exports[`DocumentListItem > renders 1`] = `
     </div>
      
     <div
-      class="documentInfo svelte-o1ttsh"
+      class="documentInfo svelte-6vo7lg"
     >
       <div
-        class="head svelte-o1ttsh"
+        class="head svelte-6vo7lg"
       >
         <h3
-          class="title svelte-o1ttsh"
+          class="title svelte-6vo7lg"
         >
           Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018
         </h3>
          
         <div
-          class="access svelte-o1ttsh"
+          class="access svelte-6vo7lg"
         >
           <div
             class="access public svelte-o63adk"
@@ -56,7 +56,7 @@ exports[`DocumentListItem > renders 1`] = `
       </div>
        
       <p
-        class="meta svelte-o1ttsh"
+        class="meta svelte-6vo7lg"
       >
         20 pages
          -
@@ -69,7 +69,7 @@ exports[`DocumentListItem > renders 1`] = `
       </p>
        
       <div
-        class="data svelte-o1ttsh"
+        class="data svelte-6vo7lg"
       />
     </div>
   </a>

--- a/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
+++ b/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`DocumentListItem > renders 1`] = `
 <div>
   <a
-    class="document-list-item svelte-j5lpiy"
+    class="document-list-item svelte-o1ttsh"
     href="https://www.dev.documentcloud.org/documents/24002098-quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018/"
   >
     <div
-      class="thumbnail svelte-j5lpiy"
+      class="thumbnail svelte-o1ttsh"
     >
       <img
         alt="Page 1, Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018"
-        class="svelte-j5lpiy"
+        class="svelte-o1ttsh"
         height="77.64705882352942px"
         loading="lazy"
         src="https://s3.documentcloud.org/documents/24002098/pages/quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018-p1-thumbnail.gif"
@@ -21,61 +21,42 @@ exports[`DocumentListItem > renders 1`] = `
     </div>
      
     <div
-      class="documentInfo svelte-j5lpiy"
+      class="documentInfo svelte-o1ttsh"
     >
       <div
-        class="head svelte-j5lpiy"
+        class="head svelte-o1ttsh"
       >
         <h3
-          class="title svelte-j5lpiy"
+          class="title svelte-o1ttsh"
         >
           Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018
         </h3>
          
         <div
-          class="access svelte-j5lpiy"
+          class="access svelte-o1ttsh"
         >
           <div
-            style="display: contents; --color: var(--gray-5); --font-size: inherit;"
+            class="access public svelte-o63adk"
           >
-            <span
-              class="sidebarItem container svelte-1i964q1 inline"
-              role="button"
-              tabindex="0"
-              title="Documents will be publicly visible to everyone"
+            <svg
+              class="octicon octicon-globe"
+              height="1em"
+              viewBox="0 0 24 24"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                class="octicon octicon-globe"
-                height="1em"
-                slot="start"
-                viewBox="0 0 24 24"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1Zm3.241 10.5v-.001c-.1-2.708-.992-4.904-1.89-6.452a13.919 13.919 0 0 0-1.304-1.88L12 3.11l-.047.059c-.354.425-.828 1.06-1.304 1.88-.898 1.547-1.79 3.743-1.89 6.451Zm-12.728 0h4.745c.1-3.037 1.1-5.49 2.093-7.204.39-.672.78-1.233 1.119-1.673C6.11 3.329 2.746 7 2.513 11.5Zm18.974 0C21.254 7 17.89 3.329 13.53 2.623c.339.44.729 1.001 1.119 1.673.993 1.714 1.993 4.167 2.093 7.204ZM8.787 13c.182 2.478 1.02 4.5 1.862 5.953.382.661.818 1.29 1.304 1.88l.047.057.047-.059c.354-.425.828-1.06 1.304-1.88.842-1.451 1.679-3.471 1.862-5.951Zm-1.504 0H2.552a9.505 9.505 0 0 0 7.918 8.377 15.773 15.773 0 0 1-1.119-1.673C8.413 18.085 7.47 15.807 7.283 13Zm9.434 0c-.186 2.807-1.13 5.085-2.068 6.704-.39.672-.78 1.233-1.118 1.673A9.506 9.506 0 0 0 21.447 13Z"
-                />
-              </svg>
-              
-               
-              <span
-                class="label svelte-1i964q1"
-              >
-                Public
-              </span>
-               
-            </span>
-            
+              <path
+                d="M12 1c6.075 0 11 4.925 11 11s-4.925 11-11 11S1 18.075 1 12 5.925 1 12 1Zm3.241 10.5v-.001c-.1-2.708-.992-4.904-1.89-6.452a13.919 13.919 0 0 0-1.304-1.88L12 3.11l-.047.059c-.354.425-.828 1.06-1.304 1.88-.898 1.547-1.79 3.743-1.89 6.451Zm-12.728 0h4.745c.1-3.037 1.1-5.49 2.093-7.204.39-.672.78-1.233 1.119-1.673C6.11 3.329 2.746 7 2.513 11.5Zm18.974 0C21.254 7 17.89 3.329 13.53 2.623c.339.44.729 1.001 1.119 1.673.993 1.714 1.993 4.167 2.093 7.204ZM8.787 13c.182 2.478 1.02 4.5 1.862 5.953.382.661.818 1.29 1.304 1.88l.047.057.047-.059c.354-.425.828-1.06 1.304-1.88.842-1.451 1.679-3.471 1.862-5.951Zm-1.504 0H2.552a9.505 9.505 0 0 0 7.918 8.377 15.773 15.773 0 0 1-1.119-1.673C8.413 18.085 7.47 15.807 7.283 13Zm9.434 0c-.186 2.807-1.13 5.085-2.068 6.704-.39.672-.78 1.233-1.118 1.673A9.506 9.506 0 0 0 21.447 13Z"
+              />
+            </svg>
+             
+            Public
           </div>
         </div>
-         
-        <hr
-          class="rule svelte-j5lpiy"
-        />
       </div>
        
       <p
-        class="meta svelte-j5lpiy"
+        class="meta svelte-o1ttsh"
       >
         20 pages
          -
@@ -88,7 +69,7 @@ exports[`DocumentListItem > renders 1`] = `
       </p>
        
       <div
-        class="data svelte-j5lpiy"
+        class="data svelte-o1ttsh"
       />
     </div>
   </a>

--- a/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
+++ b/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`DocumentListItem > renders 1`] = `
 <div>
   <a
-    class="document-list-item svelte-6vo7lg"
+    class="document-list-item svelte-enjnbe"
     href="https://www.dev.documentcloud.org/documents/24002098-quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018/"
   >
     <div
-      class="thumbnail svelte-6vo7lg"
+      class="thumbnail svelte-enjnbe"
     >
       <img
         alt="Page 1, Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018"
-        class="svelte-6vo7lg"
+        class="svelte-enjnbe"
         height="77.64705882352942px"
         loading="lazy"
         src="https://s3.documentcloud.org/documents/24002098/pages/quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018-p1-thumbnail.gif"
@@ -21,19 +21,19 @@ exports[`DocumentListItem > renders 1`] = `
     </div>
      
     <div
-      class="documentInfo svelte-6vo7lg"
+      class="documentInfo svelte-enjnbe"
     >
       <div
-        class="head svelte-6vo7lg"
+        class="head svelte-enjnbe"
       >
         <h3
-          class="title svelte-6vo7lg"
+          class="title svelte-enjnbe"
         >
           Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018
         </h3>
          
         <div
-          class="access svelte-6vo7lg"
+          class="access svelte-enjnbe"
         >
           <div
             class="access public svelte-o63adk"
@@ -56,7 +56,7 @@ exports[`DocumentListItem > renders 1`] = `
       </div>
        
       <p
-        class="meta svelte-6vo7lg"
+        class="meta svelte-enjnbe"
       >
         20 pages
          -
@@ -69,7 +69,7 @@ exports[`DocumentListItem > renders 1`] = `
       </p>
        
       <div
-        class="data svelte-6vo7lg"
+        class="data svelte-enjnbe"
       />
     </div>
   </a>

--- a/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
+++ b/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`DocumentListItem > renders 1`] = `
 <div>
   <a
-    class="document-list-item svelte-enjnbe"
+    class="document-list-item svelte-zn4dyg"
     href="https://www.dev.documentcloud.org/documents/24002098-quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018/"
   >
     <div
-      class="thumbnail svelte-enjnbe"
+      class="thumbnail svelte-zn4dyg"
     >
       <img
         alt="Page 1, Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018"
-        class="svelte-enjnbe"
+        class="svelte-zn4dyg"
         height="77.64705882352942px"
         loading="lazy"
         src="https://s3.documentcloud.org/documents/24002098/pages/quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018-p1-thumbnail.gif"
@@ -21,19 +21,19 @@ exports[`DocumentListItem > renders 1`] = `
     </div>
      
     <div
-      class="documentInfo svelte-enjnbe"
+      class="documentInfo svelte-zn4dyg"
     >
       <div
-        class="head svelte-enjnbe"
+        class="head svelte-zn4dyg"
       >
         <h3
-          class="title svelte-enjnbe"
+          class="title svelte-zn4dyg"
         >
           Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018
         </h3>
          
         <div
-          class="access svelte-enjnbe"
+          class="access svelte-zn4dyg"
         >
           <div
             class="access public svelte-o63adk"
@@ -56,7 +56,7 @@ exports[`DocumentListItem > renders 1`] = `
       </div>
        
       <p
-        class="meta svelte-enjnbe"
+        class="meta svelte-zn4dyg"
       >
         20 pages
          -
@@ -69,7 +69,7 @@ exports[`DocumentListItem > renders 1`] = `
       </p>
        
       <div
-        class="data svelte-enjnbe"
+        class="data svelte-zn4dyg"
       />
     </div>
   </a>

--- a/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
+++ b/src/lib/components/documents/tests/__snapshots__/DocumentListItem.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`DocumentListItem > renders 1`] = `
 <div>
   <a
-    class="document-list-item svelte-1bq7dbe"
+    class="document-list-item svelte-j5lpiy"
     href="https://www.dev.documentcloud.org/documents/24002098-quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018/"
   >
     <div
-      class="thumbnail svelte-1bq7dbe"
+      class="thumbnail svelte-j5lpiy"
     >
       <img
         alt="Page 1, Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018"
-        class="svelte-1bq7dbe"
+        class="svelte-j5lpiy"
         height="77.64705882352942px"
         loading="lazy"
         src="https://s3.documentcloud.org/documents/24002098/pages/quarterly-reports-created-pursuant-to-the-letter-from-the-national-archives-and-records-administration-dated-june-1-2018-p1-thumbnail.gif"
@@ -21,33 +21,20 @@ exports[`DocumentListItem > renders 1`] = `
     </div>
      
     <div
-      class="documentInfo svelte-1bq7dbe"
+      class="documentInfo svelte-j5lpiy"
     >
-      <h3
-        class="svelte-1bq7dbe"
-      >
-        Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018
-      </h3>
-       
-      <p
-        class="meta svelte-1bq7dbe"
-      >
-        20 pages
-         -
-      
-         
-        Mitchell Kotler (MuckRock)
-         -
-         
-        Mon Oct 02 2023
-      </p>
-       
-       
       <div
-        class="actions"
-        style="display: flex; flex-direction: row; flex-wrap: nowrap; align-items: center; justify-content: flex-start; gap: 0.625rem;"
+        class="head svelte-j5lpiy"
       >
-        <div>
+        <h3
+          class="title svelte-j5lpiy"
+        >
+          Quarterly Reports created pursuant to the letter from the National Archives and Records Administration dated June 1, 2018
+        </h3>
+         
+        <div
+          class="access svelte-j5lpiy"
+        >
           <div
             style="display: contents; --color: var(--gray-5); --font-size: inherit;"
           >
@@ -82,8 +69,27 @@ exports[`DocumentListItem > renders 1`] = `
           </div>
         </div>
          
-        
+        <hr
+          class="rule svelte-j5lpiy"
+        />
       </div>
+       
+      <p
+        class="meta svelte-j5lpiy"
+      >
+        20 pages
+         -
+      
+         
+        Mitchell Kotler (MuckRock)
+         -
+         
+        Mon Oct 02 2023
+      </p>
+       
+      <div
+        class="data svelte-j5lpiy"
+      />
     </div>
   </a>
 </div>


### PR DESCRIPTION
Closes #790

We already have the capability to display projects on document search results, but we weren't expanding them in the API request.