### PR TITLE
Embeds only start with /projects or /documents

### DIFF
--- a/src/lib/utils/embed.ts
+++ b/src/lib/utils/embed.ts
@@ -287,6 +287,7 @@ export const settingsConfig: Record<keyof EmbedSettings, EmbedSettingConfig> = {
  * @param url
  */
 export function isEmbed(url: URL): Boolean {
+  if (!url.pathname.match(/^\/(documents|projects)/)) return false;
   return (
     url.searchParams.has("embed") || url.hostname === "embed.documentcloud.org"
   );

--- a/src/lib/utils/tests/embed.test.ts
+++ b/src/lib/utils/tests/embed.test.ts
@@ -55,6 +55,10 @@ describe("embed utilities", () => {
         "https://www.documentcloud.org/documents/2622-agreement-between-conservatives-and-liberal-democrats-to-form-a-coalition-government/?embed",
         true,
       ],
+      [
+        "https://embed.documentcloud.org/_app/immutable/chunks/navigation.CziXxwWJ.js",
+        false,
+      ],
     ];
 
     for (const [url, embed] of urls) {


### PR DESCRIPTION
SvelteKit is serving 404 pages to missing static files and other things that it shouldn't. This should save us some bandwidth, at least.

Example: https://embed.documentcloud.org/_app/immutable/chunks/navigation.CziXxwWJ.js (may need a hard refresh if your browser cached it).
