### PR TITLE
Preserve search params when navigating within the viewer

### DIFF
--- a/src/lib/components/common/Tab.svelte
+++ b/src/lib/components/common/Tab.svelte
@@ -1,4 +1,10 @@
+<!-- @component
+A tab component for navigating within a page.
+Note that links will preserve querystrings where possible.
+-->
 <script lang="ts">
+  import { qs } from "$lib/utils/navigation";
+
   export let active = false;
   export let disabled = false;
   export let href: string = "";
@@ -6,7 +12,7 @@
 
 <div class="tab" role="tab" class:active class:disabled>
   {#if href}
-    <a {href} class:disabled>
+    <a {href} class:disabled use:qs>
       <slot />
     </a>
   {:else}

--- a/src/lib/components/viewer/ReadingToolbar.svelte
+++ b/src/lib/components/viewer/ReadingToolbar.svelte
@@ -46,14 +46,6 @@ Assumes it's a child of a ViewerContext
   const mode = getCurrentMode();
   const embed = isEmbedded();
 
-  $: document = $documentStore;
-  $: canWrite = !embed && document.edit_access;
-  $: BREAKPOINTS = {
-    READ_MENU: width > remToPx(52),
-    WRITE_MENU: width < remToPx(37),
-    SEARCH_MENU: width < remToPx(24),
-  };
-
   const readModeTabs: Map<ReadMode, string> = new Map([
     ["document", $_("mode.document")],
     ["text", $_("mode.text")],
@@ -83,6 +75,18 @@ Assumes it's a child of a ViewerContext
     redacting: EyeClosed16,
     search: Search16,
   };
+
+  $: document = $documentStore;
+  $: canWrite = !embed && document.edit_access;
+  $: BREAKPOINTS = {
+    READ_MENU: width > remToPx(52),
+    WRITE_MENU: width < remToPx(37),
+    SEARCH_MENU: width < remToPx(24),
+  };
+
+  $: current = Array.from(readModeDropdownItems ?? []).find(
+    ([value]) => value === $mode,
+  )?.[1];
 </script>
 
 <PageToolbar bind:width>
@@ -103,9 +107,7 @@ Assumes it's a child of a ViewerContext
       <Dropdown position="bottom-start">
         <SidebarItem slot="anchor">
           <svelte:component this={icons[$mode]} slot="start" />
-          {Array.from(readModeDropdownItems ?? []).find(
-            ([value]) => value === $mode,
-          )?.[1]}
+          {current}
           <ChevronDown12 slot="end" />
         </SidebarItem>
         <Menu slot="default" let:close>

--- a/src/lib/utils/navigation.ts
+++ b/src/lib/utils/navigation.ts
@@ -1,3 +1,5 @@
+import type { Action } from "svelte/action";
+
 type Breadcrumb = { href?: string; title: string };
 type Parent = () => Promise<{ breadcrumbs?: Array<Breadcrumb> }>;
 
@@ -10,4 +12,24 @@ export async function breadcrumbTrail(
 ) {
   const { breadcrumbs: trail = [] } = await parent();
   return trail.concat(crumbs);
+}
+
+/**
+ * Make a link preserve existing query params and merge in new ones
+ *
+ * @type {Action}
+ * @param node
+ */
+export function qs(node: HTMLAnchorElement) {
+  if (typeof window === "undefined") return;
+
+  const href = new URL(node.href);
+  const params = new URLSearchParams(window.location.search);
+
+  for (const [k, v] of href.searchParams) {
+    params.set(k, v);
+  }
+
+  href.search = params.toString();
+  node.href = href.toString();
 }

--- a/src/lib/utils/tests/navigation.test.ts
+++ b/src/lib/utils/tests/navigation.test.ts
@@ -1,16 +1,23 @@
+/**
+ * @vitest-environment jsdom
+ * @vitest-environment-options { "url": "https://www.dev.documentcloud.org/documents/20000065-creating-adaptable-skills-a-nonlinear-pedagogy-approach-to-mental-imagery/?mode=search&embed=1&q=pedagogy&title=0" }
+ */
+
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
-import { breadcrumbTrail } from "../navigation";
+import { breadcrumbTrail, qs } from "../navigation";
 
 describe("breadcrumbTrail", () => {
   it("returns an empty array as a base case", async () => {
     const parent = vi.fn().mockResolvedValue({});
     expect(await breadcrumbTrail(parent)).toEqual([]);
   });
+
   it("returns the parent's breadcrumb trail, if it exists", async () => {
     const parentTrail = [{ href: "/first", title: "First Level" }];
     const parent = vi.fn().mockResolvedValue({ breadcrumbs: parentTrail });
     expect(await breadcrumbTrail(parent)).toEqual(parentTrail);
   });
+
   it("concats the provided trail onto the parent's trail", async () => {
     const parentTrail = [{ href: "/first", title: "First Level" }];
     const childTrail = [{ href: "/second", title: "Second Level" }];
@@ -19,5 +26,37 @@ describe("breadcrumbTrail", () => {
       ...parentTrail,
       ...childTrail,
     ]);
+  });
+});
+
+describe("querystring links", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("adds new query params to existing URL params", () => {
+    const links = [
+      "https://www.dev.documentcloud.org/documents/20000065-creating-adaptable-skills-a-nonlinear-pedagogy-approach-to-mental-imagery/?mode=document#document/p1",
+      "https://www.dev.documentcloud.org/documents/20000065-creating-adaptable-skills-a-nonlinear-pedagogy-approach-to-mental-imagery/?mode=notes",
+      "https://www.dev.documentcloud.org/documents/20000065-creating-adaptable-skills-a-nonlinear-pedagogy-approach-to-mental-imagery/?mode=document",
+    ];
+
+    const fixed = [
+      "?mode=document&embed=1&q=pedagogy&title=0",
+      "?mode=notes&embed=1&q=pedagogy&title=0",
+      "?mode=document&embed=1&q=pedagogy&title=0",
+    ];
+
+    links.forEach((href, i) => {
+      // create the link
+      let a = document.createElement("a");
+      a.href = href;
+      a.textContent = "test";
+
+      // fix the link
+      qs(a);
+
+      expect(new URL(a.href).search).toEqual(fixed[i]);
+    });
   });
 });


### PR DESCRIPTION
Closes #933 

Example URL: https://deploy-preview-985.muckcloud.com/documents/20006908-lawsuit-document-dkt-1-68-ex-j/?q=apple&mode=search&embed=1&title=0

Clicking links in search or the `mode` tabs should keep you in the embed viewer and preserve params like `title=0`.