### PR TITLE
Delay loading to shrink page size

### DIFF
--- a/src/lib/components/common/Paginator.svelte
+++ b/src/lib/components/common/Paginator.svelte
@@ -109,7 +109,8 @@
       {:else}
         <span class="pageNumber">{page}</span>
       {/if}
-      {#if totalPages}<span class="rest">
+      {#if totalPages}
+        <span class="rest">
           {$_("paginator.of")}
           {totalPages.toLocaleString()}
         </span>

--- a/src/lib/components/common/Paginator.svelte
+++ b/src/lib/components/common/Paginator.svelte
@@ -109,8 +109,11 @@
       {:else}
         <span class="pageNumber">{page}</span>
       {/if}
-      {#if totalPages}<span class="rest">{$_("paginator.of")} {totalPages}</span
-        >{/if}
+      {#if totalPages}<span class="rest">
+          {$_("paginator.of")}
+          {totalPages.toLocaleString()}
+        </span>
+      {/if}
     </div>
   {/if}
   <Button

--- a/src/lib/components/inputs/Language.svelte
+++ b/src/lib/components/inputs/Language.svelte
@@ -4,6 +4,7 @@
     DEFAULT_LANGUAGE,
     LANGUAGE_CODES,
     LANGUAGE_NAMES,
+    LANGUAGE_MAP,
   } from "@/config/config.js";
 
   interface Item {
@@ -12,7 +13,10 @@
   }
 
   export let name = "language";
-  export let value: string | string[] | Item = DEFAULT_LANGUAGE;
+  export let value: Item = {
+    value: DEFAULT_LANGUAGE,
+    label: LANGUAGE_MAP.get(DEFAULT_LANGUAGE),
+  };
   export let required = false;
   export let placeholder: string = "";
   export let multiple = false;

--- a/src/lib/components/layouts/ContentLayout.svelte
+++ b/src/lib/components/layouts/ContentLayout.svelte
@@ -1,4 +1,8 @@
-<div class="container">
+<script lang="ts">
+  export let noBgColor = false;
+</script>
+
+<div class="container" class:noBgColor>
   {#if $$slots.header}
     <header>
       <slot name="header" />
@@ -27,6 +31,10 @@
     min-height: 100%;
     background: var(--gray-1);
     box-shadow: inset var(--shadow-2);
+  }
+  .container.noBgColor {
+    background: unset;
+    box-shadow: unset;
   }
   header {
     flex: 0 0 0;

--- a/src/lib/components/layouts/DocumentLayout.svelte
+++ b/src/lib/components/layouts/DocumentLayout.svelte
@@ -88,6 +88,7 @@ Assumes it's a child of a ViewerContext
   }
 
   main {
+    flex: 1 1 auto;
     background: var(--gray-1);
     border: 1px solid var(--gray-2);
     border-radius: var(--radius, 0.5rem);

--- a/src/lib/components/layouts/DocumentLayout.svelte
+++ b/src/lib/components/layouts/DocumentLayout.svelte
@@ -67,7 +67,9 @@ Assumes it's a child of a ViewerContext
 
       <AddOns pinnedAddOns={addons} query="+document:{document.id}" />
     </Flex>
-    <DocumentMetadata {document} {text} />
+    {#await text then text}
+      <DocumentMetadata {document} {text} />
+    {/await}
   </aside>
 </SidebarLayout>
 

--- a/src/lib/components/layouts/stories/EmbedLayout.stories.svelte
+++ b/src/lib/components/layouts/stories/EmbedLayout.stories.svelte
@@ -11,6 +11,7 @@
   import ViewerContext from "../../viewer/ViewerContext.svelte";
 
   const document = doc as Document;
+  const text = Promise.resolve(txt);
 
   export const meta = {
     title: "Layout / Embed",
@@ -32,7 +33,7 @@
 
 <Story name="With Document" {args} let:args>
   <div class="vh">
-    <ViewerContext {document} text={txt} asset_url={pdfUrl(document)}>
+    <ViewerContext {document} {text} asset_url={pdfUrl(document)}>
       <EmbedLayout
         settings={args.settings}
         canonicalUrl={canonicalUrl(document).href}

--- a/src/lib/components/viewer/Notes.svelte
+++ b/src/lib/components/viewer/Notes.svelte
@@ -55,6 +55,7 @@ Assumes it's a child of a ViewerContext
     margin: 0 auto;
     max-width: 38.0625rem;
     padding: 2rem 0;
+    min-height: 100%;
   }
 
   .card {

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -80,15 +80,17 @@
     class:sm={width < remToPx(35)}
     class:lg={width > remToPx(70)}
   >
-    {#each sizes as [width, height], n}
-      {@const page_number = n + 1}
-      {#if sections[n]}
-        <h3 class="section">
-          {sections[n].title}
-        </h3>
-      {/if}
-      <PdfPage {page_number} {scale} {width} {height} />
-    {/each}
+    {#await $pdf then _}
+      {#each sizes as [width, height], n}
+        {@const page_number = n + 1}
+        {#if sections[n]}
+          <h3 class="section">
+            {sections[n].title}
+          </h3>
+        {/if}
+        <PdfPage {page_number} {scale} {width} {height} />
+      {/each}
+    {/await}
   </div>
 {/if}
 

--- a/src/lib/components/viewer/PaginationToolbar.svelte
+++ b/src/lib/components/viewer/PaginationToolbar.svelte
@@ -89,8 +89,10 @@
               on:click={() => {
                 gotoPage(section.page_number + 1);
                 close();
-              }}>{section.title}</MenuItem
+              }}
             >
+              {section.title}
+            </MenuItem>
           {:else}
             <Empty icon={ListOrdered24}>
               <p>{$_("sidebar.toc.empty")}</p>
@@ -102,15 +104,17 @@
                 ghost
                 mode="primary"
                 on:click={() => (sectionsOpen = true)}
-                >{$_("sidebar.toc.cta")}</Button
               >
+                {$_("sidebar.toc.cta")}
+              </Button>
             {:else}
               <Button
                 ghost
                 mode="primary"
                 on:click={() => (sectionsOpen = true)}
-                >{$_("sections.edit")}</Button
               >
+                {$_("sections.edit")}
+              </Button>
             {/if}
           {/if}
         </Menu>

--- a/src/lib/components/viewer/Text.svelte
+++ b/src/lib/components/viewer/Text.svelte
@@ -30,13 +30,15 @@
 </script>
 
 <div class="textPages" style:--zoom={+$zoom || 1}>
-  {#each text?.pages ?? [] as { page, contents }}
-    <Page page_number={page + 1} track>
-      <pre>
-        {@html highlight(contents, query)}
-      </pre>
-    </Page>
-  {/each}
+  {#await text then text}
+    {#each text?.pages ?? [] as { page, contents }}
+      <Page page_number={page + 1} track>
+        <pre>
+      {@html highlight(contents, query)}
+    </pre>
+      </Page>
+    {/each}
+  {/await}
 </div>
 
 <style>

--- a/src/lib/components/viewer/Viewer.svelte
+++ b/src/lib/components/viewer/Viewer.svelte
@@ -51,7 +51,7 @@ Assumes it's a child of a ViewerContext
 </script>
 
 <div class="container">
-  <ContentLayout>
+  <ContentLayout noBgColor>
     <!-- toolbars -->
     <Flex slot="header">
       {#if !embed && $sidebars["navigation"] === false}

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -172,6 +172,7 @@ layouts, stories, and tests.
   }
 
   onMount(() => {
+    console.log("ViewerContext");
     // we might move this to a load function
     if (!task) {
       task = pdfjs.getDocument({ url: asset_url });

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -43,7 +43,7 @@ layouts, stories, and tests.
     return getContext("document");
   }
 
-  export function getText(): Maybe<DocumentText> {
+  export function getText(): Promise<Maybe<DocumentText>> {
     return getContext("text");
   }
 
@@ -98,7 +98,7 @@ layouts, stories, and tests.
   import { noteFromHash } from "$lib/api/notes";
 
   export let document: Document;
-  export let text: Maybe<DocumentText> = undefined;
+  export let text: Promise<Maybe<DocumentText>> = new Promise(() => {});
   export let note: Nullable<Note> = null;
   export let asset_url: URL = pdfUrl(document);
   export let embed: boolean = false;
@@ -172,7 +172,6 @@ layouts, stories, and tests.
   }
 
   onMount(() => {
-    console.log("ViewerContext");
     // we might move this to a load function
     if (!task) {
       task = pdfjs.getDocument({ url: asset_url });

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -19,12 +19,7 @@ layouts, stories, and tests.
   import { getContext, onMount, setContext } from "svelte";
   import { type Writable, writable } from "svelte/store";
 
-  import {
-    pageFromHash,
-    pdfUrl,
-    shouldPaginate,
-    shouldPreload,
-  } from "$lib/api/documents";
+  import { pageFromHash, pdfUrl, shouldPaginate } from "$lib/api/documents";
 
   import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
   if (!pdfjs.GlobalWorkerOptions.workerSrc) {
@@ -202,16 +197,5 @@ layouts, stories, and tests.
 </script>
 
 <svelte:window on:hashchange={onHashChange} on:popstate={onHashChange} />
-<svelte:head>
-  {#if shouldPreload($currentMode)}
-    <link
-      rel="prefetch"
-      href={asset_url.href}
-      as="fetch"
-      crossorigin="anonymous"
-      type="application/pdf"
-    />
-  {/if}
-</svelte:head>
 
 <slot />

--- a/src/lib/components/viewer/stories/Text.stories.svelte
+++ b/src/lib/components/viewer/stories/Text.stories.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <Story name="default">
-  <ViewerContext {document} {text}>
+  <ViewerContext {document} text={Promise.resolve(text)}>
     <Text />
   </ViewerContext>
 </Story>

--- a/src/lib/load/document.ts
+++ b/src/lib/load/document.ts
@@ -9,6 +9,9 @@ interface Load {
   url: URL;
 }
 
+/**
+ * Load a document and its assets
+ */
 export default async function load({ fetch, params, url }: Load) {
   const { data: document, error: err } = await documents.get(+params.id, fetch);
 
@@ -22,7 +25,7 @@ export default async function load({ fetch, params, url }: Load) {
 
   let mode: ViewerMode =
     (url.searchParams.get("mode") as ViewerMode) ?? "document";
-  const text = await documents.text(document, fetch);
+  const text = { updated: 0, pages: [] }; // await documents.text(document, fetch);
   const asset_url = await documents.assetUrl(document, fetch);
 
   if (!documents.MODES.has(mode)) {

--- a/src/lib/load/document.ts
+++ b/src/lib/load/document.ts
@@ -25,7 +25,6 @@ export default async function load({ fetch, params, url }: Load) {
 
   let mode: ViewerMode =
     (url.searchParams.get("mode") as ViewerMode) ?? "document";
-  const text = { updated: 0, pages: [] }; // await documents.text(document, fetch);
   const asset_url = await documents.assetUrl(document, fetch);
 
   if (!documents.MODES.has(mode)) {
@@ -34,7 +33,6 @@ export default async function load({ fetch, params, url }: Load) {
 
   return {
     document,
-    text,
     asset_url,
     mode,
   };

--- a/src/routes/(app)/documents/[id]-[slug]/+page.svelte
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.svelte
@@ -6,7 +6,7 @@
   import "@/style/kit.css";
 
   import { embedUrl } from "$lib/api/embed";
-  import { canonicalUrl, pageImageUrl } from "$lib/api/documents";
+  import * as documents from "$lib/api/documents";
 
   import DocumentLayout from "$lib/components/layouts/DocumentLayout.svelte";
   import GuidedTour from "$lib/components/onboarding/GuidedTour.svelte";
@@ -16,9 +16,9 @@
 
   $: document = data.document;
   $: mode = data.mode;
-  $: text = data.text;
+  $: text = documents.text(document);
   $: asset_url = data.asset_url;
-  $: canonical_url = canonicalUrl(document).href;
+  $: canonical_url = documents.canonicalUrl(document).href;
 
   $: action = data.action;
   $: addons = data.pinnedAddons;
@@ -45,7 +45,7 @@
   {/if}
   <meta
     property="og:image"
-    content={pageImageUrl(document, 0, "normal").href}
+    content={documents.pageImageUrl(document, 0, "normal").href}
   />
   <!-- Social cards -->
   <meta property="twitter:card" content="summary_large_image" />

--- a/src/routes/(app)/documents/[id]-[slug]/+page.svelte
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.svelte
@@ -55,6 +55,14 @@
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="og:url" content={canonical_url} />
   <meta property="og:title" content={document.title} />
+
+  <link
+    rel="prefetch"
+    href={asset_url.href}
+    as="fetch"
+    crossorigin="anonymous"
+    type="application/pdf"
+  />
 </svelte:head>
 
 <ViewerContext {document} {mode} {text} {asset_url}>

--- a/src/routes/(app)/documents/[id]-[slug]/+page.svelte
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.svelte
@@ -5,6 +5,8 @@
 <script lang="ts">
   import "@/style/kit.css";
 
+  import { browser } from "$app/environment";
+
   import { embedUrl } from "$lib/api/embed";
   import * as documents from "$lib/api/documents";
 
@@ -16,7 +18,9 @@
 
   $: document = data.document;
   $: mode = data.mode;
-  $: text = documents.text(document);
+  $: text = browser
+    ? documents.text(document)
+    : Promise.resolve({ pages: [], updated: 0 });
   $: asset_url = data.asset_url;
   $: canonical_url = documents.canonicalUrl(document).href;
 

--- a/src/routes/(app)/documents/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.ts
@@ -14,9 +14,6 @@ import { breadcrumbTrail } from "$lib/utils/index";
 import loadDocument from "$lib/load/document";
 import { getQuery } from "$lib/utils/search";
 
-// just for testing
-export const ssr = false;
-
 /** @type {import('./$types').PageLoad} */
 export async function load({ fetch, params, parent, depends, url }) {
   const { document, text, asset_url, mode } = await loadDocument({

--- a/src/routes/(app)/documents/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.ts
@@ -14,6 +14,9 @@ import { breadcrumbTrail } from "$lib/utils/index";
 import loadDocument from "$lib/load/document";
 import { getQuery } from "$lib/utils/search";
 
+// just for testing
+export const ssr = false;
+
 /** @type {import('./$types').PageLoad} */
 export async function load({ fetch, params, parent, depends, url }) {
   const { document, text, asset_url, mode } = await loadDocument({

--- a/src/routes/(app)/documents/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.ts
@@ -16,7 +16,7 @@ import { getQuery } from "$lib/utils/search";
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ fetch, params, parent, depends, url }) {
-  let { document, text, asset_url, mode } = await loadDocument({
+  const { document, text, asset_url, mode } = await loadDocument({
     fetch,
     params,
     url,

--- a/src/routes/(app)/documents/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.ts
@@ -16,7 +16,7 @@ import { getQuery } from "$lib/utils/search";
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ fetch, params, parent, depends, url }) {
-  const { document, text, asset_url, mode } = await loadDocument({
+  const { document, asset_url, mode } = await loadDocument({
     fetch,
     params,
     url,
@@ -47,7 +47,6 @@ export async function load({ fetch, params, parent, depends, url }) {
   return {
     document,
     mode,
-    text,
     asset_url,
     action,
     pinnedAddons,

--- a/src/routes/embed/documents/[id]-[slug]/+page.svelte
+++ b/src/routes/embed/documents/[id]-[slug]/+page.svelte
@@ -8,15 +8,15 @@ Assumes it's a child of a ViewerContext
   import ViewerContext from "$lib/components/viewer/ViewerContext.svelte";
 
   // config and utils
-  import { canonicalUrl, pdfUrl } from "$lib/api/documents";
+  import * as documents from "$lib/api/documents";
 
   export let data;
 
   $: document = data.document;
   $: mode = data.mode;
-  $: text = data.text;
+  $: text = documents.text(document);
   $: asset_url = data.asset_url;
-  $: canonical_url = canonicalUrl(document).href;
+  $: canonical_url = documents.canonicalUrl(document).href;
 </script>
 
 <svelte:head>
@@ -33,8 +33,8 @@ Assumes it's a child of a ViewerContext
 <ViewerContext {document} {mode} {text} {asset_url}>
   <EmbedLayout
     settings={data.settings}
-    canonicalUrl={canonicalUrl(document).href}
-    downloadUrl={pdfUrl(document).href}
+    canonicalUrl={canonical_url}
+    downloadUrl={documents.pdfUrl(document).href}
   >
     <DocumentEmbed settings={data.settings} />
   </EmbedLayout>

--- a/src/routes/embed/documents/[id]-[slug]/+page.svelte
+++ b/src/routes/embed/documents/[id]-[slug]/+page.svelte
@@ -28,6 +28,14 @@ Assumes it's a child of a ViewerContext
   {#if document.noindex || document.admin_noindex}
     <meta name="robots" content="noindex" />
   {/if}
+
+  <link
+    rel="prefetch"
+    href={asset_url.href}
+    as="fetch"
+    crossorigin="anonymous"
+    type="application/pdf"
+  />
 </svelte:head>
 
 <ViewerContext {document} {mode} {text} {asset_url}>

--- a/src/routes/embed/documents/[id]-[slug]/+page.ts
+++ b/src/routes/embed/documents/[id]-[slug]/+page.ts
@@ -9,7 +9,7 @@ import * as documents from "$lib/api/documents";
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ fetch, url, params, depends }) {
-  let { document, text, asset_url, mode } = await loadDocument({
+  let { document, asset_url, mode } = await loadDocument({
     fetch,
     url,
     params,
@@ -30,7 +30,6 @@ export async function load({ fetch, url, params, depends }) {
   return {
     document,
     mode,
-    text,
     asset_url,
     settings,
     query,

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -10,7 +10,9 @@ export default {
   },
 
   kit: {
-    adapter: adapter({}),
+    adapter: adapter({
+      preprocess: true,
+    }),
     alias: {
       "@": "./src",
       "@/*": "./src/*",


### PR DESCRIPTION
Fixes #837 

Test URL: https://deploy-preview-839.muckcloud.com/documents/20006876-2017-epa-staff-calendars-part2-s/

The issue seems to be that server-side rendering every page in a giant document produces a huge HTML page that's too big for our Lambda workers to push it through. 

This PR fixes it, but we should do another pass and see if we can slim down our pages further.