### PR TITLE
Show confirmation when navigating away from in-progress upload form

### DIFF
--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -144,6 +144,7 @@
     "tesseract": "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://tesseract-ocr.github.io/tessdoc/\">Tesseract</a> is an open source OCR engine available free to all DocumentCloud accounts.",
     "textract": "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://aws.amazon.com/textract/\">Textract</a> is a more powerful OCR engine that can better handle messy text, handwriting and fuzzy scans.",
     "empty": "Get started by selecting, pasting or dragging-and-dropping files",
+    "confirmLeave": "Your upload is not complete. Are you sure you want to leave the page?",
     "steps": {
       "ready": "Ready",
       "created": "Created",

--- a/src/lib/components/forms/DocumentUpload.svelte
+++ b/src/lib/components/forms/DocumentUpload.svelte
@@ -39,9 +39,10 @@ progress through the three-part upload process.
     Project,
   } from "$lib/api/types";
 
+  import { beforeNavigate } from "$app/navigation";
+
   import { filesize } from "filesize";
   import { onMount } from "svelte";
-  import { beforeNavigate } from "$app/navigation";
   import { _ } from "svelte-i18n";
   import { Paperclip16, Paperclip24, Upload16 } from "svelte-octicons";
 

--- a/src/lib/components/forms/DocumentUpload.svelte
+++ b/src/lib/components/forms/DocumentUpload.svelte
@@ -41,6 +41,7 @@ progress through the three-part upload process.
 
   import { filesize } from "filesize";
   import { onMount } from "svelte";
+  import { beforeNavigate } from "$app/navigation";
   import { _ } from "svelte-i18n";
   import { Paperclip16, Paperclip24, Upload16 } from "svelte-octicons";
 
@@ -137,6 +138,14 @@ progress through the three-part upload process.
   onMount(() => {
     csrf_token = getCsrfToken();
     addFiles(getFilesToUpload());
+  });
+
+  beforeNavigate((navigation) => {
+    if (!empty && !loading) {
+      if (!window.confirm($_("uploadDialog.confirmLeave"))) {
+        navigation.cancel();
+      }
+    }
   });
 
   function uniqueId(): string {


### PR DESCRIPTION
Fixes #983

When the upload form isn't empty or is loading, show a confirmation dialog before completing a navigation away.