### PR TITLE
Show message and links to unverified users

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -37,6 +37,11 @@ export const SIGN_IN_URL = new URL(DC_LOGIN, DC_BASE).toString();
 export const SIGN_UP_URL = new URL(SQUARELET_SIGNUP, SQUARELET_BASE).toString();
 export const SIGN_OUT_URL = new URL(DC_LOGOUT, DC_BASE).toString();
 
+export const VERIFICATION_FORM_URL =
+  "https://airtable.com/app93Yt5cwdVWTnqn/pagogIhgB1jZTzq00/form";
+export const SQUARELET_ORGS_URL =
+  "https://accounts.muckrock.com/organizations/";
+
 export const LANGUAGES = [
   ["US English", "en", "🇺🇸"],
   ["Deutsche", "de", "🇩🇪"],

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -62,8 +62,6 @@
     "update": "Update",
     "dismiss": "Dismiss",
     "dispatch": "Dispatch",
-    "organize": "Organize",
-    "run": "Run",
     "required": "This field is required"
   },
   "dialogReprocessDialog": {
@@ -186,11 +184,8 @@
     }
   },
   "unverified": {
-    "noSearchResults": "No search results",
-    "queryNoResults": "Your search query returned no results. Try again with a broader search query.",
-    "welcome": "Welcome to DocumentCloud!",
-    "verify": "Before you can upload documents, you need to verify your account. You can do this by joining a verified news organization or by requesting verification for yourself.",
-    "allowed_actions": "Until you're verified, you can search through the public repository, organize documents you're interested in into projects, leave private notes, and collaborate on editing and annotating documents other users invite you to.",
+    "verify": "Before you can upload documents, we need to verify your account. DocumentCloud verification is available to newsrooms, academic institutions, researchers, legal clinics and non-profits that have a track record of posting vetted primary source materials in the public interest. If you are working with an eligible organization, please join their organization account.",
+    "allowed_actions": "If you are not eligible for verification, you can still search the public repository, organize documents you're interested in into projects, make private notes, and collaborate on editing and annotating documents other users invite you to.",
     "requestVerificationAction": "Request verification",
     "orgs": "Search organizations",
     "faq": "Read more about verification in our FAQ"
@@ -549,7 +544,6 @@
     "addons": "Add-Ons",
     "documents": "Documents",
     "unknown": "Unknown",
-    "totalCount": "{n} active {n, plural, one {process} other {processes}}",
     "download": "Download file"
   },
   "feedback": {

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -184,6 +184,16 @@
       "refreshOn": "Credit allowance will reset on {date}"
     }
   },
+  "unverified": {
+    "noSearchResults": "No search results",
+    "queryNoResults": "Your search query returned no results. Try again with a broader search query.",
+    "welcome": "Welcome to DocumentCloud!",
+    "verify": "Before you can upload documents, you need to be verify your account. You can do this by joining a verified news organization or by requesting verification for yourself.",
+    "allowed_actions": "Until you're verified, you can search through the public repository, organize documents you're interested in into projects, leave private notes, and collaborate on editing and annotating documents other users invite you to.",
+    "requestVerificationAction": "Request verification",
+    "orgs": "Search organizations",
+    "faq": "Read more about verification in our FAQ"
+  },
   "documents": {
     "yourDocuments": "Your Documents",
     "accessDocuments": "Your {access}Documents",

--- a/src/lib/components/accounts/Unverified.svelte
+++ b/src/lib/components/accounts/Unverified.svelte
@@ -6,6 +6,7 @@ a user who is logged in but has `verified_journalist = false`.
   import type { Nullable, User } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
+  import { Unverified24 } from "svelte-octicons";
 
   import Button from "../common/Button.svelte";
   import Flex from "../common/Flex.svelte";
@@ -45,6 +46,7 @@ a user who is logged in but has `verified_journalist = false`.
 </script>
 
 <Tip>
+  <Unverified24 slot="icon" />
   <p>{$_("unverified.verify")}</p>
   <Flex class="buttons" gap={1}>
     <Button href={SQUARELET_ORGS_URL} target="_blank">

--- a/src/lib/components/accounts/Unverified.svelte
+++ b/src/lib/components/accounts/Unverified.svelte
@@ -3,7 +3,7 @@ This component displays anywhere we need to explain verification to
 a user who is logged in but has `verified_journalist = false`.
 -->
 <script lang="ts">
-  import type { Maybe, User } from "$lib/api/types";
+  import type { Nullable, User } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
 
@@ -17,16 +17,15 @@ a user who is logged in but has `verified_journalist = false`.
   } from "@/config/config.js";
   import { isOrg } from "$lib/api/accounts";
 
