### PR TITLE
Attempted fix for private PDF 403 error

### DIFF
--- a/src/lib/components/viewer/stories/Viewer.stories.svelte
+++ b/src/lib/components/viewer/stories/Viewer.stories.svelte
@@ -8,6 +8,8 @@
   import doc from "@/test/fixtures/documents/document-expanded.json";
   import txt from "@/test/fixtures/documents/document.txt.json";
   import { searchWithin } from "@/test/handlers/documents";
+  import { simulatePDF403Error } from "@/test/handlers/viewer";
+  import { pdfUrl } from "@/lib/api/documents";
 
   const document = doc as Document;
 
@@ -98,6 +100,21 @@
       ...document,
       edit_access: true,
       notes: document.notes?.map((note) => ({ ...note, edit_access: true })),
+    },
+  }}
+/>
+
+<Story
+  name="With 403 Error"
+  parameters={{
+    msw: { handlers: [simulatePDF403Error(pdfUrl(document).href)] },
+  }}
+  args={{
+    ...args,
+    mode: "document",
+    document: {
+      ...document,
+      access: "private",
     },
   }}
 />

--- a/src/test/handlers/viewer.ts
+++ b/src/test/handlers/viewer.ts
@@ -1,0 +1,6 @@
+import { rest } from "msw";
+
+export const simulatePDF403Error = (asset_url: string) =>
+  rest.get(asset_url, (req, res, ctx) =>
+    res(ctx.status(403, "Not Found"), ctx.json({ detail: "Not found." })),
+  );


### PR DESCRIPTION
Fixes #836

When we're fetching a private asset and we get a 403 response, try refetching the private asset URL and trying again (up to a maximum of 5 tries).