### PR TITLE
Ignore trailing slashes for flat pages

### DIFF
--- a/src/routes/(pages)/[...path]/+page.ts
+++ b/src/routes/(pages)/[...path]/+page.ts
@@ -4,6 +4,9 @@ import { error } from "@sveltejs/kit";
 import { PAGE_MAX_AGE } from "@/config/config.js";
 import * as flatpages from "$lib/api/flatpages";
 
+export const trailingSlash = "ignore";
+export const prerender = "auto";
+
 export async function load({ fetch, params, setHeaders }) {
   const { data, error: err } = await flatpages.get(params.path, fetch);
 

--- a/src/routes/(pages)/[...path]/+page.ts
+++ b/src/routes/(pages)/[...path]/+page.ts
@@ -5,7 +5,6 @@ import { PAGE_MAX_AGE } from "@/config/config.js";
 import * as flatpages from "$lib/api/flatpages";
 
 export const trailingSlash = "ignore";
-export const prerender = "auto";
 
 export async function load({ fetch, params, setHeaders }) {
   const { data, error: err } = await flatpages.get(params.path, fetch);

--- a/src/routes/(pages)/home/+page.ts
+++ b/src/routes/(pages)/home/+page.ts
@@ -10,6 +10,8 @@ import { getMe } from "$lib/api/accounts";
 
 marked.use(gfmHeadingId());
 
+export const trailingSlash = "always";
+
 export async function load({ fetch, setHeaders }) {
   const [{ data: page, error: err }, me] = await Promise.all([
     flatpages.get("/home/", fetch),

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -4,8 +4,6 @@ import { getLanguage } from "$lib/utils/language";
 
 import "$lib/i18n/index.js"; // Import to initialize. Important :)
 
-export const trailingSlash = "always";
-
 export async function load() {
   if (browser) {
     let lang: string;

--- a/src/routes/embed/+layout.ts
+++ b/src/routes/embed/+layout.ts
@@ -1,1 +1,1 @@
-export const ssr = true;
+export const trailingSlash = "always";


### PR DESCRIPTION
See if this solves #1006 

My theory is that requests to missing assets are being caught by the flat page route, which tries to normalize to a trailing slash. This will still trigger one function call with a 404, but not two -- a redirect and then a 404.

We may be able to further optimize this by using a more specific flat page route.