-  export let user: Maybe<User> = undefined;
+  export let user: Nullable<User>;
 
   const FAQ = "https://www.documentcloud.org/help/faq#verification";
 
-  function prefill(form_url: string, user?: User) {
+  function prefill(form_url: string, user: Nullable<User>) {
     if (!user) return form_url;
 
     const url = new URL(form_url);
 
-    //`${baseUrl}?prefill_MR+User+Email=${email}&prefill_MR+User+Name=${username}&prefill_MR+User+Account+URL=${accountUrl}&prefill_MR+Organization+Name=${orgSlug}&prefill_MR+Organization+Account+URL=${orgAccountUrl}`;
     const accountUrl = `https://accounts.muckrock.com/users/${user.username}/`;
     const orgAccountUrl = isOrg(user.organization)
       ? `https://accounts.muckrock.com/organizations/${user.organization.slug}`

--- a/src/lib/components/accounts/Unverified.svelte
+++ b/src/lib/components/accounts/Unverified.svelte
@@ -17,7 +17,7 @@ a user who is logged in but has `verified_journalist = false`.
   } from "@/config/config.js";
   import { isOrg } from "$lib/api/accounts";
 
-  export let user: Nullable<User>;
+  export let user: Nullable<User> = null;
 
   const FAQ = "https://www.documentcloud.org/help/faq#verification";
 

--- a/src/lib/components/accounts/Unverified.svelte
+++ b/src/lib/components/accounts/Unverified.svelte
@@ -1,0 +1,64 @@
+<!-- @component
+This component displays anywhere we need to explain verification to
+a user who is logged in but has `verified_journalist = false`.
+-->
+<script lang="ts">
+  import type { Maybe, User } from "$lib/api/types";
+
+  import { _ } from "svelte-i18n";
+
+  import Button from "../common/Button.svelte";
+  import Flex from "../common/Flex.svelte";
+  import Tip from "../common/Tip.svelte";
+
+  import {
+    VERIFICATION_FORM_URL,
+    SQUARELET_ORGS_URL,
+  } from "@/config/config.js";
+  import { isOrg } from "$lib/api/accounts";
+
+  export let user: Maybe<User> = undefined;
+
+  const FAQ = "https://www.documentcloud.org/help/faq#verification";
+
+  function prefill(form_url: string, user?: User) {
+    if (!user) return form_url;
+
+    const url = new URL(form_url);
+
+    //`${baseUrl}?prefill_MR+User+Email=${email}&prefill_MR+User+Name=${username}&prefill_MR+User+Account+URL=${accountUrl}&prefill_MR+Organization+Name=${orgSlug}&prefill_MR+Organization+Account+URL=${orgAccountUrl}`;
+    const accountUrl = `https://accounts.muckrock.com/users/${user.username}/`;
+    const orgAccountUrl = isOrg(user.organization)
+      ? `https://accounts.muckrock.com/organizations/${user.organization.slug}`
+      : "";
+
+    const params = {
+      "prefill_MR User Email": user.email ?? "",
+      "prefill_MR User Name": user.username ?? "",
+      "prefill_MR User Account URL": accountUrl,
+      "prefill_MR Organization Account URL": orgAccountUrl,
+    };
+
+    url.search = new URLSearchParams(params).toString();
+
+    return url.href;
+  }
+</script>
+
+<Tip>
+  <p>{$_("unverified.verify")}</p>
+  <Flex class="buttons" gap={1}>
+    <Button href={SQUARELET_ORGS_URL} target="_blank">
+      {$_("unverified.orgs")}
+    </Button>
+    <Button href={prefill(VERIFICATION_FORM_URL, user)} target="_blank">
+      {$_("unverified.requestVerificationAction")}
+    </Button>
+  </Flex>
+  <p>{$_("unverified.allowed_actions")}</p>
+  <p>
+    <a href={FAQ} target="_blank">
+      {$_("unverified.faq")}
+    </a>
+  </p>
+</Tip>

--- a/src/lib/components/accounts/Unverified.svelte
+++ b/src/lib/components/accounts/Unverified.svelte
@@ -20,7 +20,7 @@ a user who is logged in but has `verified_journalist = false`.
 
   export let user: Nullable<User> = null;
 
-  const FAQ = "https://www.documentcloud.org/help/faq#verification";
+  const FAQ = `${APP_URL}help/faq#verification`;
 
   function prefill(form_url: string, user: Nullable<User>) {
     if (!user) return form_url;

--- a/src/lib/components/accounts/Unverified.svelte
+++ b/src/lib/components/accounts/Unverified.svelte
@@ -13,8 +13,9 @@ a user who is logged in but has `verified_journalist = false`.
   import Tip from "../common/Tip.svelte";
 
   import {
-    VERIFICATION_FORM_URL,
+    APP_URL,
     SQUARELET_ORGS_URL,
+    VERIFICATION_FORM_URL,
   } from "@/config/config.js";
   import { isOrg } from "$lib/api/accounts";
 

--- a/src/lib/components/accounts/stories/Unverified.stories.svelte
+++ b/src/lib/components/accounts/stories/Unverified.stories.svelte
@@ -1,0 +1,18 @@
+<script context="module" lang="ts">
+  import { Story } from "@storybook/addon-svelte-csf";
+  import Unverified from "../Unverified.svelte";
+
+  import { me } from "@/test/fixtures/accounts";
+
+  export const meta = {
+    title: "Components / Accounts / Unverified",
+    component: Unverified,
+    parameters: { layout: "centered" },
+  };
+
+  const user = { ...me, verified_journalist: false };
+</script>
+
+<Story name="default">
+  <Unverified {user} />
+</Story>

--- a/src/lib/components/common/Tip.svelte
+++ b/src/lib/components/common/Tip.svelte
@@ -33,6 +33,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+    gap: var(--font-md);
   }
   .tip.normal {
     color: var(--yellow-5);

--- a/src/lib/components/common/Tip.svelte
+++ b/src/lib/components/common/Tip.svelte
@@ -14,6 +14,7 @@
 <style>
   .tip {
     display: flex;
+    align-items: flex-start;
     gap: var(--gap, 1rem);
     padding: var(--padding, 1rem);
     border-radius: var(--border-radius, 1rem);
@@ -21,14 +22,13 @@
     fill: var(--fill, var(--gray-4, #5c717c));
     background-color: var(--background-color, var(--gray-1, #f5f6f7));
     border: 1px solid var(--border-color, var(--gray-3, #99a8b3));
-
-    font-weight: var(--font-semibold);
   }
   .icon {
     display: flex;
     align-items: center;
   }
   .inner {
+    margin-top: 0.125rem;
     width: 100%;
     display: flex;
     flex-direction: column;

--- a/src/lib/components/common/stories/Tip.stories.svelte
+++ b/src/lib/components/common/stories/Tip.stories.svelte
@@ -24,7 +24,7 @@
 
 <Story name="With Icon" let:args>
   <Tip {...args}>
-    <Pin slot="icon" />
+    <Pin size={1.5} slot="icon" />
     Pinned items will appear here.
   </Tip>
 </Story>

--- a/src/lib/components/documents/ResultsList.svelte
+++ b/src/lib/components/documents/ResultsList.svelte
@@ -102,9 +102,9 @@
 </script>
 
 <div class="container" data-sveltekit-preload-data={preload}>
-  <slot name="start" />
-  {#each results as document (document.id)}
-    <Flex direction="column">
+  <Flex direction="column">
+    <slot name="start" />
+    {#each results as document (document.id)}
       <Flex gap={0.625} align="center">
         {#if !embed}
           <label>
@@ -126,13 +126,14 @@
       {#if document.note_highlights}
         <NoteHighlights {document} />
       {/if}
-    </Flex>
-  {:else}
-    <Empty icon={Search24}>
-      <h2>{$_("noDocuments.noSearchResults")}</h2>
-      <p>{$_("noDocuments.queryNoResults")}</p>
-    </Empty>
-  {/each}
+    {:else}
+      <Empty icon={Search24}>
+        <h2>{$_("noDocuments.noSearchResults")}</h2>
+        <p>{$_("noDocuments.queryNoResults")}</p>
+      </Empty>
+    {/each}
+  </Flex>
+
   <div bind:this={end} class="end">
     {#if next}
       <Button

--- a/src/lib/components/documents/stories/ResultsList.stories.svelte
+++ b/src/lib/components/documents/stories/ResultsList.stories.svelte
@@ -4,6 +4,9 @@
   import { Story } from "@storybook/addon-svelte-csf";
   import ResultsList from "../ResultsList.svelte";
   import Pending from "../Pending.svelte";
+  import Unverified from "../../accounts/Unverified.svelte";
+
+  import { me } from "@/test/fixtures/accounts";
 
   // typescript complains without the type assertion
   import searchResults from "@/test/fixtures/documents/search-highlight.json";
@@ -23,6 +26,8 @@
     component: ResultsList,
     tags: ["autodocs"],
   };
+
+  const user = { ...me, verified_journalist: false };
 </script>
 
 <Story name="With Results">
@@ -45,4 +50,10 @@
 
 <Story name="Highlighted">
   <ResultsList results={highlighted} {count} {next} />
+</Story>
+
+<Story name="Unverified user">
+  <ResultsList {results} {count} {next}>
+    <Unverified {user} slot="start" />
+  </ResultsList>
 </Story>

--- a/src/lib/components/forms/DocumentUpload.svelte
+++ b/src/lib/components/forms/DocumentUpload.svelte
@@ -74,8 +74,8 @@ progress through the three-part upload process.
   export let files: File[] = getFilesToUpload();
   export let projects: Project[] = [];
   export let user = getCurrentUser();
+  export let csrf_token: Maybe<string> = undefined;
 
-  let csrf_token: Maybe<string>;
   let fileDropActive: boolean;
 
   /**

--- a/src/lib/components/forms/DocumentUpload.svelte
+++ b/src/lib/components/forms/DocumentUpload.svelte
@@ -357,7 +357,7 @@ progress through the three-part upload process.
             type="submit"
             full
             mode="primary"
-            disabled={disabled || exceedsSizeLimit}
+            disabled={disabled || exceedsSizeLimit || empty}
           >
             <Upload16 />{$_("uploadDialog.beginUpload")}
           </Button>

--- a/src/lib/components/forms/stories/DocumentUpload.stories.svelte
+++ b/src/lib/components/forms/stories/DocumentUpload.stories.svelte
@@ -1,6 +1,10 @@
 <script context="module" lang="ts">
+  import { writable } from "svelte/store";
   import { Story, Template } from "@storybook/addon-svelte-csf";
   import DocumentUpload from "../DocumentUpload.svelte";
+  import Unverified from "../../accounts/Unverified.svelte";
+
+  import { me } from "@/test/fixtures/accounts";
 
   export const meta = {
     title: "Forms / Document Upload",
@@ -11,6 +15,8 @@
   const args = {
     files: [],
   };
+
+  const user = { ...me, verified_journalist: false };
 </script>
 
 <Template let:args>
@@ -47,3 +53,5 @@
     ],
   }}
 />
+
+<Story name="Unverified user" args={{ ...args, user: writable(user) }} />

--- a/src/lib/components/forms/tests/DocumentUpload.test.ts
+++ b/src/lib/components/forms/tests/DocumentUpload.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { writable } from "svelte/store";
 import {
   act,
   render,
@@ -9,10 +10,11 @@ import {
 
 import DocumentUploadForm from "../DocumentUpload.svelte";
 import { PDF_SIZE_LIMIT } from "@/config/config";
+import { me } from "@/test/fixtures/accounts";
 
 describe("DocumentUpload form", () => {
   it("lists files selected for upload", async () => {
-    render(DocumentUploadForm);
+    render(DocumentUploadForm, { user: writable(me), csrf_token: "token" });
     const dropElement = screen.getByText(
       "Select, paste or drag-and-drop files to upload",
     );
@@ -25,10 +27,11 @@ describe("DocumentUpload form", () => {
     });
     await act(() => fireEvent(dropElement, dropEvent));
     const fileListItem = screen.getByRole("listitem");
-    expect(fileListItem).toContainHTML("128 kB");
+    expect(fileListItem.textContent).toContain("128 kB");
   });
+
   it("provides feedback when a file is too large", async () => {
-    render(DocumentUploadForm);
+    render(DocumentUploadForm, { user: writable(me), csrf_token: "token" });
     const dropElement = screen.getByText(
       "Select, paste or drag-and-drop files to upload",
     );
@@ -43,6 +46,8 @@ describe("DocumentUpload form", () => {
     });
     await act(() => fireEvent(dropElement, dropEvent));
     const fileListItem = screen.getByRole("listitem");
-    expect(fileListItem).toContainHTML("The maximum size for a PDF is 500MB");
+    expect(fileListItem.textContent).toContain(
+      "The maximum size for a PDF is 500MB",
+    );
   });
 });

--- a/src/lib/components/layouts/DocumentBrowser.svelte
+++ b/src/lib/components/layouts/DocumentBrowser.svelte
@@ -36,7 +36,7 @@
 
   // Form components
   import Dropzone from "$lib/components/inputs/Dropzone.svelte";
-  import BulkActions from "@/lib/components/documents/BulkActions.svelte";
+  import BulkActions from "$lib/components/documents/BulkActions.svelte";
   import Search from "$lib/components/forms/Search.svelte";
   import {
     filesToUpload,
@@ -44,7 +44,10 @@
   } from "$lib/components/forms/DocumentUpload.svelte";
 
   // Layout comopnents
-  import ContentLayout from "$lib/components/layouts/ContentLayout.svelte";
+  import ContentLayout from "./ContentLayout.svelte";
+  import Dropdown from "../common/Dropdown.svelte";
+  import Menu from "../common/Menu.svelte";
+  import Unverified from "../accounts/Unverified.svelte";
   import { sidebars } from "$lib/components/layouts/Sidebar.svelte";
 
   // Utilities
@@ -52,8 +55,6 @@
   import { isSupported } from "$lib/utils/files";
   import { canUploadFiles, getCurrentUser } from "$lib/utils/permissions";
   import { remToPx } from "$lib/utils/layout";
-  import Dropdown from "../common/Dropdown.svelte";
-  import Menu from "../common/Menu.svelte";
 
   setContext("selected", selected);
 
@@ -182,7 +183,13 @@
             next={documentsResults.next}
             count={documentsResults.count}
             auto
-          />
+          >
+            <svelte:fragment slot="start">
+              {#if $me && !canUploadFiles($me)}
+                <Unverified user={$me} />
+              {/if}
+            </svelte:fragment>
+          </ResultsList>
         {/if}
       {:catch}
         <Error>{uiText.error}</Error>


### PR DESCRIPTION
Feedback welcome on the text here and the icon. Closes #841.
![Screenshot 2024-11-20 at 12 59 34 PM](https://github.com/user-attachments/assets/3328b436-ce62-4d38-9034-6487b475c4fe)

![Screenshot 2024-11-20 at 12 59 55 PM](https://github.com/user-attachments/assets/ba09e8a2-57e2-4b34-9099-a4fd6ba0a7ee)

Text:

- `verify`: "Before you can upload documents, you need to be verify your account. You can do this by joining a verified news organization or by requesting verification for yourself.",
- `allowed_actions`: "Until you're verified, you can search through the public repository, organize documents you're interested in into projects, leave private notes, and collaborate on editing and annotating documents other users invite you to."
