### PR TITLE
Limit bulk editing to 25 documents at a time, show errors

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -100,6 +100,9 @@ export const IMAGE_WIDTHS_MAP = new Map(IMAGE_WIDTHS_ENTRIES);
 export const DEFAULT_PER_PAGE = 25;
 export const MAX_PER_PAGE = 100;
 
+export const EDIT_BATCH_SIZE = 25;
+export const MAX_EDIT_BATCH = 100;
+
 export const PDF_SIZE_LIMIT = 525336576;
 export const PDF_SIZE_LIMIT_READABLE = "500 MB";
 

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -100,8 +100,8 @@ export const IMAGE_WIDTHS_MAP = new Map(IMAGE_WIDTHS_ENTRIES);
 export const DEFAULT_PER_PAGE = 25;
 export const MAX_PER_PAGE = 100;
 
-export const EDIT_BATCH_SIZE = 25;
-export const MAX_EDIT_BATCH = 100;
+// export const EDIT_BATCH_SIZE = 25; // batching isn't supported yet
+export const MAX_EDIT_BATCH = 25;
 
 export const PDF_SIZE_LIMIT = 525336576;
 export const PDF_SIZE_LIMIT_READABLE = "500 MB";

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -434,6 +434,7 @@
     },
     "nodocs": "No documents selected. Close this form and select at least one document first.",
     "many": "Editing {n, plural, one {one document} other {# documents}}. This will add the same values to all selected documents.",
+    "toomany": "Bulk editing is limited to {n} documents at a time.",
     "allowedHTML": "Limited HTML can be used for formatting. See <a target=\"_blank\" href=\"/help/api\">API documentation</a> for details.",
     "save": "Save",
     "cancel": "Cancel",

--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -50,6 +50,8 @@ export const MODES = new Set<ViewerMode>([...READING_MODES, ...WRITING_MODES]);
 // for keeping track of deleted documents that haven't been purged from search yet
 export const deleted: Writable<Set<string>> = writable(new Set());
 
