### PR TITLE
Don't just catch everything as a flat page

### DIFF
--- a/src/routes/(pages)/about/+page.svelte
+++ b/src/routes/(pages)/about/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Flatpage from "@/lib/components/layouts/Flatpage.svelte";
+  import Flatpage from "$lib/components/layouts/Flatpage.svelte";
 
   export let data;
 

--- a/src/routes/(pages)/about/+page.ts
+++ b/src/routes/(pages)/about/+page.ts
@@ -1,13 +1,14 @@
-// load data for flatpages
 import { error } from "@sveltejs/kit";
 
 import { PAGE_MAX_AGE } from "@/config/config.js";
 import * as flatpages from "$lib/api/flatpages";
 
-export const trailingSlash = "ignore";
+export const trailingSlash = "always";
 
-export async function load({ fetch, params, setHeaders }) {
-  const { data, error: err } = await flatpages.get(params.path, fetch);
+const path = "/about/";
+
+export async function load({ fetch, setHeaders }) {
+  const { data, error: err } = await flatpages.get(path, fetch);
 
   if (err) {
     return error(err.status, { message: err.message });

--- a/src/routes/(pages)/help/[...path]/+page.svelte
+++ b/src/routes/(pages)/help/[...path]/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import Flatpage from "$lib/components/layouts/Flatpage.svelte";
+
+  export let data;
+
+  $: title = data.title;
+  $: content = data.content;
+</script>
+
+<svelte:head>
+  <title>{title} | DocumentCloud</title>
+</svelte:head>
+
+<Flatpage {content} />

--- a/src/routes/(pages)/help/[...path]/+page.ts
+++ b/src/routes/(pages)/help/[...path]/+page.ts
@@ -1,0 +1,26 @@
+// load data for flatpages
+import { error } from "@sveltejs/kit";
+
+import { PAGE_MAX_AGE } from "@/config/config.js";
+import * as flatpages from "$lib/api/flatpages";
+
+export const trailingSlash = "always";
+
+export async function load({ fetch, params, setHeaders }) {
+  const path = ["help", ...params.path.split("/")].join("/");
+  const { data, error: err } = await flatpages.get(path, fetch);
+
+  if (err) {
+    return error(err.status, { message: err.message });
+  }
+
+  if (!data) {
+    return error(404, "Page not found");
+  }
+
+  setHeaders({
+    "cache-control": `public, max-age=${PAGE_MAX_AGE}`,
+  });
+
+  return data;
+}


### PR DESCRIPTION
Lots of missing assets are being served as flatpage 404s instead of letting Netlify serve a plain text 404. This narrows the route matching to avoid that.

The only flat pages outside of `/help/` are `/home/` and `/about/`, so there's a dedicated route for each of those now.