### PR TITLE
Change how we observe clicks outside Dropdowns

### DIFF
--- a/src/lib/components/common/Dropdown.svelte
+++ b/src/lib/components/common/Dropdown.svelte
@@ -89,10 +89,14 @@
     return clickInsideDropdown || clickInsideAnchor;
   }
 
+  function isInSubtree(element: Element) {
+    return dropdown.contains(element) || anchor.contains(element);
+  }
+
   // Close the dropdown when a click or escape is made outside its subtree
   function closeOnEventOutside(event: MouseEvent) {
     if (event.target instanceof Element) {
-      if (!isInBoundingRect(event)) {
+      if (!isInSubtree(event.target) && !isInBoundingRect(event)) {
         close();
       }
     }

--- a/src/lib/components/common/Dropdown.svelte
+++ b/src/lib/components/common/Dropdown.svelte
@@ -73,12 +73,26 @@
     }
   }
 
+  function isInBoundingRect(event: MouseEvent) {
+    const dropdownRect = dropdown.getBoundingClientRect();
+    const anchorRect = anchor.getBoundingClientRect();
+    const clickInsideDropdown =
+      event.clientX >= dropdownRect.left &&
+      event.clientX <= dropdownRect.right &&
+      event.clientY >= dropdownRect.top &&
+      event.clientY <= dropdownRect.bottom;
+    const clickInsideAnchor =
+      event.clientX >= anchorRect.left &&
+      event.clientX <= anchorRect.right &&
+      event.clientY >= anchorRect.top &&
+      event.clientY <= anchorRect.bottom;
+    return clickInsideDropdown || clickInsideAnchor;
+  }
+
   // Close the dropdown when a click or escape is made outside its subtree
   function closeOnEventOutside(event: MouseEvent) {
     if (event.target instanceof Element) {
-      const outside = !dropdown.contains(event.target);
-      const notTitle = !anchor.contains(event.target);
-      if (outside && notTitle) {
+      if (!isInBoundingRect(event)) {
         close();
       }
     }

--- a/src/lib/components/common/stories/Dropdown.stories.svelte
+++ b/src/lib/components/common/stories/Dropdown.stories.svelte
@@ -77,3 +77,27 @@
     </Menu>
   </Dropdown>
 </Story>
+
+<Story name="With Nested Dropdown">
+  <Dropdown position="right">
+    <SidebarItem slot="anchor">
+      <Globe16 slot="start" />
+      Open Dropdown
+      <ChevronRight12 slot="end" />
+    </SidebarItem>
+    <Menu slot="default" let:close>
+      <SidebarItem on:click={close}>Item 1</SidebarItem>
+      <SidebarItem on:click={close}>Item 2</SidebarItem>
+      <Dropdown position="right">
+        <SidebarItem slot="anchor">
+          Item 3
+          <ChevronRight12 slot="end" />
+        </SidebarItem>
+        <Menu slot="default">
+          <MenuItem>Item 1</MenuItem>
+          <MenuItem>Item 2</MenuItem>
+        </Menu>
+      </Dropdown>
+    </Menu>
+  </Dropdown>
+</Story>


### PR DESCRIPTION
Fixes #857 

Instead of only checking that the click event's target element is inside the dropdown, we enhance this to check whether the click's position is over the dropdown's bounding rect. When both checks fail, we consider the click to be outside the dropdown.

We can't assume the target will be inside the dropdown, because if the click causes the tree to rerender than our target will be outdated and no longer in the DOM. We also can't assume that a click will always be in the dropdown's bounding rect, because a sub-menu may be absolutely  positioned outside it. When both checks fail, however, we can be very certain that the click was outside the dropdown.