### PR TITLE
Fixes for page-level notes

### DIFF
--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -12,7 +12,7 @@ Assumes it's a child of a ViewerContext
 <script lang="ts">
   import type { BBox, Maybe, Note as NoteType, Nullable } from "$lib/api/types";
 
-  import { invalidate, pushState } from "$app/navigation";
+  import { invalidate, goto } from "$app/navigation";
 
   import { fly } from "svelte/transition";
   import { _ } from "svelte-i18n";
@@ -20,9 +20,6 @@ Assumes it's a child of a ViewerContext
   import Note from "./Note.svelte";
   import EditNote from "../forms/EditNote.svelte";
   import NoteTab from "./NoteTab.svelte";
-
-  import Modal from "../layouts/Modal.svelte";
-  import Portal from "../layouts/Portal.svelte";
 
   import { width, height, isPageLevel, noteHashUrl } from "$lib/api/notes";
   import {
@@ -52,11 +49,6 @@ Assumes it's a child of a ViewerContext
     getNotes(document)[page_number]?.filter((note) => !isPageLevel(note)) ?? [];
   $: writing = $mode === "annotating";
   $: activeNote = Boolean($currentNote) || (Boolean($newNote) && !drawing);
-  $: edit_page_note =
-    writing &&
-    Boolean($currentNote) &&
-    isPageLevel($currentNote ?? {}) &&
-    page_number === $currentNote?.page_number;
 
   function getNoteId(note: NoteType) {
     return noteHashUrl(note).split("#")[1];
@@ -143,7 +135,8 @@ Assumes it's a child of a ViewerContext
       target?.href || getViewerHref({ document, note, mode: $mode, embed });
     $currentNote = note;
     $newNote = null;
-    pushState(href, { note });
+    // pushState(href, { note });
+    goto(href);
   }
 
   function closeNote() {
@@ -151,7 +144,8 @@ Assumes it's a child of a ViewerContext
     $newNote = null;
     $currentNote = null;
     const href = getViewerHref({ document, mode: $mode, embed });
-    pushState(href, {});
+    // pushState(href, {});
+    goto(href);
   }
 
   function onkeypress(e: KeyboardEvent) {
@@ -264,24 +258,6 @@ Assumes it's a child of a ViewerContext
     {/if}
   {/if}
 </div>
-
-{#if edit_page_note}
-  <Portal>
-    <Modal on:close={closeNote}>
-      <h2 slot="title">
-        {$_("annotate.cta.add-note")}
-      </h2>
-
-      <EditNote
-        {document}
-        note={$currentNote ?? {}}
-        {page_number}
-        on:close={closeNote}
-        on:success={(e) => onEditNoteSuccess(e, $currentNote)}
-      />
-    </Modal>
-  </Portal>
-{/if}
 
 <style>
   .notes {

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -135,7 +135,6 @@ Assumes it's a child of a ViewerContext
       target?.href || getViewerHref({ document, note, mode: $mode, embed });
     $currentNote = note;
     $newNote = null;
-    // pushState(href, { note });
     goto(href);
   }
 
@@ -144,7 +143,6 @@ Assumes it's a child of a ViewerContext
     $newNote = null;
     $currentNote = null;
     const href = getViewerHref({ document, mode: $mode, embed });
-    // pushState(href, {});
     goto(href);
   }
 

--- a/src/lib/components/viewer/Note.svelte
+++ b/src/lib/components/viewer/Note.svelte
@@ -120,11 +120,6 @@
     const image = new Image();
 
     let src = pageImageUrl(document, page_number, SIZE);
-    /* not sure we need this
-    if (document.access !== "public") {
-      src = await getPrivateAsset(src);
-    }
-    */
 
     image.src = src.href;
     image.addEventListener("load", (e) => {

--- a/src/lib/components/viewer/Note.svelte
+++ b/src/lib/components/viewer/Note.svelte
@@ -211,10 +211,14 @@
     {/if}
     <div class="headerText">
       <h3>
-        <a href={note_url} target={embed ? "_blank" : null}>
+        {#if page_level}
           {note.title}
-          {#if embed}({$_("documents.pageAbbrev")} {page_number}){/if}
-        </a>
+        {:else}
+          <a href={note_url} target={embed ? "_blank" : null}>
+            {note.title}
+            {#if embed}({$_("documents.pageAbbrev")} {page_number}){/if}
+          </a>
+        {/if}
       </h3>
       {#if user}
         <p class="author">
@@ -280,7 +284,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 1rem;
+    gap: 0.75rem;
     pointer-events: all;
     position: relative;
     scroll-margin-top: 6rem;
@@ -289,6 +293,11 @@
 
   /* page-level */
   .note.page_level {
+    background-color: var(--white, white);
+    border: 1px solid var(--gray-2);
+    box-shadow: var(--shadow-3);
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
     position: relative;
     width: 100%;
     z-index: inherit;


### PR DESCRIPTION
- **Remove duplicate modal for page-level notes**
- **Page-level notes don't open and get better styles**

Closes #1065

In the course of this, I realized that page-level notes weren't obvious as their own thing, so I added a border and background to make them more obvious and separate them from the page itself.
