### PR TITLE
Set language via localStorage if set

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -44,6 +44,7 @@ export const LANGUAGES = [
   ["Deutsche", "de", "🇩🇪"],
   ["українська", "uk", "🇺🇦"],
   ["русский", "ru", "🇷🇺"],
+  ["Italiano", "it", "🇮🇹"],
 ];
 
 export const CSRF_COOKIE_NAME = "csrftoken";

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -22,7 +22,7 @@ export async function handleFetch({ event, request, fetch }) {
   if (request.url.startsWith(DC_BASE)) {
     // handle docker issues
     event.url.protocol = "https";
-    request.headers.set("cookie", event.request.headers.get("cookie"));
+    request.headers.set("cookie", event.request.headers.get("cookie") ?? "");
   }
 
   return fetch(request);

--- a/src/langs/i18n.js
+++ b/src/langs/i18n.js
@@ -13,6 +13,7 @@ for (let i = 0; i < langs.length; i++) {
   const lang = langs[i][1];
   register(lang, () => import(`../langs/json/${lang}.json`));
   langDict[lang] = true;
+  console.log(lang);
 }
 
 function resolveLocale(locale) {

--- a/src/langs/json/it.json
+++ b/src/langs/json/it.json
@@ -497,7 +497,7 @@
     "matchingNotes": "{n, plural, one {# note} other {# notes}} corrisponde all'espressione di ricerca",
     "page": "Pagine",
     "pageAbbrev": "p.",
-    "pageCount": "Signed in as {name}.",
+    "pageCount": "{n, plural, one {# pagina} other {# pagine}}",
     "select": "Scegliere",
     "noteCount": "{n, plural, uno {# note} altri {# notes}}"
   },
@@ -981,7 +981,7 @@
     "none": "Non sono selezionati documenti. Chiudi questo form e seleziona almeno un documento prima."
   },
   "data": {
-    "title": "{Edit} tagi e dati",
+    "title": "Modifica tag e dati",
     "key": "Chiave",
     "newkey": "Nuovo articolo",
     "value": "Valore",
@@ -997,7 +997,7 @@
     "title": "Modifica",
     "actions": {
       "edit": "Accesso e metadati",
-      "data": "{Add tags and data}",
+      "data": "Aggiungi tag e dati",
       "reprocess": "Riproposizione",
       "delete": "Cancella documenti",
       "project": "Aggiungi al progetto"

--- a/src/lib/components/navigation/LanguageMenu.svelte
+++ b/src/lib/components/navigation/LanguageMenu.svelte
@@ -4,18 +4,19 @@
 
   import Dropdown, {
     type Placement,
-  } from "@/lib/components/common/Dropdown.svelte";
-  import Menu from "@/lib/components/common/Menu.svelte";
+  } from "$lib/components/common/Dropdown.svelte";
+  import Flex from "../common/Flex.svelte";
+  import Menu from "$lib/components/common/Menu.svelte";
   import SidebarItem from "$lib/components/sidebar/SidebarItem.svelte";
 
-  import langs from "@/langs/langs.json";
-  import Flex from "../common/Flex.svelte";
+  import { LANGUAGES } from "@/config/config.js";
 
   export let position: Placement = "bottom-end";
 
-  $: currentLang = langs.find(([_, code]) => code == $locale) ?? langs[0];
+  $: currentLang =
+    LANGUAGES.find(([_, code]) => code === $locale) ?? LANGUAGES[0];
 
-  function updateLanguage(code) {
+  function updateLanguage(code: string) {
     $locale = code;
     try {
       localStorage.setItem("dc-locale", code);
@@ -23,7 +24,7 @@
   }
 </script>
 
-{#if langs.length > 1}
+{#if LANGUAGES.length > 1}
   <!-- Language Menu -->
   <Dropdown {position}>
     <SidebarItem slot="anchor">
@@ -38,10 +39,10 @@
       </div>
     </SidebarItem>
     <Menu slot="default" let:close>
-      {#each langs as [name, code, flag]}
+      {#each LANGUAGES as [name, code, flag]}
         <SidebarItem
           on:click={() => {
-            updateLanguage(code);
+            updateLanguage(code ?? "");
             close();
           }}
           hover

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -7,7 +7,9 @@ export const trailingSlash = "always";
 
 export async function load() {
   if (browser) {
-    locale.set(window.navigator.language);
+    const language =
+      localStorage.getItem("dc-locale") || window.navigator.language;
+    locale.set(language);
   }
   await waitLocale();
 }


### PR DESCRIPTION
Closes #784 

This sets the `$locale` store in the top layout using `localStorage`, if we've set it.

I'd like to figure out a way to set it even earlier, because in this version, we're loading the English JSON file and then the other language, but this is a good-enough fix for now.