### PR TITLE
Get full list of pinned projects

### DIFF
--- a/src/lib/api/projects.ts
+++ b/src/lib/api/projects.ts
@@ -96,6 +96,15 @@ export async function getShared(
 }
 
 /**
+ * Get all pinned projects for a user
+ */
+export async function getPinnedProjects(fetch = globalThis.fetch) {
+  const endpoint = new URL("projects/", BASE_API_URL);
+  endpoint.searchParams.set("pinned", "true");
+  return getAll<Project>(endpoint, undefined, fetch);
+}
+
+/**
  * Set the pinned status of a project.
  * When requesting PATCH on the project endpoint,
  * it returns the updated project object.

--- a/src/routes/(app)/+layout.ts
+++ b/src/routes/(app)/+layout.ts
@@ -11,7 +11,7 @@ import type {
 import { getMe, orgUsers, userOrgs } from "$lib/api/accounts";
 import { getTipOfDay } from "$lib/api/flatpages";
 import { getPinnedAddons } from "$lib/api/addons";
-import { list as listProjects } from "$lib/api/projects";
+import { getPinnedProjects } from "$lib/api/projects";
 
 export const trailingSlash = "always";
 
@@ -42,12 +42,10 @@ export async function load({ fetch }) {
       console.error(e);
       return null;
     });
-    pinnedProjects = listProjects({ pinned: true }, fetch)
-      .then((r) => r.data?.results ?? [])
-      .catch((e) => {
-        console.error(e);
-        return [];
-      });
+    pinnedProjects = getPinnedProjects(fetch).catch((e) => {
+      console.error(e);
+      return [];
+    });
   }
 
   return {


### PR DESCRIPTION
Fixes #924

This uses the `getAll` util to concatenate all pinned projects into a single array. On errors, we return an empty array.