### PR TITLE
Add cache busting to public asset URLs

### DIFF
--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -525,6 +525,9 @@ export async function assetUrl(
       console.warn(asset_url.href);
       return asset_url;
     });
+  } else {
+    const updated = Date.parse(document.updated_at);
+    asset_url.searchParams.set("t", updated.toString());
   }
 
   return asset_url;

--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -179,6 +179,9 @@ export async function text(
       console.warn(e);
       return empty;
     }
+  } else {
+    const updated = Date.parse(document.updated_at);
+    url.searchParams.set("t", updated.toString());
   }
 
   const resp = await fetch(url).catch(console.warn);
@@ -207,6 +210,9 @@ export async function textPositions(
       console.warn(e);
       return [];
     }
+  } else {
+    const updated = Date.parse(document.updated_at);
+    url.searchParams.set("t", updated.toString());
   }
 
   try {

--- a/src/lib/api/tests/documents.test.ts
+++ b/src/lib/api/tests/documents.test.ts
@@ -184,6 +184,9 @@ describe("document fetching", () => {
     }));
 
     const endpoint = documents.jsonUrl(document);
+    const updated = Date.parse(document.updated_at);
+
+    endpoint.searchParams.set("t", updated.toString());
 
     const t = await documents.text(document, mockFetch);
     expect(t).toMatchObject(text);
@@ -194,6 +197,7 @@ describe("document fetching", () => {
   test("documents.text private", async ({ document, text }) => {
     const { asset_url } = document;
     const privateText = new URL("private.txt.json", asset_url);
+
     const privateDoc = {
       ...document,
       access: "private",

--- a/src/lib/api/tests/documents.test.ts
+++ b/src/lib/api/tests/documents.test.ts
@@ -676,9 +676,11 @@ describe("document helper methods", () => {
     });
 
     let asset_url = await documents.assetUrl(document, mockFetch);
-
+    const updated = Date.parse(document.updated_at);
+    const public_url = documents.pdfUrl(document);
+    public_url.searchParams.set("t", updated.toString());
     // for public documents, these are the same
-    expect(asset_url).toStrictEqual(documents.pdfUrl(document));
+    expect(asset_url).toStrictEqual(public_url);
     expect(mockFetch).toBeCalledTimes(0); // didn't use it
 
     // for private documents and those still processing, the URL should be private

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -166,7 +166,7 @@ export interface Document {
   source?: string;
   status: Status;
   title: string;
-  updated_at: string | Date;
+  updated_at: string;
   user: number | User;
 
   // for uploads

--- a/src/lib/utils/pageSize.ts
+++ b/src/lib/utils/pageSize.ts
@@ -43,21 +43,27 @@ export function pageSizesFromSpec(pageSpec) {
  * Parse page_spec and return an array of [width, height] tuples
  *
  * @param {string} pageSpec A string encoding page dimensions in a compact format
+ * @example "612.0x792.0:0-427,429-431,433-447;611.9999389648438x792.0:428,432"
  * @returns {[number, number][]}
  */
-export function pageSizes(pageSpec) {
+export function pageSizes(pageSpec: string): [number, number][] {
   // Handle empty page spec
   if (pageSpec.trim().length == 0) return [];
 
   const parts = pageSpec.split(";");
 
-  return parts.reduce((sizes, part, i) => {
-    const [size, range] = part.split(":");
-    const [width, height] = size.split("x").map(parseFloat);
+  return parts.reduce((sizes, part) => {
+    const [size, ranges] = part.split(":");
+    if (!size || !ranges) return sizes;
 
-    range.split(",").forEach((rangePart) => {
+    const [width, height] = size.split("x").map(parseFloat);
+    if (!width || !height) return sizes;
+
+    ranges.split(",").forEach((rangePart) => {
       if (rangePart.includes("-")) {
         const [start, end] = rangePart.split("-").map((x) => parseInt(x, 10));
+        if (start === undefined || end === undefined) return;
+
         for (let page = start; page <= end; page++) {
           sizes[page] = [width, height];
         }


### PR DESCRIPTION
Closes #1036 

This adds a `t=<timestamp>` to text and text position asset URLs on public documents. (Private documents aren't cached the same way.)
