### PR TITLE
Redirect page and note endpoints to embed versions

### DIFF
--- a/src/routes/(app)/documents/[id]/annotations/[note_id]/+page.ts
+++ b/src/routes/(app)/documents/[id]/annotations/[note_id]/+page.ts
@@ -1,0 +1,13 @@
+import { redirect } from "@sveltejs/kit";
+
+import { EMBED_URL } from "@/config/config.js";
+
+// redirect to embed route
+export function load({ url }) {
+  const u = new URL(url);
+
+  u.searchParams.set("embed", "1");
+  u.hostname = EMBED_URL;
+
+  return redirect(302, u);
+}

--- a/src/routes/(app)/documents/[id]/pages/[page]/+page.ts
+++ b/src/routes/(app)/documents/[id]/pages/[page]/+page.ts
@@ -1,0 +1,13 @@
+import { redirect } from "@sveltejs/kit";
+
+import { EMBED_URL } from "@/config/config.js";
+
+// redirect to embed route
+export function load({ url }) {
+  const u = new URL(url);
+
+  u.searchParams.set("embed", "1");
+  u.hostname = EMBED_URL;
+
+  return redirect(302, u);
+}


### PR DESCRIPTION
- **Redirect old note permalinks to embeds**
- **Redirect page endpoints to embed**

This should handle any existing embeds that didn't include the `embed.documentcloud.org` or `?embed=1` in the URL.