### PR TITLE
Run local dev server against staging API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ static/viewer/*
 playwright-report
 test-results
 coverage
+certs
 
 # local fixtures, everyone should generate their own
 tests/fixtures/development.json

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The main frontend for DocumentCloud, written in [SvelteKit](https://kit.svelte.d
 
 ## Usage
 
-This project depends on both [Squarelet](https://github.com/muckrock/squarelet) and the [DocumentCloud (Django)](https://github.com/muckrock/documentcloud). Follow the steps in their READMEs before setting up this project.
+### Local Stack
+
+It's possible to run all the dependencies for this project completely locally, as long as you already have both [Squarelet](https://github.com/muckrock/squarelet) and the [DocumentCloud (Django)](https://github.com/muckrock/documentcloud) running in Docker containers. Follow the steps in their READMEs before setting up this project.
 
 In order to install dependencies inside the Docker container and on your host machine, run:
 
@@ -27,6 +29,30 @@ echo "127.0.0.1 www.dev.documentcloud.org" | sudo tee -a /etc/hosts
 ```
 
 Once everything is up and running, you should be able to see the website live at [www.dev.documentcloud.org](http://www.dev.documentcloud.org/).
+
+### Remote Stack
+
+It's possible to run the frontend against the staging API, instead of a locally running API server, providing a lightweight solution for local development. The frontend needs to run on a custom localhost, `https://local.muckcloud.com`, and is exposed on the standard `5173` port used by Vite dev servers.
+
+To run the dev server locally against the staging API, take the following steps:
+
+1. Update your hosts file
+    ```bash
+    echo "127.0.0.1 local.muckcloud.com" | sudo tee -a /etc/hosts
+    ```
+2. Make a local certificate in a `certs` directory
+    ```bash
+    mkdir certs && cd certs
+    mkcert -install
+    mkcert local.muckcloud.com
+    ```
+3. Use NPM to install and run the `dev:remote` script
+    ```bash
+    npm install
+    npm run dev:remote
+    ```
+
+Now, you should have a dev server accessible at `https://local.muckcloud.com:5173` that connects to the staging DocumentCloud API (https://api.muckcloud.com) and staging authentication service (https://squarelet-staging.herokuapp.com).
 
 ## Building for production
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "scripts": {
     "dev": "NODE_ENV=development vite dev",
+    "dev:remote": "NODE_ENV=staging vite dev",
     "build": "vite build && node embeds.js",
     "preview": "vite preview",
     "sync": "svelte-kit sync",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "scripts": {
     "dev": "NODE_ENV=development vite dev",
-    "dev:remote": "NODE_ENV=staging vite dev",
+    "dev:remote": "NODE_ENV=remote vite dev",
     "build": "vite build && node embeds.js",
     "preview": "vite preview",
     "sync": "svelte-kit sync",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "scripts": {
     "dev": "NODE_ENV=development vite dev",
-    "dev:remote": "NODE_ENV=remote vite dev",
+    "dev:remote": "NODE_ENV=remote vite dev --host local.muckcloud.com",
     "build": "vite build && node embeds.js",
     "preview": "vite preview",
     "sync": "svelte-kit sync",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,3 +1,4 @@
+import * as remote from "./remote.js";
 import * as staging from "./staging.js";
 import * as production from "./production.js";
 
@@ -10,6 +11,14 @@ let EMBED_URL = "https://www.dev.documentcloud.org/";
 let SQUARELET_BASE = "https://dev.squarelet.com";
 let STAFF_ONLY_S3_URL =
   "http://minio.documentcloud.org:9000/minio/documents/documents/$$ID$$/";
+
+if (process.env.NODE_ENV === "remote") {
+  DC_BASE = remote.DC_BASE;
+  APP_URL = remote.APP_URL;
+  EMBED_URL = remote.EMBED_URL;
+  SQUARELET_BASE = remote.SQUARELET_BASE;
+  STAFF_ONLY_S3_URL = remote.STAFF_ONLY_S3_URL;
+}
 
 if (process.env.NODE_ENV === "staging") {
   DC_BASE = staging.DC_BASE;

--- a/src/config/remote.js
+++ b/src/config/remote.js
@@ -1,0 +1,6 @@
+export const DC_BASE = "https://api.muckcloud.com";
+export const APP_URL = "https://local.muckcloud.com:5173";
+export const EMBED_URL = APP_URL;
+export const SQUARELET_BASE = "https://squarelet-staging.herokuapp.com";
+export const STAFF_ONLY_S3_URL =
+  "https://s3.console.aws.amazon.com/s3/buckets/documentcloud-staging-files?region=us-east-1&prefix=documents/$$ID$$/&showversions=false";

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,22 @@ import { defineConfig, configDefaults } from "vitest/config";
 const __filename = url.fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const localServer = {
+  host: "0.0.0.0",
+  port: process.env.DOCKER ? 80 : 5173,
+  origin: "https://www.dev.documentcloud.org",
+};
+
+const remoteServer = {
+  host: "0.0.0.0",
+  port: 5173,
+  origin: "https://local.muckcloud.com:5173",
+  https: {
+    key: path.resolve(__dirname, "certs/local.muckcloud.com-key.pem"),
+    cert: path.resolve(__dirname, "certs/local.muckcloud.com.pem"),
+  },
+};
+
 export default defineConfig({
   build: {
     sourcemap: true,
@@ -46,11 +62,7 @@ export default defineConfig({
     },
   },
 
-  server: {
-    host: "0.0.0.0",
-    port: process.env.DOCKER ? 80 : 5173,
-    origin: "https://www.dev.documentcloud.org",
-  },
+  server: process.env.NODE_ENV === "remote" ? remoteServer : localServer,
 
   test: {
     setupFiles: ["./vitest-setup.js"],

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,6 +24,21 @@ const remoteServer = {
   },
 };
 
+const plugins =
+  process.env.NODE_ENV === "remote"
+    ? [sveltekit()]
+    : [
+        sentrySvelteKit({
+          sourceMapsUploadOptions: {
+            org: process.env.SENTRY_ORG,
+            project:
+              process.env.SENTRY_PROJECT ?? "documentcloud-frontend-staging",
+            authToken: process.env.SENTRY_AUTH_TOKEN,
+          },
+        }),
+        sveltekit(),
+      ];
+
 export default defineConfig({
   build: {
     sourcemap: true,
@@ -37,16 +52,7 @@ export default defineConfig({
     ),
   },
 
-  plugins: [
-    sentrySvelteKit({
-      sourceMapsUploadOptions: {
-        org: process.env.SENTRY_ORG,
-        project: process.env.SENTRY_PROJECT ?? "documentcloud-frontend-staging",
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-      },
-    }),
-    sveltekit(),
-  ],
+  plugins,
 
   // allow top-level await
   optimizeDeps: {


### PR DESCRIPTION
Closes #677

Adds a new `npm run dev:remote` command that runs the Vite dev server against our staging APIs for DocumentCloud and Squarelet. This removes the dependency on a local stack to do frontend development.

The steps required for setup are detailed in the README. This approach leverages our support for Netlify Deploy Previews by aliasing localhost as another `*.muckcloud.com` subdomain.


