### PR TITLE
Adds a helpful message on 404 pages if the user is signed out

### DIFF
--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -220,7 +220,8 @@
     "retry": "Please try again."
   },
   "error": {
-    "report": "Report a problem"
+    "report": "Report a problem",
+    "signIn": "To access private content, <a href=\"{href}\">sign in first</a>."
   },
   "noDocuments": {
     "noSearchResults": "No search results",

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -220,6 +220,7 @@
     "retry": "Please try again."
   },
   "error": {
+    "error": "Error",
     "report": "Report a problem",
     "signIn": "To access private content, <a href=\"{href}\">sign in first</a>."
   },

--- a/src/lib/components/layouts/Error.svelte
+++ b/src/lib/components/layouts/Error.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
+  import { page } from "$app/stores";
 
   import Button from "../common/Button.svelte";
   import Error from "../common/Error.svelte";
@@ -8,10 +9,13 @@
   import UserFeedback from "../forms/UserFeedback.svelte";
 
   import { getCurrentUser } from "$lib/utils/permissions";
+  import { APP_URL, SIGN_IN_URL } from "@/config/config";
 
   const me = getCurrentUser();
 
   let feedbackOpen = false;
+
+  $: sign_in_url = new URL(`?next=${APP_URL}`, SIGN_IN_URL);
 </script>
 
 <div class="container">
@@ -24,6 +28,12 @@
     <slot name="message" />
   </Error>
   <slot />