+const DEFAULT_EXPAND = ["user", "organization", "projects"];
+
 /**
  * Search documents
  * https://www.documentcloud.org/help/search/
@@ -67,9 +69,7 @@ export async function search(
 ): Promise<APIResponse<DocumentResults, null>> {
   const endpoint = new URL("documents/search/", BASE_API_URL);
 
-  const expand = ["user", "organization", "projects"].join(",");
-
-  endpoint.searchParams.set("expand", expand);
+  endpoint.searchParams.set("expand", DEFAULT_EXPAND.join(","));
   endpoint.searchParams.set("q", query);
 
   for (const [k, v] of Object.entries(options)) {
@@ -423,6 +423,9 @@ export async function edit_many(
 ) {
   const endpoint = new URL("documents/", BASE_API_URL);
 
+  // return the same data we get from search
+  endpoint.searchParams.set("expand", DEFAULT_EXPAND.join(","));
+
   const resp = await fetch(endpoint, {
     credentials: "include",
     method: "PATCH",
@@ -434,7 +437,7 @@ export async function edit_many(
     body: JSON.stringify(documents),
   }).catch(console.warn);
 
-  return getApiResponse<DocumentResults>(resp);
+  return getApiResponse<DocumentResults, ValidationError>(resp);
 }
 
 /**

--- a/src/lib/api/tests/documents.test.ts
+++ b/src/lib/api/tests/documents.test.ts
@@ -537,7 +537,7 @@ describe("document write methods", () => {
     expect(error).toBeUndefined();
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL("documents/", BASE_API_URL),
+      new URL("documents/?expand=user%2Corganization%2Cprojects", BASE_API_URL),
       {
         credentials: "include",
         method: "PATCH",

--- a/src/lib/components/common/Tip.svelte
+++ b/src/lib/components/common/Tip.svelte
@@ -57,12 +57,19 @@
     border-color: var(--green-2);
     background: var(--green-1);
   }
-  .tip.danger,
-  .tip.error {
+  .tip.danger {
     color: var(--orange-5);
     fill: var(--orange-3);
     background-color: var(--orange-3);
     border-color: var(--orange-2);
     background: var(--orange-1);
+  }
+
+  .tip.error {
+    color: var(--red-5);
+    fill: var(--red-3);
+    background-color: var(--red-3);
+    border-color: var(--red-2);
+    background: var(--red-1);
   }
 </style>

--- a/src/lib/components/common/Tip.svelte
+++ b/src/lib/components/common/Tip.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { LightBulb24 } from "svelte-octicons";
 
-  export let mode: "normal" | "primary" | "premium" | "danger" = "normal";
+  export let mode: "normal" | "primary" | "premium" | "danger" | "error" =
+    "normal";
 </script>
 
 <aside class="tip {mode}">
@@ -56,7 +57,8 @@
     border-color: var(--green-2);
     background: var(--green-1);
   }
-  .tip.danger {
+  .tip.danger,
+  .tip.error {
     color: var(--orange-5);
     fill: var(--orange-3);
     background-color: var(--orange-3);

--- a/src/lib/components/common/stories/Tip.stories.svelte
+++ b/src/lib/components/common/stories/Tip.stories.svelte
@@ -1,15 +1,15 @@
 <script context="module" lang="ts">
   import { Story } from "@storybook/addon-svelte-csf";
+  import { Info24, Alert24 } from "svelte-octicons";
+
   import Tip from "../Tip.svelte";
   import Pin from "$lib/components/icons/Pin.svelte";
   import Premium from "$lib/components/icons/Premium.svelte";
-  import { Info24, Alert24 } from "svelte-octicons";
   import Flex from "../Flex.svelte";
 
   export const meta = {
     title: "Components / Common / Tip",
     component: Tip,
-    tags: ["autodocs"],
     parameters: { layout: "centered" },
   };
 
@@ -43,6 +43,10 @@
     <Tip {...args} mode="danger">
       <Alert24 slot="icon" />
       Watch out ahead!
+    </Tip>
+    <Tip {...args} mode="error">
+      <Alert24 slot="icon" />
+      Something went wrong!
     </Tip>
   </Flex>
 </Story>

--- a/src/lib/components/forms/EditMany.svelte
+++ b/src/lib/components/forms/EditMany.svelte
@@ -4,6 +4,7 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
 -->
 <script lang="ts">
   import type { Document } from "$lib/api/types";
+
   import { enhance } from "$app/forms";
 
   import { createEventDispatcher } from "svelte";
@@ -20,6 +21,8 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
   import TextArea from "../inputs/TextArea.svelte";
   import Tip from "../common/Tip.svelte";
 
+  import { MAX_EDIT_BATCH } from "@/config/config.js";
+
   export let documents: Document[];
 
   const dispatch = createEventDispatcher();
@@ -27,6 +30,7 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
   const action = "/documents/?/edit";
 
   $: ids = documents?.map((d) => d.id) ?? [];
+  $: disabled = documents.length < 1 || documents.length >= MAX_EDIT_BATCH;
 
   function onSubmit() {
     dispatch("close");
@@ -46,6 +50,15 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
       >
         <Alert24 slot="icon" />
         {$_("edit.nodocs")}
+      </Tip>
+    {:else if documents.length >= MAX_EDIT_BATCH}
+      <Tip
+        --background-color="var(--caution)"
+        --color="var(--gray-1)"
+        --fill="var(--gray-1)"
+      >
+        <Alert24 slot="icon" />
+        {$_("edit.toomany", { values: { n: MAX_EDIT_BATCH } })}
       </Tip>
     {/if}
 
@@ -84,10 +97,10 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
     <input type="hidden" name="documents" value={ids.join(",")} />
 
     <Flex class="buttons">
-      <Button type="submit" mode="primary" full disabled={documents.length < 1}>
+      <Button type="submit" mode="primary" full {disabled}>
         {$_("edit.save")}
       </Button>
-      <Button full on:click={(e) => dispatch("close")}>
+      <Button full on:click={() => dispatch("close")}>
         {$_("edit.cancel")}
       </Button>
     </Flex>

--- a/src/lib/components/forms/EditMany.svelte
+++ b/src/lib/components/forms/EditMany.svelte
@@ -30,10 +30,19 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
   const action = "/documents/?/edit";
 
   $: ids = documents?.map((d) => d.id) ?? [];
-  $: disabled = documents.length < 1 || documents.length >= MAX_EDIT_BATCH;
+  $: disabled = documents.length < 1 || documents.length > MAX_EDIT_BATCH;
 
-  function onSubmit() {
-    dispatch("close");
+  /**
+   * @type {import('@sveltejs/kit').SubmitFunction}
+   */
+  function onSubmit({ submitter }) {
+    submitter.disabled = true;
+
+    return async ({ result, update }) => {
+      submitter.disabled = false;
+      update(result);
+      dispatch("close");
+    };
   }
 </script>
 
@@ -51,7 +60,7 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
         <Alert24 slot="icon" />
         {$_("edit.nodocs")}
       </Tip>
-    {:else if documents.length >= MAX_EDIT_BATCH}
+    {:else if documents.length > MAX_EDIT_BATCH}
       <Tip
         --background-color="var(--caution)"
         --color="var(--gray-1)"

--- a/src/lib/components/forms/EditMany.svelte
+++ b/src/lib/components/forms/EditMany.svelte
@@ -3,7 +3,12 @@ Edit metadata for many documents. This touches all top-level data.
 Usually this will be rendered inside a modal, but it doesn't have to be.
 -->
 <script lang="ts">
-  import type { Document } from "$lib/api/types";
+  import type {
+    APIError,
+    Document,
+    Maybe,
+    ValidationError,
+  } from "$lib/api/types";
 
   import { enhance } from "$app/forms";
 
@@ -25,6 +30,9 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
 
   export let documents: Document[];
 
+  // exported for testing and demos
+  export let error: Maybe<APIError<ValidationError>> = undefined;
+
   const dispatch = createEventDispatcher();
 
   const action = "/documents/?/edit";
