### PR TITLE
Preserve querystring in menu items (sometimes)

### DIFF
--- a/src/lib/components/common/MenuItem.svelte
+++ b/src/lib/components/common/MenuItem.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { CheckCircleFill16 } from "svelte-octicons";
+  import { qs } from "$lib/utils/navigation";
 
   export let danger = false;
   export let selectable = true;
@@ -13,12 +14,16 @@
 
   let className = "";
   export { className as class };
+
+  export let preserveQS = false;
 </script>
 
 {#if href}
   <a
     {target}
     {href}
+    role="menuitem"
+    tabindex="0"
     class="item {className}"
     class:selectable
     class:selected
@@ -28,8 +33,7 @@
     class:indent
     class:special
     on:click
-    role="menuitem"
-    tabindex="0"
+    use:qs={preserveQS}
   >
     <slot name="icon" />
     <span class="label"><slot>Define an item</slot></span>

--- a/src/lib/components/viewer/ReadingToolbar.svelte
+++ b/src/lib/components/viewer/ReadingToolbar.svelte
@@ -30,8 +30,8 @@ Assumes it's a child of a ViewerContext
   import Tab from "$lib/components/common/Tab.svelte";
 
   import { remToPx } from "$lib/utils/layout";
-  import { getViewerHref } from "$lib/utils/viewer";
   import { getQuery } from "$lib/utils/search";
+  import { getViewerHref } from "$lib/utils/viewer";
   import {
     getCurrentMode,
     getDocument,
@@ -115,6 +115,7 @@ Assumes it's a child of a ViewerContext
             <MenuItem
               selected={$mode === value}
               href={getViewerHref({ document, mode: value, embed, query })}
+              preserveQS
               on:click={close}
             >
               <svelte:component this={icons[value]} slot="icon" />

--- a/src/lib/utils/navigation.ts
+++ b/src/lib/utils/navigation.ts
@@ -1,5 +1,3 @@
-import type { Action } from "svelte/action";
-
 type Breadcrumb = { href?: string; title: string };
 type Parent = () => Promise<{ breadcrumbs?: Array<Breadcrumb> }>;
 
@@ -18,10 +16,12 @@ export async function breadcrumbTrail(
  * Make a link preserve existing query params and merge in new ones
  *
  * @type {Action}
- * @param node
+ * @param {HTMLAnchorElement} node
+ * @param {boolean} enable
  */
-export function qs(node: HTMLAnchorElement) {
+export function qs(node: HTMLAnchorElement, enable = true): void {
   if (typeof window === "undefined") return;
+  if (!enable) return;
 
   const href = new URL(node.href);
   const params = new URLSearchParams(window.location.search);

--- a/src/lib/utils/tests/navigation.test.ts
+++ b/src/lib/utils/tests/navigation.test.ts
@@ -59,4 +59,19 @@ describe("querystring links", () => {
       expect(new URL(a.href).search).toEqual(fixed[i]);
     });
   });
+
+  it("is a noop if enabled = false", () => {
+    const href =
+      "https://www.dev.documentcloud.org/documents/20000065-creating-adaptable-skills-a-nonlinear-pedagogy-approach-to-mental-imagery/?mode=document#document/p1";
+
+    // create the link
+    let a = document.createElement("a");
+    a.href = href;
+    a.textContent = "test";
+
+    // fix the link, but not really
+    qs(a, false);
+
+    expect(a.href).toEqual(href);
+  });
 });


### PR DESCRIPTION
Fixes #1056 

The `MenuItem` component now takes a `preserveQS` flag, which enables the `qs` action. That action now has an `enabled` argument, which defaults to true. On `MenuItem`, `preserveQS` defaults to false.