### PR TITLE
Fix redaction box drawing logic

### DIFF
--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -98,10 +98,10 @@ Assumes it's a child of a ViewerContext
     const movingRight = x > startX;
     const movingDown = y > startY;
 
-    const x1 = movingRight ? $newNote.x1 : x;
-    const x2 = movingRight ? x : $newNote.x2;
-    const y1 = movingDown ? $newNote.y1 : y;
-    const y2 = movingDown ? y : $newNote.y2;
+    const x1 = movingRight ? startX : x;
+    const x2 = movingRight ? x : startX;
+    const y1 = movingDown ? startY : y;
+    const y2 = movingDown ? y : startY;
 
     $newNote = {
       x1,


### PR DESCRIPTION
Fixes #969

As a bonus, slight improvement to annotation box drawing logic, too!

Doesn't consolidate the logic, since it depends on global variables to work correctly. Could be revisited in the future.