### PR TITLE
Don't truncate search highlights

### DIFF
--- a/src/lib/components/common/Highlight.svelte
+++ b/src/lib/components/common/Highlight.svelte
@@ -15,7 +15,7 @@
   {#if segments.length > 0}
     <blockquote>
       {#each segments as segment}
-        <p class="segment ellipsis">{@html sanitize(segment)}</p>
+        <p class="segment">{@html sanitize(segment)}</p>
       {/each}
     </blockquote>
   {/if}


### PR DESCRIPTION
Closes #1071 

Just removes the `ellipses` class on the `p` tag.