### PR TITLE
Hide empty sections menu for non-editors

### DIFF
--- a/src/lib/components/viewer/PaginationToolbar.svelte
+++ b/src/lib/components/viewer/PaginationToolbar.svelte
@@ -74,7 +74,7 @@
   bind:clientWidth={width}
 >
   <div class="sections">
-    {#if showPDF && (sections || canEditSections)}
+    {#if showPDF && (sections.length > 0 || canEditSections)}
       <Dropdown position="top-start" --offset="5px">
         <div class="toolbarItem" slot="anchor">
           <SidebarItem>


### PR DESCRIPTION
This applies to embeds and the regular viewer. If you don't have edit access and there are no sections, there's no point showing you the empty menu.

Closes #1058 