### PR TITLE
Embeds don't need SSR

### DIFF
--- a/src/routes/embed/+layout.ts
+++ b/src/routes/embed/+layout.ts
@@ -1,0 +1,1 @@
+export const ssr = false;


### PR DESCRIPTION
We're burning through our functions quota on Netlify serving embeds, which are almost entirely client-side rendered anyway.