### PR TITLE
Calculate sizes when the PDF loads, not in onMount

### DIFF
--- a/src/lib/components/layouts/DocumentLayout.svelte
+++ b/src/lib/components/layouts/DocumentLayout.svelte
@@ -1,6 +1,6 @@
 <!-- @component
-  Assumes it's a child of a ViewerContext
- -->
+Assumes it's a child of a ViewerContext
+-->
 
 <script lang="ts">
   import type {

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -30,20 +30,29 @@
   const pdf = getPDF();
   const zoom = getZoom();
 
+  let width: number;
+
   $: document = $documentStore;
   $: scale = zoomToScale($zoom);
   $: sizes = document.page_spec ? pageSizes(document.page_spec) : [];
   $: sections = getSections(document);
   $: errors = getErrors();
 
+  // handle missing page_spec
+  $: $pdf
+    .then((p) => {
+      if (sizes.length === 0) {
+        sizes = Array(p.numPages).fill([0, 0]);
+      }
+    })
+    .catch((e) => {
+      console.error(e);
+      errors.update((errs) => [...errs, e]);
+    });
+
   onMount(() => {
     $pdf
       .then((p) => {
-        // handle missing page_spec
-        if (sizes.length === 0) {
-          sizes = Array(p.numPages).fill([0, 0]);
-        }
-
         if ($currentPage > 1) {
           scrollToPage($currentPage);
         }
@@ -56,8 +65,6 @@
         errors.update((errs) => [...errs, e]);
       });
   });
-
-  let width: number;
 </script>
 
 {#if Boolean($errors?.length)}

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -17,7 +17,7 @@ layouts, stories, and tests.
   import { afterNavigate } from "$app/navigation";
 
   import { getContext, onMount, setContext } from "svelte";
-  import { type Readable, type Writable, writable } from "svelte/store";
+  import { type Writable, writable } from "svelte/store";
 
   import {
     pageFromHash,
@@ -175,13 +175,16 @@ layouts, stories, and tests.
     // we might move this to a load function
     if (!task) {
       task = pdfjs.getDocument({ url: asset_url });
+      $pdf = task.promise;
+
       task.onProgress = (p: DocumentLoadProgress) => {
         $progress = p;
       };
-      $pdf = task.promise.catch((error) => {
+
+      task.promise.then(console.log).catch((error) => {
         console.error(error);
         $currentErrors = [...$currentErrors, error];
-        return Promise.reject(error);
+        throw error;
       });
     }
   });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,7 +15,7 @@
   // this checks if the site has been updated and triggers a full page reload
   // on the next navigation to update the cache
   beforeNavigate(({ willUnload, to }) => {
-    if ($updated && !willUnload && to?.url) {
+    if (browser && $updated && !willUnload && to?.url) {
       location.href = to.url.href;
     }
   });


### PR DESCRIPTION
Fixes a regression where documents still processing wouldn't load. Now we can see them again.