### PR TITLE
Detect iframes

### DIFF
--- a/src/lib/components/onboarding/GuidedTour.svelte
+++ b/src/lib/components/onboarding/GuidedTour.svelte
@@ -61,6 +61,7 @@
 </script>
 
 <script lang="ts">
+  import { afterNavigate } from "$app/navigation";
   import { onMount } from "svelte";
   import { getCurrentUser } from "$lib/utils/permissions";
 
@@ -84,6 +85,11 @@
         startTour();
       }
     }
+  });
+
+  afterNavigate(() => {
+    // if we navigate anywhere else, end the tour
+    endTour();
   });
 </script>
 

--- a/src/routes/(app)/documents/[id]-[slug]/+page.server.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.server.ts
@@ -4,12 +4,21 @@ import type { Access, Document, Note } from "$lib/api/types";
 import { fail } from "@sveltejs/kit";
 import { setFlash, redirect } from "sveltekit-flash-message/server";
 
-import { CSRF_COOKIE_NAME } from "@/config/config.js";
+import { CSRF_COOKIE_NAME, EMBED_URL } from "@/config/config.js";
 import { destroy, edit, redact } from "$lib/api/documents";
 import * as notes from "$lib/api/notes";
 import { isErrorCode } from "$lib/utils/api";
 
-export function load({ cookies }) {
+export function load({ cookies, request, url }) {
+  const inIframe = request.headers.get("Sec-Fetch-Dest") === "iframe";
+  if (inIframe) {
+    const embed = new URL(url);
+
+    embed.host = new URL(EMBED_URL).host;
+    embed.searchParams.set("embed", "1");
+    return redirect(307, embed);
+  }
+
   const csrf_token = cookies.get(CSRF_COOKIE_NAME);
 
   return { csrf_token };

--- a/src/routes/(app)/documents/[id]-[slug]/+page.svelte
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.svelte
@@ -3,10 +3,11 @@
  -->
 
 <script lang="ts">
-  import "@/style/kit.css";
-
   import { browser } from "$app/environment";
+  import { goto } from "$app/navigation";
+  import { page } from "$app/stores";
 
+  import { onMount } from "svelte";
   import { embedUrl } from "$lib/api/embed";
   import * as documents from "$lib/api/documents";
 
@@ -26,6 +27,15 @@
 
   $: action = data.action;
   $: hasDescription = Boolean(document.description?.trim().length);
+
+  onMount(() => {
+    // if we're in an iframe, redirect to the embed route
+    const inIframe = window.self !== window.top;
+    if (inIframe) {
+      const embedUrl = documents.embedUrl(document, $page.url.searchParams);
+      goto(embedUrl);
+    }
+  });
 </script>
 
 <svelte:head>

--- a/src/routes/(app)/documents/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.ts
@@ -20,6 +20,7 @@ export async function load({
   depends,
   url,
   setHeaders,
+  data,
 }) {
   const { document, asset_url, mode } = await loadDocument({
     fetch,
@@ -55,6 +56,7 @@ export async function load({
   }
 
   return {
+    ...data,
     document,
     mode,
     asset_url,

--- a/src/routes/embed/+layout.ts
+++ b/src/routes/embed/+layout.ts
@@ -1,1 +1,1 @@
-export const trailingSlash = "always";
+export const trailingSlash = "ignore";


### PR DESCRIPTION
- **Detect iframe in doc viewer and goto embed**
- **Check for Sec-Fetch-Dest header and redirect if we see it**
- **Ignore trailing slashes on embeds**

When I tested locally, iframes aren't sending the `Sec-Fetch-Dest` header in Chrome, but setting it with `curl` triggers the correct redirect. Firefox is setting that header and it works as expected, so that's something.

Closes #1008 