### PR TITLE
Dial up caching and allow overrides through env

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,6 +1,8 @@
 import * as staging from "./staging.js";
 import * as production from "./production.js";
 
+import * as env from "$env/static/public";
+
 // these are the only values that change across environments
 let DC_BASE = "https://api.dev.documentcloud.org";
 let APP_URL = "https://www.dev.documentcloud.org/";
@@ -37,9 +39,9 @@ export const SIGN_IN_URL = new URL(DC_LOGIN, DC_BASE).toString();
 export const SIGN_UP_URL = new URL(SQUARELET_SIGNUP, SQUARELET_BASE).toString();
 export const SIGN_OUT_URL = new URL(DC_LOGOUT, DC_BASE).toString();
 
-export const EMBED_MAX_AGE = 60 * 20;
-export const PAGE_MAX_AGE = 60 * 10;
-export const VIEWER_MAX_AGE = 60 * 10;
+export const EMBED_MAX_AGE = +env.PUBLIC_EMBED_MAX_AGE || 60 * 60 * 24;
+export const PAGE_MAX_AGE = +env.PUBLIC_PAGE_MAX_AGE || 60 * 60 * 24;
+export const VIEWER_MAX_AGE = +env.PUBLIC_VIEWER_MAX_AGE || 60 * 60;
 
 export const VERIFICATION_FORM_URL =
   "https://airtable.com/app93Yt5cwdVWTnqn/pagogIhgB1jZTzq00/form";

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -39,8 +39,13 @@ export const SIGN_IN_URL = new URL(DC_LOGIN, DC_BASE).toString();
 export const SIGN_UP_URL = new URL(SQUARELET_SIGNUP, SQUARELET_BASE).toString();
 export const SIGN_OUT_URL = new URL(DC_LOGOUT, DC_BASE).toString();
 
+// @ts-ignore
 export const EMBED_MAX_AGE = +env.PUBLIC_EMBED_MAX_AGE || 60 * 60 * 24;
+
+// @ts-ignore
 export const PAGE_MAX_AGE = +env.PUBLIC_PAGE_MAX_AGE || 60 * 60 * 24;
+
+// @ts-ignore
 export const VIEWER_MAX_AGE = +env.PUBLIC_VIEWER_MAX_AGE || 60 * 60;
 
 export const VERIFICATION_FORM_URL =

--- a/src/lib/components/layouts/EmbedLayout.svelte
+++ b/src/lib/components/layouts/EmbedLayout.svelte
@@ -45,7 +45,7 @@
   </main>
   <footer>
     <Tooltip caption="View on DocumentCloud">
-      <a href={canonicalUrl} class="logo">
+      <a href={canonicalUrl} class="logo" target="_blank">
         <Logo />
       </a>
     </Tooltip>


### PR DESCRIPTION
Setting cache headers on embeds and flat pages to 24 hours.