### PR TITLE
Standardize on 'en', not 'en-US' as a language code, but register both

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -35,8 +35,11 @@ async function language({ event, resolve }) {
   const lang =
     event.request.headers.get("accept-language")?.split(",")[0] ?? "en";
 
-  if (lang) {
-    locale.set(lang);
+  // use en.json for en-US and such
+  const [language, ...tags] = lang.split("-");
+
+  if (language) {
+    locale.set(language);
   }
 
   return resolve(event, {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -33,7 +33,7 @@ export const handleError = Sentry.handleErrorWithSentry();
 /** @type {import('@sveltejs/kit').Handle} */
 async function language({ event, resolve }) {
   const lang =
-    event.request.headers.get("accept-language")?.split(",")[0] ?? "en-US";
+    event.request.headers.get("accept-language")?.split(",")[0] ?? "en";
 
   if (lang) {
     locale.set(lang);

--- a/src/lib/components/documents/Access.svelte
+++ b/src/lib/components/documents/Access.svelte
@@ -30,7 +30,7 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
 
-  import type { Access } from "@/lib/api/types";
+  import type { Access } from "$lib/api/types";
   import type { Level } from "$lib/components/inputs/AccessLevel.svelte";
 
   export let level: Level;

--- a/src/lib/components/documents/BulkActions.svelte
+++ b/src/lib/components/documents/BulkActions.svelte
@@ -42,12 +42,12 @@ Most actual actions are deferred to their own forms, so this is more of a switch
   const selected: Readable<Document[]> = getContext("selected");
 
   const actions: Record<Action, ActionDetail> = {
-    share: [$_("bulk.actions.share"), Share16],
-    edit: [$_("bulk.actions.edit"), Pencil16],
-    data: [$_("bulk.actions.data"), Tag16],
-    project: [$_("bulk.actions.project"), FileDirectory16],
-    reprocess: [$_("bulk.actions.reprocess"), IssueReopened16],
-    delete: [$_("bulk.actions.delete"), Alert16],
+    share: ["bulk.actions.share", Share16],
+    edit: ["bulk.actions.edit", Pencil16],
+    data: ["bulk.actions.data", Tag16],
+    project: ["bulk.actions.project", FileDirectory16],
+    reprocess: ["bulk.actions.reprocess", IssueReopened16],
+    delete: ["bulk.actions.delete", Alert16],
   };
 
   let visible: Nullable<Action> = null;
@@ -76,7 +76,7 @@ Most actual actions are deferred to their own forms, so this is more of a switch
     }}
   >
     <svelte:component this={icon} slot="start" />
-    {label}
+    {$_(label)}
   </SidebarItem>
 {/each}
 

--- a/src/lib/i18n/index.js
+++ b/src/lib/i18n/index.js
@@ -5,10 +5,12 @@ import { LANGUAGES } from "@/config/config.js";
 const defaultLocale = "en";
 
 LANGUAGES.forEach(([name, code, flag]) => {
-  if (code) {
-    register(code, () => import(`@/langs/json/${code}.json`));
-  }
+  register(code, () => import(`@/langs/json/${code}.json`));
 });
+
+// handle two-part locales
+register("en-US", () => import("@/langs/json/en.json"));
+register("en-GB", () => import("@/langs/json/en.json"));
 
 init({
   fallbackLocale: defaultLocale,

--- a/src/lib/i18n/index.js
+++ b/src/lib/i18n/index.js
@@ -1,6 +1,7 @@
 import { browser } from "$app/environment";
 import { init, register } from "svelte-i18n";
 import { LANGUAGES } from "@/config/config.js";
+import { getLanguage } from "../utils/language";
 
 const defaultLocale = "en";
 
@@ -16,5 +17,7 @@ register("en-GB", () => import("@/langs/json/en.json"));
 
 init({
   fallbackLocale: defaultLocale,
-  initialLocale: browser ? window.navigator.language : defaultLocale,
+  initialLocale: browser
+    ? getLanguage(window.navigator?.language ?? defaultLocale)
+    : defaultLocale,
 });

--- a/src/lib/i18n/index.js
+++ b/src/lib/i18n/index.js
@@ -5,7 +5,9 @@ import { LANGUAGES } from "@/config/config.js";
 const defaultLocale = "en";
 
 LANGUAGES.forEach(([name, code, flag]) => {
-  register(code, () => import(`@/langs/json/${code}.json`));
+  if (code) {
+    register(code, () => import(`@/langs/json/${code}.json`));
+  }
 });
 
 // handle two-part locales

--- a/src/lib/utils/language.ts
+++ b/src/lib/utils/language.ts
@@ -1,0 +1,6 @@
+// handle language parsing here so we can test it
+
+export function getLanguage(code: string, fallback: string = "en") {
+  const [language, ...tags] = code.split("-");
+  return language || fallback;
+}

--- a/src/lib/utils/tests/language.test.ts
+++ b/src/lib/utils/tests/language.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "vitest";
+import { getLanguage } from "../language";
+
+// code, expected
+const languages = [
+  ["en", "en"],
+  ["en-US", "en"],
+  ["en-GB", "en"],
+  ["es", "es"],
+  ["--", "en"],
+];
+
+describe("language", () => {
+  test("split language codes", () => {
+    for (const [code, expected] of languages) {
+      expect(getLanguage(code as string)).toEqual(expected);
+    }
+  });
+});

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,5 +1,6 @@
 import { browser } from "$app/environment";
 import { locale, waitLocale } from "svelte-i18n";
+import { getLanguage } from "$lib/utils/language";
 
 import "$lib/i18n/index.js"; // Import to initialize. Important :)
 
@@ -7,8 +8,11 @@ export const trailingSlash = "always";
 
 export async function load() {
   if (browser) {
-    const language =
-      localStorage.getItem("dc-locale") || window.navigator.language;
+    const lang = localStorage.getItem("dc-locale") || window.navigator.language;
+
+    // use en.json for en-US and such
+    const language = getLanguage(lang, "en");
+
     locale.set(language);
   }
   await waitLocale();


### PR DESCRIPTION
Trying to solve #818 

My browser sets the `accept-language` header and `window.navigator.language` to `en-US`, but we weren't registering that as a locale, only `en`. So this adds that registration and also standardizes our own setting to `en`.