### PR TITLE
Set window.location instead of using goto

### DIFF
--- a/src/routes/(app)/documents/[id]-[slug]/+page.svelte
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.svelte
@@ -33,7 +33,7 @@
     const inIframe = window.self !== window.top;
     if (inIframe) {
       const embedUrl = documents.embedUrl(document, $page.url.searchParams);
-      goto(embedUrl);
+      window.location.href = embedUrl.href;
     }
   });
 </script>


### PR DESCRIPTION
Since `embed.documentcloud.org` is technically an external domain.