### PR TITLE
Capture page URL for feedback

### DIFF
--- a/src/lib/api/feedback.ts
+++ b/src/lib/api/feedback.ts
@@ -9,6 +9,7 @@ export interface Feedback {
   Type: string;
   Message: string;
   User: string;
+  URL: string;
 }
 
 export interface CreateFeedbackResponse {
@@ -22,6 +23,7 @@ export interface CreateFeedbackResponse {
     color: string;
   };
   User: string;
+  URL: string;
 }
 
 export async function createFeedback(

--- a/src/lib/components/forms/UserFeedback.svelte
+++ b/src/lib/components/forms/UserFeedback.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import { enhance } from "$app/forms";
+  import { page } from "$app/page";
   import { _ } from "svelte-i18n";
   import { Bug16, Comment16, Question16 } from "svelte-octicons";
   import type { Nullable, User } from "$lib/api/types";
@@ -108,6 +109,7 @@
       </label>
     </fieldset>
   {/if}
+  <input type="text" name="url" value={$page.url.href} hidden />
   <textarea
     class="feedback"
     name="message"

--- a/src/lib/components/forms/UserFeedback.svelte
+++ b/src/lib/components/forms/UserFeedback.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
   import { enhance } from "$app/forms";
-  import { page } from "$app/page";
+  import { page } from "$app/stores";
   import { _ } from "svelte-i18n";
   import { Bug16, Comment16, Question16 } from "svelte-octicons";
   import type { Nullable, User } from "$lib/api/types";

--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -14,6 +14,7 @@ export const actions = {
       Type: String(data.get("type")) ?? "",
       Message: String(data.get("message")) ?? "",
       User: String(data.get("user")) ?? "",
+      URL: String(data.get("url")) ?? "",
     };
     try {
       await createFeedback(feedback, fetch);


### PR DESCRIPTION
We get a lot of anonymous feedback about loading issues. By adding the page URL to the feedback payload, we can better target diagnoses.