### PR TITLE
Call `loadPDF` on `visibilitychange` events

### DIFF
--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -175,6 +175,12 @@ layouts, stories, and tests.
         $progress = p;
       };
 
+      task.promise.then(() => {
+        // Clear the task when the loading is complete,
+        // so we can reload the document if needed
+        task = null;
+      });
+
       task.promise.catch(async (error) => {
         if (error.status === 403 && retriesOn403Error < 5) {
           // try to load the document again using a fresh asset_url
@@ -196,7 +202,7 @@ layouts, stories, and tests.
     loadPDF(asset_url);
   });
 
-  function onPageShow() {
+  function onTabVisible() {
     loadPDF(asset_url);
   }
 
@@ -215,10 +221,7 @@ layouts, stories, and tests.
   });
 </script>
 
-<svelte:window
-  on:hashchange={onHashChange}
-  on:popstate={onHashChange}
-  on:pageshow={onPageShow}
-/>
+<svelte:document on:visibilitychange={onTabVisible} />
+<svelte:window on:hashchange={onHashChange} on:popstate={onHashChange} />
 
 <slot />

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -196,6 +196,10 @@ layouts, stories, and tests.
     loadPDF(asset_url);
   });
 
+  function onPageShow() {
+    loadPDF(asset_url);
+  }
+
   afterNavigate(() => {
     // refresh stores from URL state
     const { hash } = $pageStore.url;
@@ -211,6 +215,10 @@ layouts, stories, and tests.
   });
 </script>
 
-<svelte:window on:hashchange={onHashChange} on:popstate={onHashChange} />
+<svelte:window
+  on:hashchange={onHashChange}
+  on:popstate={onHashChange}
+  on:pageshow={onPageShow}
+/>
 
 <slot />


### PR DESCRIPTION
Fixes #1002

Waiting on @eyeseast to push caching fixes when getting a private asset URL to see if that makes this unnecessary, but it's still probably a good idea to refetch the PDF when the page is shown again. The use case for this would be:

> I'm collaborating with somebody on a doc. I have it in an open tab, but I tab away to do other business. They make a redaction in the meantime, causing a reprocess. Once I tab back minutes or hours later, I want to be looking at the reprocessed, redacted document, not the stale version.