### PR TITLE
Give embeds a minimal config to exclude unused imports

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -19,7 +19,7 @@
   // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
   // from the referenced tsconfig.json - TypeScript does not merge them in
   "include": [
-    ".svelte-kit/**",
+    // ".svelte-kit/**",
     ".svelte-kit/ambient.d.ts",
     "vite.config.js",
     "vite.config.ts",

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,10 +2,6 @@
 command = "npm run build"
 publish = "build"
 
-
-[[context.production.plugins]]
-package = "/plugins/cache-bust"
-
 [[plugins]]
 package = "@netlify/plugin-lighthouse"
 # https://github.com/netlify/netlify-plugin-lighthouse

--- a/src/config/embed.js
+++ b/src/config/embed.js
@@ -1,0 +1,18 @@
+// dedicated, minimal config required for embeds
+import * as staging from "./staging.js";
+import * as production from "./production.js";
+
+let APP_URL = "https://www.dev.documentcloud.org/";
+let EMBED_URL = "https://www.dev.documentcloud.org/";
+
+if (process.env.NODE_ENV === "staging") {
+  APP_URL = staging.APP_URL;
+  EMBED_URL = staging.EMBED_URL;
+}
+
+if (process.env.NODE_ENV === "production") {
+  APP_URL = production.APP_URL;
+  EMBED_URL = production.EMBED_URL;
+}
+
+export { APP_URL, EMBED_URL };

--- a/src/embed/enhance.js
+++ b/src/embed/enhance.js
@@ -1,5 +1,5 @@
 import { setupResizeEvent } from "./iframeSizer.js";
-import { APP_URL } from "../config/config.js";
+import { APP_URL } from "../config/embed.js";
 
 const embeds = document.querySelectorAll(".DC-embed");
 const enhanced = "DC-embed-enhanced";

--- a/src/embed/noteLoader.js
+++ b/src/embed/noteLoader.js
@@ -1,5 +1,5 @@
 import { setupResizeEvent } from "./iframeSizer.js";
-import { APP_URL } from "../config/config.js";
+import { APP_URL } from "../config/embed.js";
 
 const enhanced = "DC-embed-enhanced";
 

--- a/src/embed/projectLoader.js
+++ b/src/embed/projectLoader.js
@@ -1,6 +1,6 @@
 import { setupResizeEvent } from "./iframeSizer.js";
 import { queryBuilder } from "@/legacy/util/url.js";
-import { EMBED_URL } from "../config/config.js";
+import { EMBED_URL } from "../config/embed.js";
 
 function logInvalidQuery(options, container) {
   const q = options.q;


### PR DESCRIPTION
The `$env/static/public` import was breaking our embed scripts, which made me realize we were importing a bunch of unneeded config in those anyway. This fixes both problems.