### PR TITLE
Add project slugs to search queries for readability

### DIFF
--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -1,9 +1,7 @@
 /**
  * API response types
- *
- * This is a separate module from what's in src/api to prevent conflicts.
- * Both modules can be merged later.
- * */
+ */
+
 import type { DefinedError } from "ajv";
 
 export type Access = "public" | "private" | "organization"; // https://www.documentcloud.org/help/api#access-levels

--- a/src/lib/components/layouts/Project.svelte
+++ b/src/lib/components/layouts/Project.svelte
@@ -22,7 +22,7 @@
   export let query: string = "";
   export let addons: Promise<APIResponse<Page<AddOnListItem>>>;
 
-  $: combinedQuery = `+project:${project.id} ${query}`.trim();
+  $: combinedQuery = `+project:${project.slug}-${project.id} ${query}`.trim();
 </script>
 
 <SidebarLayout>

--- a/src/lib/utils/search.ts
+++ b/src/lib/utils/search.ts
@@ -1,5 +1,6 @@
 import type { Nullable, Project, User } from "$lib/api/types";
 import type { Access } from "../api/types";
+
 import { APP_URL } from "@/config/config.js";
 import { slugify } from "$lib/utils/slugify";
 import { getUserName } from "../api/accounts";
@@ -11,7 +12,7 @@ export function searchUrl(query: string): URL {
 }
 
 export function projectSearchUrl(project: Project): string {
-  return searchUrl(`+project:${project.id} `).href;
+  return searchUrl(`+project:${project.slug}-${project.id} `).href;
 }
 
 /**


### PR DESCRIPTION
We were already doing this with users and orgs. Now when we link to a project query, we use the slug there, too. For example, `+project:200002` is now `+project:test-2-200002`.