### PR TITLE
Set sentry environment for better filtering

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -6,6 +6,7 @@ Sentry.init({
   // @ts-ignore
   dsn: env.PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.5,
+  environment: window.location.hostname,
 
   // Capture Replay for 10% of all sessions,
   replaysSessionSampleRate: 0.1,

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,9 +3,9 @@ import type { Handle } from "@sveltejs/kit";
 
 import { env } from "$env/dynamic/private";
 
+import { locale } from "svelte-i18n";
 import { sequence } from "@sveltejs/kit/hooks";
 import * as Sentry from "@sentry/sveltekit";
-import { locale } from "svelte-i18n";
 
 import { DC_BASE } from "./config/config.js";
 import { log } from "$lib/utils/logging";
@@ -14,6 +14,7 @@ Sentry.init({
   dsn: env.SENTRY_DSN,
   integrations: [Sentry.captureConsoleIntegration({ levels: ["error"] })],
   tracesSampleRate: 0.5,
+  environment: "server",
 });
 
 /** @type {import('@sveltejs/kit').HandleFetch} */


### PR DESCRIPTION
This should let us filter errors by `hostname` or `server` (in client and server, respectively), and hopefully let us see where some weird non-crashing errors are happening.