### PR TITLE
Handles errors when rendering PDF in viewer

### DIFF
--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -52,6 +52,7 @@
         window.pdf = p;
       })
       .catch((e) => {
+        console.error(e);
         errors.update((errs) => [...errs, e]);
       });
   });

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -176,6 +176,7 @@ layouts, stories, and tests.
         $progress = p;
       };
       $pdf = task.promise.catch((error) => {
+        console.error(error);
         $currentErrors = [...$currentErrors, error];
         return Promise.reject(error);
       });

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -87,6 +87,10 @@ layouts, stories, and tests.
   export function getZoom(): Writable<Zoom> {
     return getContext("zoom");
   }
+
+  export function getErrors(): Writable<Error[]> {
+    return getContext("errors");
+  }
 </script>
 
 <script lang="ts">
@@ -102,6 +106,7 @@ layouts, stories, and tests.
   export let mode: ViewerMode = "document";
   export let query: string = "";
   export let zoom: Zoom = 1;
+  export let errors: Error[] = [];
 
   // https://mozilla.github.io/pdf.js/api/draft/module-pdfjsLib-PDFDocumentProxy.html
   export let pdf: Writable<Promise<pdfjs.PDFDocumentProxy>> = writable(
@@ -131,11 +136,13 @@ layouts, stories, and tests.
   setContext("zoom", writable(zoom));
   setContext("progress", progress);
   setContext("pdf", pdf);
+  setContext("errors", writable(errors));
 
   $: currentDoc = getDocument();
   $: currentMode = getCurrentMode();
   $: currentPage = getCurrentPage();
   $: currentNote = getCurrentNote();
+  $: currentErrors = getErrors();
 
   $: noteMatchingPageHash = (note: Note) =>
     note.id === noteFromHash($pageStore.url.hash);
@@ -168,7 +175,10 @@ layouts, stories, and tests.
       task.onProgress = (p: DocumentLoadProgress) => {
         $progress = p;
       };
-      $pdf = task.promise;
+      $pdf = task.promise.catch((error) => {
+        $currentErrors = [...$currentErrors, error];
+        return Promise.reject(error);
+      });
     }
   });
 

--- a/src/lib/components/viewer/stories/PDF.stories.svelte
+++ b/src/lib/components/viewer/stories/PDF.stories.svelte
@@ -1,6 +1,6 @@
 <script context="module" lang="ts">
   import { rest } from "msw";
-  import type { Document, Note, Section, ViewerMode } from "@/lib/api/types";
+  import type { Document, Section } from "@/lib/api/types";
 
   import { Story, Template } from "@storybook/addon-svelte-csf";
 
@@ -143,6 +143,20 @@
     context: {
       ...args.context,
       document: { ...document, notes: [], sections },
+    },
+  }}
+/>
+
+<Story
+  name="With Errors"
+  args={{
+    ...args,
+    context: {
+      ...args.context,
+      errors: [
+        new TypeError("Something went wrong :("),
+        new TypeError("And another thing, too!"),
+      ],
     },
   }}
 />


### PR DESCRIPTION
Fixes #758

Doesn't address the root causes of `InvalidPDFException`, but will catch and display the error instead of crashing the viewer.