+  {#if $page.status === 404 && !me}
+    <p class="signInMessage">
+      To access private content,
+      <a href={sign_in_url.href}>sign in first</a>.
+    </p>
+  {/if}
   <Button
     ghost
     size="small"
@@ -60,5 +70,10 @@
   .status-code {
     font-size: var(--font-xl);
     font-weight: var(--font-semibold);
+  }
+  .signInMessage {
+    margin: 0;
+    font-size: var(--font-sm);
+    color: var(--gray-5);
   }
 </style>

--- a/src/lib/components/layouts/Error.svelte
+++ b/src/lib/components/layouts/Error.svelte
@@ -30,8 +30,7 @@
   <slot />
   {#if $page.status === 404 && !me}
     <p class="signInMessage">
-      To access private content,
-      <a href={sign_in_url.href}>sign in first</a>.
+      {@html $_("error.signIn", { values: { href: sign_in_url.href } })}
     </p>
   {/if}
   <Button

--- a/src/lib/components/layouts/Error.svelte
+++ b/src/lib/components/layouts/Error.svelte
@@ -9,13 +9,13 @@
   import UserFeedback from "../forms/UserFeedback.svelte";
 
   import { getCurrentUser } from "$lib/utils/permissions";
-  import { APP_URL, SIGN_IN_URL } from "@/config/config";
+  import { SIGN_IN_URL } from "@/config/config";
 
   const me = getCurrentUser();
 
   let feedbackOpen = false;
 
-  $: sign_in_url = new URL(`?next=${APP_URL}`, SIGN_IN_URL);
+  $: sign_in_url = new URL(`?next=${$page.url.href}`, SIGN_IN_URL);
 </script>
 
 <div class="container">

--- a/src/lib/components/layouts/Error.svelte
+++ b/src/lib/components/layouts/Error.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
-  import { page } from "$app/stores";
 
   import Button from "../common/Button.svelte";
   import Error from "../common/Error.svelte";
@@ -9,13 +8,10 @@
   import UserFeedback from "../forms/UserFeedback.svelte";
 
   import { getCurrentUser } from "$lib/utils/permissions";
-  import { SIGN_IN_URL } from "@/config/config";
 
   const me = getCurrentUser();
 
   let feedbackOpen = false;
-
-  $: sign_in_url = new URL(`?next=${$page.url.href}`, SIGN_IN_URL);
 </script>
 
 <div class="container">
@@ -28,11 +24,6 @@
     <slot name="message" />
   </Error>
   <slot />
-  {#if $page.status === 404 && !me}
-    <p class="signInMessage">
-      {@html $_("error.signIn", { values: { href: sign_in_url.href } })}
-    </p>
-  {/if}
   <Button
     ghost
     size="small"

--- a/src/lib/components/layouts/Error.svelte
+++ b/src/lib/components/layouts/Error.svelte
@@ -26,6 +26,7 @@
     {#if status}
       <h1 class="status-code">
         {status}
+        {$_("error.error")}
       </h1>
     {/if}
     <slot name="message" />

--- a/src/lib/components/layouts/Error.svelte
+++ b/src/lib/components/layouts/Error.svelte
@@ -20,7 +20,10 @@
 
   let feedbackOpen = false;
 
-  $: sign_in_url = new URL(`?next=${$page.url.href}`, SIGN_IN_URL);
+  $: sign_in_url = new URL(
+    `?next=${encodeURIComponent($page.url.href)}`,
+    SIGN_IN_URL,
+  );
 </script>
 
 <div class="container">

--- a/src/lib/components/layouts/Error.svelte
+++ b/src/lib/components/layouts/Error.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+  import type { Maybe } from "$lib/api/types";
+
+  import { page } from "$app/stores";
+
   import { _ } from "svelte-i18n";
 
   import Button from "../common/Button.svelte";
@@ -7,10 +11,8 @@
   import Portal from "./Portal.svelte";
   import UserFeedback from "../forms/UserFeedback.svelte";
 
-  import { page } from "$app/stores";
-  import type { Maybe } from "$lib/api/types";
   import { getCurrentUser } from "$lib/utils/permissions";
-  import { SIGN_IN_URL } from "@/config/config";
+  import { SIGN_IN_URL } from "@/config/config.js";
 
   const me = getCurrentUser();
 
@@ -32,7 +34,7 @@
     <slot name="message" />
   </Error>
   <slot />
-  {#if status === 404 && !me}
+  {#if status === 404 && !$me}
     <p class="signInMessage">
       {@html $_("error.signIn", { values: { href: sign_in_url.href } })}
     </p>

--- a/src/lib/components/layouts/Error.svelte
+++ b/src/lib/components/layouts/Error.svelte
@@ -7,23 +7,35 @@
   import Portal from "./Portal.svelte";
   import UserFeedback from "../forms/UserFeedback.svelte";
 
+  import { page } from "$app/stores";
+  import type { Maybe } from "$lib/api/types";
   import { getCurrentUser } from "$lib/utils/permissions";
+  import { SIGN_IN_URL } from "@/config/config";
 
   const me = getCurrentUser();
 
+  export let status: Maybe<number> = undefined;
+
   let feedbackOpen = false;
+
+  $: sign_in_url = new URL(`?next=${$page.url.href}`, SIGN_IN_URL);
 </script>
 
 <div class="container">
   <Error>
-    {#if $$slots.status}
-      <div class="status-code">
-        <slot name="status" />
-      </div>
+    {#if status}
+      <h1 class="status-code">
+        {status}
+      </h1>
     {/if}
     <slot name="message" />
   </Error>
   <slot />
+  {#if status === 404 && !me}
+    <p class="signInMessage">
+      {@html $_("error.signIn", { values: { href: sign_in_url.href } })}
+    </p>
+  {/if}
   <Button
     ghost
     size="small"

--- a/src/lib/components/layouts/stories/Error.stories.svelte
+++ b/src/lib/components/layouts/stories/Error.stories.svelte
@@ -1,13 +1,17 @@
 <script context="module" lang="ts">
   import { Story } from "@storybook/addon-svelte-csf";
   import Error from "../Error.svelte";
-  import Button from "../../common/Button.svelte";
 
   export const meta = {
     title: "Layout / Error",
     component: Error,
     parameters: { layout: "fullscreen" },
   };
+</script>
+
+<script lang="ts">
+  import { setContext } from "svelte";
+  setContext("me", null);
 </script>
 
 <Story name="With Message">
@@ -19,12 +23,22 @@
   </div>
 </Story>
 
-<Story name="With Action">
+<Story
+  name="With Action"
+  parameters={{
+    sveltekit_experimental: {
+      stores: {
+        page: {
+          status: 404,
+        },
+      },
+    },
+  }}
+>
   <div class="vh-100">
     <Error>
       <p slot="status">404 Error</p>
       <p slot="message">Page not found</p>
-      <Button mode="primary">Go home</Button>
     </Error>
   </div>
 </Story>

--- a/src/lib/components/layouts/stories/Error.stories.svelte
+++ b/src/lib/components/layouts/stories/Error.stories.svelte
@@ -9,7 +9,7 @@
   };
 </script>
 
-<Story name="500 Error">
+<Story name="Error 500">
   <div class="vh-100">
     <Error>
       <p slot="status">500 Error</p>
@@ -18,7 +18,7 @@
   </div>
 </Story>
 
-<Story name="404 Error">
+<Story name="Error 404">
   <div class="vh-100">
     <Error>
       <p slot="status">404 Error</p>

--- a/src/lib/components/layouts/stories/Error.stories.svelte
+++ b/src/lib/components/layouts/stories/Error.stories.svelte
@@ -29,6 +29,7 @@
     sveltekit_experimental: {
       stores: {
         page: {
+          url: new URL("http://localhost:3000/missing-page"),
           status: 404,
         },
       },

--- a/src/lib/components/layouts/stories/Error.stories.svelte
+++ b/src/lib/components/layouts/stories/Error.stories.svelte
@@ -9,12 +9,7 @@
   };
 </script>
 
-<script lang="ts">
-  import { setContext } from "svelte";
-  setContext("me", null);
-</script>
-
-<Story name="With Message">
+<Story name="500 Error">
   <div class="vh-100">
     <Error>
       <p slot="status">500 Error</p>
@@ -23,19 +18,7 @@
   </div>
 </Story>
 
-<Story
-  name="With Action"
-  parameters={{
-    sveltekit_experimental: {
-      stores: {
-        page: {
-          url: new URL("http://localhost:3000/missing-page"),
-          status: 404,
-        },
-      },
-    },
-  }}
->
+<Story name="404 Error">
   <div class="vh-100">
     <Error>
       <p slot="status">404 Error</p>

--- a/src/lib/components/layouts/stories/Error.stories.svelte
+++ b/src/lib/components/layouts/stories/Error.stories.svelte
@@ -11,8 +11,7 @@
 
 <Story name="Error 500">
   <div class="vh-100">
-    <Error>
-      <p slot="status">500 Error</p>
+    <Error status={500}>
       <p slot="message">Something broke on our end!</p>
     </Error>
   </div>
@@ -20,8 +19,7 @@
 
 <Story name="Error 404">
   <div class="vh-100">
-    <Error>
-      <p slot="status">404 Error</p>
+    <Error status={404}>
       <p slot="message">Page not found</p>
     </Error>
   </div>

--- a/src/routes/(app)/+error.svelte
+++ b/src/routes/(app)/+error.svelte
@@ -4,11 +4,7 @@
   import Error from "$lib/components/layouts/Error.svelte";
 </script>
 
-<Error>
-  <h1 slot="status">
-    {$page.status}
-  </h1>
-
+<Error status={$page.status}>
   <p slot="message">
     {#if $page.status === 404}
       {$_("notfound.content")}

--- a/src/routes/(app)/add-ons/+error.svelte
+++ b/src/routes/(app)/add-ons/+error.svelte
@@ -4,11 +4,7 @@
   import Error from "$lib/components/layouts/Error.svelte";
 </script>
 
-<Error>
-  <h1 slot="status">
-    {$page.status}
-  </h1>
-
+<Error status={$page.status}>
   <p slot="message">
     {#if $page.status === 404}
       {$_("notfound.content")}

--- a/src/routes/(app)/add-ons/[owner]/[repo]/+error.svelte
+++ b/src/routes/(app)/add-ons/[owner]/[repo]/+error.svelte
@@ -4,11 +4,7 @@
   import Error from "$lib/components/layouts/Error.svelte";
 </script>
 
-<Error>
-  <h1 slot="status">
-    {$page.status}
-  </h1>
-
+<Error status={$page.status}>
   <p slot="message">
     {#if $page.status === 404}
       {$_("notfound.content")}

--- a/src/routes/(app)/documents/+error.svelte
+++ b/src/routes/(app)/documents/+error.svelte
@@ -2,35 +2,14 @@
   import { page } from "$app/stores";
   import { _ } from "svelte-i18n";
   import Error from "$lib/components/layouts/Error.svelte";
-  import { getCurrentUser } from "@/lib/utils/permissions";
-  import { SIGN_IN_URL } from "@/config/config";
-
-  const me = getCurrentUser();
-
-  $: sign_in_url = new URL(`?next=${$page.url.href}`, SIGN_IN_URL);
 </script>
 
-<Error>
-  <h1 slot="status">
-    {$page.status}
-  </h1>
-
-  <div slot="message">
+<Error status={$page.status}>
+  <p slot="message">
     {#if $page.status === 404}
-      <p>{$_("notfound.content")}</p>
-      {#if !me}
-        <p class="signInMessage">
-          {@html $_("error.signIn", { values: { href: sign_in_url.href } })}
-        </p>
-      {/if}
+      {$_("notfound.content")}
     {:else}
-      <p>{$page.error?.message}</p>
+      {$page.error?.message}
     {/if}
-  </div>
+  </p>
 </Error>
-
-<style>
-  .signInMessage {
-    margin: 1rem 0;
-  }
-</style>

--- a/src/routes/(app)/documents/+error.svelte
+++ b/src/routes/(app)/documents/+error.svelte
@@ -2,6 +2,12 @@
   import { page } from "$app/stores";
   import { _ } from "svelte-i18n";
   import Error from "$lib/components/layouts/Error.svelte";
+  import { getCurrentUser } from "@/lib/utils/permissions";
+  import { SIGN_IN_URL } from "@/config/config";
+
+  const me = getCurrentUser();
+
+  $: sign_in_url = new URL(`?next=${$page.url.href}`, SIGN_IN_URL);
 </script>
 
 <Error>
@@ -9,11 +15,22 @@
     {$page.status}
   </h1>
 
-  <p slot="message">
+  <div slot="message">
     {#if $page.status === 404}
-      {$_("notfound.content")}
+      <p>{$_("notfound.content")}</p>
+      {#if !me}
+        <p class="signInMessage">
+          {@html $_("error.signIn", { values: { href: sign_in_url.href } })}
+        </p>
+      {/if}
     {:else}
-      {$page.error?.message}
+      <p>{$page.error?.message}</p>
     {/if}
-  </p>
+  </div>
 </Error>
+
+<style>
+  .signInMessage {
+    margin: 1rem 0;
+  }
+</style>

--- a/src/routes/(app)/documents/[id]-[slug]/+error.svelte
+++ b/src/routes/(app)/documents/[id]-[slug]/+error.svelte
@@ -4,11 +4,7 @@
   import Error from "$lib/components/layouts/Error.svelte";
 </script>
 
-<Error>
-  <h1 slot="status">
-    {$page.status}
-  </h1>
-
+<Error status={$page.status}>
   <p slot="message">
     {#if $page.status === 404}
       {$_("notfound.content")}

--- a/src/routes/(app)/projects/+error.svelte
+++ b/src/routes/(app)/projects/+error.svelte
@@ -2,35 +2,14 @@
   import { page } from "$app/stores";
   import { _ } from "svelte-i18n";
   import Error from "$lib/components/layouts/Error.svelte";
-  import { getCurrentUser } from "@/lib/utils/permissions";
-  import { SIGN_IN_URL } from "@/config/config";
-
-  const me = getCurrentUser();
-
-  $: sign_in_url = new URL(`?next=${$page.url.href}`, SIGN_IN_URL);
 </script>
 
-<Error>
-  <h1 slot="status">
-    {$page.status}
-  </h1>
-
-  <div slot="message">
+<Error status={$page.status}>
+  <p slot="message">
     {#if $page.status === 404}
-      <p>{$_("notfound.content")}</p>
-      {#if !me}
-        <p class="signInMessage">
-          {@html $_("error.signIn", { values: { href: sign_in_url.href } })}
-        </p>
-      {/if}
+      {$_("notfound.content")}
     {:else}
-      <p>{$page.error?.message}</p>
+      {$page.error?.message}
     {/if}
-  </div>
+  </p>
 </Error>
-
-<style>
-  .signInMessage {
-    margin: 1rem 0;
-  }
-</style>

--- a/src/routes/(app)/projects/+error.svelte
+++ b/src/routes/(app)/projects/+error.svelte
@@ -2,6 +2,12 @@
   import { page } from "$app/stores";
   import { _ } from "svelte-i18n";
   import Error from "$lib/components/layouts/Error.svelte";
+  import { getCurrentUser } from "@/lib/utils/permissions";
+  import { SIGN_IN_URL } from "@/config/config";
+
+  const me = getCurrentUser();
+
+  $: sign_in_url = new URL(`?next=${$page.url.href}`, SIGN_IN_URL);
 </script>
 
 <Error>
@@ -9,11 +15,22 @@
     {$page.status}
   </h1>
 
-  <p slot="message">
+  <div slot="message">
     {#if $page.status === 404}
-      {$_("notfound.content")}
+      <p>{$_("notfound.content")}</p>
+      {#if !me}
+        <p class="signInMessage">
+          {@html $_("error.signIn", { values: { href: sign_in_url.href } })}
+        </p>
+      {/if}
     {:else}
-      {$page.error?.message}
+      <p>{$page.error?.message}</p>
     {/if}
-  </p>
+  </div>
 </Error>
+
+<style>
+  .signInMessage {
+    margin: 1rem 0;
+  }
+</style>

--- a/src/routes/(app)/projects/[id]-[slug]/+error.svelte
+++ b/src/routes/(app)/projects/[id]-[slug]/+error.svelte
@@ -4,11 +4,7 @@
   import Error from "$lib/components/layouts/Error.svelte";
 </script>
 
-<Error>
-  <h1 slot="status">
-    {$page.status}
-  </h1>
-
+<Error status={$page.status}>
   <p slot="message">
     {#if $page.status === 404}
       {$_("notfound.content")}

--- a/src/routes/(app)/upload/+error.svelte
+++ b/src/routes/(app)/upload/+error.svelte
@@ -4,11 +4,7 @@
   import Error from "$lib/components/layouts/Error.svelte";
 </script>
 
-<Error>
-  <h1 slot="status">
-    {$page.status}
-  </h1>
-
+<Error status={$page.status}>
   <p slot="message">
     {#if $page.status === 404}
       {$_("notfound.content")}

--- a/src/routes/(pages)/+error.svelte
+++ b/src/routes/(pages)/+error.svelte
@@ -4,11 +4,7 @@
   import Error from "$lib/components/layouts/Error.svelte";
 </script>
 
-<Error>
-  <h1 slot="status">
-    {$page.status}
-  </h1>
-
+<Error status={$page.status}>
   <p slot="message">
     {#if $page.status === 404}
       {$_("notfound.content")}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -2,35 +2,14 @@
   import { page } from "$app/stores";
   import { _ } from "svelte-i18n";
   import Error from "$lib/components/layouts/Error.svelte";
-  import { getCurrentUser } from "@/lib/utils/permissions";
-  import { SIGN_IN_URL } from "@/config/config";
-
-  const me = getCurrentUser();
-
-  $: sign_in_url = new URL(`?next=${$page.url.href}`, SIGN_IN_URL);
 </script>
 
-<Error>
-  <h1 slot="status">
-    {$page.status}
-  </h1>
-
-  <div slot="message">
+<Error status={$page.status}>
+  <p slot="message">
     {#if $page.status === 404}
-      <p>{$_("notfound.content")}</p>
-      {#if !me}
-        <p class="signInMessage">
-          {@html $_("error.signIn", { values: { href: sign_in_url.href } })}
-        </p>
-      {/if}
+      {$_("notfound.content")}
     {:else}
-      <p>{$page.error?.message}</p>
+      {$page.error?.message}
     {/if}
-  </div>
+  </p>
 </Error>
-
-<style>
-  .signInMessage {
-    margin: 1rem 0;
-  }
-</style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -28,3 +28,9 @@
     {/if}
   </div>
 </Error>
+
+<style>
+  .signInMessage {
+    margin: 1rem 0;
+  }
+</style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -2,6 +2,12 @@
   import { page } from "$app/stores";
   import { _ } from "svelte-i18n";
   import Error from "$lib/components/layouts/Error.svelte";
+  import { getCurrentUser } from "@/lib/utils/permissions";
+  import { SIGN_IN_URL } from "@/config/config";
+
+  const me = getCurrentUser();
+
+  $: sign_in_url = new URL(`?next=${$page.url.href}`, SIGN_IN_URL);
 </script>
 
 <Error>
@@ -9,11 +15,16 @@
     {$page.status}
   </h1>
 
-  <p slot="message">
+  <div slot="message">
     {#if $page.status === 404}
-      {$_("notfound.content")}
+      <p>{$_("notfound.content")}</p>
+      {#if !me}
+        <p class="signInMessage">
+          {@html $_("error.signIn", { values: { href: sign_in_url.href } })}
+        </p>
+      {/if}
     {:else}
-      {$page.error?.message}
+      <p>{$page.error?.message}</p>
     {/if}
-  </p>
+  </div>
 </Error>


### PR DESCRIPTION
When a user hits a 404 page, they may not know whether they're signed in or not. This can be problematic on private documents. Here, we check the status and the session, prompting the user to sign in if they're not already authenticated.