### PR TITLE
Show search result snippets by default

### DIFF
--- a/src/lib/components/documents/NoteHighlights.svelte
+++ b/src/lib/components/documents/NoteHighlights.svelte
@@ -25,7 +25,7 @@
   import HighlightGroup from "../common/HighlightGroup.svelte";
 
   export let document: Document;
-  export let open = false;
+  export let open = true;
 
   $: highlights = Object.entries(document.note_highlights ?? {});
   $: notes = new Map(document.notes?.map((n) => [n.id, n]));

--- a/src/lib/components/documents/PageHighlights.svelte
+++ b/src/lib/components/documents/PageHighlights.svelte
@@ -22,7 +22,7 @@
   import { pageNumber } from "$lib/utils/search";
 
   export let document: Document;
-  export let open = false;
+  export let open = true;
 
   $: highlights = Object.entries(document.highlights ?? {});
 


### PR DESCRIPTION
Fixes #848

Default `open = true` for page and note highlight groups