### PR TITLE
Preserve querystrings on redirects

### DIFF
--- a/src/routes/(app)/+page.ts
+++ b/src/routes/(app)/+page.ts
@@ -1,12 +1,16 @@
 import { redirect } from "@sveltejs/kit";
-import { searchUrl, userDocs } from "$lib/utils/search";
+import { userDocs } from "$lib/utils/search";
 
-export async function load({ parent }) {
+export async function load({ parent, url }) {
   const { me } = await parent();
+  const u = new URL(url);
 
   if (me) {
-    return redirect(302, searchUrl(userDocs(me)));
+    u.pathname = "/documents/";
+    u.searchParams.set("q", userDocs(me));
+    return redirect(302, u);
   }
 
-  return redirect(302, "/home/");
+  u.pathname = "/home/";
+  return redirect(302, u);
 }

--- a/src/routes/(app)/app/+page.ts
+++ b/src/routes/(app)/app/+page.ts
@@ -2,6 +2,11 @@
 
 import { redirect } from "@sveltejs/kit";
 
-export function load() {
-  return redirect(302, "/");
+export function load({ url }) {
+  const u = new URL(url);
+
+  // change the path but preserve other parts of the URL
+  u.pathname = "/documents/";
+
+  return redirect(302, u);
 }


### PR DESCRIPTION
Closes #945 

Clones the URL, change the path but preserves other properties, including querystring.