### PR TITLE
Split SSR functions by route

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
 command = "npm run build"
 publish = "build"
 
+[[context.production.plugins]]
+package = "/plugins/cache-bust"
+
 [[plugins]]
 package = "@netlify/plugin-lighthouse"
 # https://github.com/netlify/netlify-plugin-lighthouse

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,6 +12,7 @@ export default {
   kit: {
     adapter: adapter({
       preprocess: true,
+      split: true,
     }),
     alias: {
       "@": "./src",


### PR DESCRIPTION
The goal here is to give us better visibility into where we're running Netlify functions.

This also reenables cache busting on deploy. I think getting rid of that caused more problems than it solved.
