### PR TITLE
Add plausible to flat pages

### DIFF
--- a/src/lib/components/common/PlausibleTracker.svelte
+++ b/src/lib/components/common/PlausibleTracker.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  import Plausible from "plausible-tracker";
-
-  import { getContext, onMount } from "svelte";
   import type { Writable } from "svelte/store";
-  import { afterNavigate } from "$app/navigation";
+
   import { browser } from "$app/environment";
+  import { afterNavigate } from "$app/navigation";
+
+  import Plausible from "plausible-tracker";
+  import { getContext, onMount } from "svelte";
+
   import { getCurrentUser } from "$lib/utils/permissions";
 
   let plausible;

--- a/src/routes/(pages)/help/[...path]/+page.svelte
+++ b/src/routes/(pages)/help/[...path]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Flatpage from "$lib/components/layouts/Flatpage.svelte";
+  import PlausibleTracker from "$lib/components/common/PlausibleTracker.svelte";
 
   export let data;
 
@@ -11,4 +12,6 @@
   <title>{title} | DocumentCloud</title>
 </svelte:head>
 
-<Flatpage {content} />
+<PlausibleTracker>
+  <Flatpage {content} />
+</PlausibleTracker>

--- a/src/routes/(pages)/home/+page.svelte
+++ b/src/routes/(pages)/home/+page.svelte
@@ -4,6 +4,7 @@
 
   import Button from "$lib/components/common/Button.svelte";
   import Logo from "$lib/components/common/Logo.svelte";
+  import PlausibleTracker from "$lib/components/common/PlausibleTracker.svelte";
 
   // SVG assets
 
@@ -517,6 +518,9 @@
 
   <footer />
 </div>
+
+<!-- this just needs to be on the page -->
+<PlausibleTracker />
 
 <style>
   :global(.masthead) {


### PR DESCRIPTION
Closes #1011 

For the home page, I just added the `<PlausibleTracker />` component at the bottom, since we just need it on the page and it doesn't need to wrap anything.