@@ -40,8 +48,15 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
 
     return async ({ result, update }) => {
       submitter.disabled = false;
-      update(result);
-      dispatch("close");
+      if (result.type === "failure") {
+        console.error(result);
+        error = result.data.error;
+      }
+
+      if (result.type === "success") {
+        update(result);
+        dispatch("close");
+      }
     };
   }
 </script>
@@ -52,22 +67,30 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
     <slot />
 
     {#if documents.length < 1}
-      <Tip
-        --background-color="var(--caution)"
-        --color="var(--gray-1)"
-        --fill="var(--gray-1)"
-      >
+      <Tip mode="error">
         <Alert24 slot="icon" />
         {$_("edit.nodocs")}
       </Tip>
     {:else if documents.length > MAX_EDIT_BATCH}
-      <Tip
-        --background-color="var(--caution)"
-        --color="var(--gray-1)"
-        --fill="var(--gray-1)"
-      >
+      <Tip mode="danger">
         <Alert24 slot="icon" />
         {$_("edit.toomany", { values: { n: MAX_EDIT_BATCH } })}
+      </Tip>
+    {/if}
+
+    {#if error}
+      <Tip mode="error">
+        <Alert24 slot="icon" />
+        <p>{error.message}</p>
+        {#if Object.keys(error.errors ?? {}).length}
+          <ul>
+            {#each Object.entries(error.errors ?? {}) as [field, errs]}
+              <li>
+                <strong>{field}</strong>: {errs.join(";")}
+              </li>
+            {/each}
+          </ul>
+        {/if}
       </Tip>
     {/if}
 

--- a/src/lib/components/forms/stories/Edit.stories.svelte
+++ b/src/lib/components/forms/stories/Edit.stories.svelte
@@ -51,3 +51,16 @@
     </EditMany>
   </div>
 </Story>
+
+<Story name="Bulk edit, too many documents">
+  <div style="min-width: 600px;">
+    <EditMany documents={Array(100).fill(document)}>
+      <header>
+        <h2>{$_("edit.title")}</h2>
+        <p>
+          This will edit all documents to have the same data. Use carefully.
+        </p>
+      </header>
+    </EditMany>
+  </div>
+</Story>

--- a/src/lib/components/forms/stories/Edit.stories.svelte
+++ b/src/lib/components/forms/stories/Edit.stories.svelte
@@ -1,7 +1,9 @@
 <script context="module" lang="ts">
+  import type { APIError, Document, ValidationError } from "$lib/api/types";
+
   import { _ } from "svelte-i18n";
-  import type { Document } from "@/lib/api/types";
   import { Story } from "@storybook/addon-svelte-csf";
+
   import EditForm from "../Edit.svelte";
   import EditMany from "../EditMany.svelte";
 
@@ -13,6 +15,14 @@
     title: "Forms / Document Edit",
     component: EditForm,
     parameters: { layout: "centered" },
+  };
+
+  const error: APIError<ValidationError> = {
+    status: 400,
+    message: "Something went wrong",
+    errors: {
+      published_url: ["Published URL must be a valid URL"],
+    },
   };
 </script>
 
@@ -55,6 +65,19 @@
 <Story name="Bulk edit, too many documents">
   <div style="min-width: 600px;">
     <EditMany documents={Array(100).fill(document)}>
+      <header>
+        <h2>{$_("edit.title")}</h2>
+        <p>
+          This will edit all documents to have the same data. Use carefully.
+        </p>
+      </header>
+    </EditMany>
+  </div>
+</Story>
+
+<Story name="Bulk edit, with error">
+  <div style="min-width: 600px;">
+    <EditMany documents={[document]} {error}>
       <header>
         <h2>{$_("edit.title")}</h2>
         <p>

--- a/src/routes/(app)/documents/+page.server.ts
+++ b/src/routes/(app)/documents/+page.server.ts
@@ -114,7 +114,7 @@ export const actions = {
       return { ...update, id };
     });
 
-    const { error } = await edit_many(docs, csrf_token, fetch);
+    const { error, data } = await edit_many(docs, csrf_token, fetch);
 
     if (error) {
       setFlash({ message: error.message, status: "error" }, cookies);
@@ -127,8 +127,8 @@ export const actions = {
         : `Saved edits to ${ids.length} documents`;
     setFlash({ message, status: "success" }, cookies);
     return {
-      success: true,
       count: ids.length,
+      data,
     };
   },
 } satisfies Actions;


### PR DESCRIPTION
This is a short term fix, with hooks to adjust as we go. I've limited bulk editing to 25 documents at a time, disabling the form if you've selected more. We can do two things to increase that in two ways:

- increase the backend limit
- batch requests

Both of those have tradeoffs and we should talk about them, but this will keep people from hitting unexpected errors. 

![Screenshot 2025-02-19 at 2 37 31 PM](https://github.com/user-attachments/assets/92bf6759-75a3-4731-abfa-4c9a3d705c79)
