### PR TITLE
Use getApiResponse on infinite scrolls, too

### DIFF
--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -203,7 +203,9 @@
     "pageAbbrev": "p.",
     "pageCount": "{n, plural, one {# page} other {# pages}}",
     "select": "Select",
-    "noteCount": "{n, plural, one {# note} other {# notes}}"
+    "noteCount": "{n, plural, one {# note} other {# notes}}",
+    "more": "Load more",
+    "retry": "Please try again."
   },
   "error": {
     "report": "Report a problem"

--- a/src/lib/components/addons/History.svelte
+++ b/src/lib/components/addons/History.svelte
@@ -3,7 +3,7 @@
   import type { Run } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
-  import { History16, History24, Hourglass24 } from "svelte-octicons";
+  import { Alert16, History16, History24, Hourglass24 } from "svelte-octicons";
 
   import HistoryEvent from "./HistoryEvent.svelte";
   import Paginator from "$lib/components/common/Paginator.svelte";
@@ -11,11 +11,15 @@
   import SidebarItem from "../sidebar/SidebarItem.svelte";
   import Empty from "../common/Empty.svelte";
 
+  import { getApiResponse } from "$lib/utils/api";
+
   export let runs: Run[];
   export let previous: Maybe<Nullable<string>> = undefined;
   export let next: Maybe<Nullable<string>> = undefined;
 
   export let loading = false;
+
+  let error: string = "";
 
   $: empty = runs.length === 0;
 
@@ -23,21 +27,22 @@
   async function load(url: URL) {
     loading = true;
 
-    // todo: better error handling
-    const res = await fetch(url, { credentials: "include" }).catch(
+    const resp = await fetch(url, { credentials: "include" }).catch(
       console.error,
     );
-    if (!res) return console.error("API error");
-    if (!res.ok) {
-      console.error(res.statusText);
-      loading = false;
+
+    const { data: results, error: err } = await getApiResponse<Page<Run>>(resp);
+
+    if (err) {
+      error = err.message;
     }
 
-    const results: Page<Run> = await res.json();
+    if (results) {
+      runs = results.results;
+      next = results.next;
+      previous = results.previous;
+    }
 
-    runs = results.results;
-    next = results.next;
-    previous = results.previous;
     loading = false;
   }
 </script>
@@ -50,6 +55,10 @@
 
   {#if loading}
     <Empty icon={Hourglass24}>Loading past runs…</Empty>
+  {:else if error}
+    <Empty icon={Alert16}>
+      {error}
+    </Empty>
   {:else}
     {#each runs as run}
       <HistoryEvent {run} />
@@ -62,10 +71,10 @@
     <Paginator
       has_next={Boolean(next)}
       has_previous={Boolean(previous)}
-      on:next={(e) => {
+      on:next={() => {
         if (next) load(new URL(next));
       }}
-      on:previous={(e) => {
+      on:previous={() => {
         if (previous) load(new URL(previous));
       }}
     />

--- a/src/lib/components/addons/History.svelte
+++ b/src/lib/components/addons/History.svelte
@@ -3,7 +3,7 @@
   import type { Run } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
-  import { Alert16, History16, History24, Hourglass24 } from "svelte-octicons";
+  import { Alert24, History16, History24, Hourglass24 } from "svelte-octicons";
 
   import HistoryEvent from "./HistoryEvent.svelte";
   import Paginator from "$lib/components/common/Paginator.svelte";
@@ -56,7 +56,7 @@
   {#if loading}
     <Empty icon={Hourglass24}>Loading past runs…</Empty>
   {:else if error}
-    <Empty icon={Alert16}>
+    <Empty icon={Alert24}>
       {error}
     </Empty>
   {:else}

--- a/src/lib/components/addons/Scheduled.svelte
+++ b/src/lib/components/addons/Scheduled.svelte
@@ -2,7 +2,7 @@
   import type { Maybe, Nullable, Page, Event } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
-  import { Alert16, Clock16, Hourglass24 } from "svelte-octicons";
+  import { Alert24, Clock16, Hourglass24 } from "svelte-octicons";
 
   import ScheduledEvent from "./ScheduledEvent.svelte";
   import SidebarGroup from "../sidebar/SidebarGroup.svelte";
@@ -54,7 +54,7 @@
   {#if loading}
     <Empty icon={Hourglass24}>{$_("common.loading")}</Empty>
   {:else if error}
-    <Empty icon={Alert16}>
+    <Empty icon={Alert24}>
       {error}
     </Empty>
   {:else}

--- a/src/lib/components/documents/ResultsList.svelte
+++ b/src/lib/components/documents/ResultsList.svelte
@@ -192,6 +192,7 @@
   }
 
   .error {
+    text-align: center;
     color: var(--error, red);
   }
 </style>

--- a/src/lib/components/documents/stories/ResultsList.stories.svelte
+++ b/src/lib/components/documents/stories/ResultsList.stories.svelte
@@ -7,6 +7,7 @@
   import Unverified from "../../accounts/Unverified.svelte";
 
   import { me } from "@/test/fixtures/accounts";
+  import { documents as mock } from "@/test/handlers/documents";
 
   // typescript complains without the type assertion
   import searchResults from "@/test/fixtures/documents/search-highlight.json";
@@ -24,7 +25,6 @@
   export const meta = {
     title: "Components / Documents / Results list",
     component: ResultsList,
-    tags: ["autodocs"],
   };
 
   const user = { ...me, verified_journalist: false };
@@ -56,4 +56,8 @@
   <ResultsList {results} {count} {next}>
     <Unverified {user} slot="start" />
   </ResultsList>
+</Story>
+
+<Story name="Loading error" parameters={{ msw: { handlers: [mock.error] } }}>
+  <ResultsList {results} {count} {next} auto />
 </Story>

--- a/src/test/handlers/documents.ts
+++ b/src/test/handlers/documents.ts
@@ -13,6 +13,10 @@ export const documents = {
     new URL("documents/pending/", BASE_API_URL).href,
     (req, res, ctx) => res(ctx.json(pending)),
   ),
+  error: rest.get(
+    new URL("documents/search/", "https://api.www.documentcloud.org/api/").href,
+    (req, res, ctx) => res(ctx.status(500, "Something went wrong")),
+  ),
 };
 
 export const revisionControl = {


### PR DESCRIPTION
Closes #829 

This aligns our infinite scroll handling with other places we hit the API and lets us show an error message when something fails.