### PR TITLE
Solve URLs for page-level notes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "documentcloud-frontend",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "documentcloud-frontend",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dependencies": {
         "@floating-ui/dom": "^1.6.11",
         "@sentry/svelte": "^7.66.0",
@@ -14206,9 +14206,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001664",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz",
-      "integrity": "sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==",
+      "version": "1.0.30001706",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz",
+      "integrity": "sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/lib/components/addons/tests/__snapshots__/AddOnListItem.test.ts.snap
+++ b/src/lib/components/addons/tests/__snapshots__/AddOnListItem.test.ts.snap
@@ -20,7 +20,7 @@ exports[`AddOnListItem 1`] = `
             style="display: contents; --fill: var(--gray-3);"
           >
             <button
-              class="pin svelte-ne3jki"
+              class="pin svelte-1pb8719"
               style="--padding:0.25em; --border-radius:4px;"
             >
               <svg
@@ -101,7 +101,7 @@ exports[`AddOnListItem 2`] = `
             style="display: contents; --fill: var(--gray-3);"
           >
             <button
-              class="pin svelte-ne3jki"
+              class="pin svelte-1pb8719"
               style="--padding:0.25em; --border-radius:4px;"
             >
               <svg

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -50,10 +50,6 @@ Assumes it's a child of a ViewerContext
   $: writing = $mode === "annotating";
   $: activeNote = Boolean($currentNote) || (Boolean($newNote) && !drawing);
 
-  function getNoteId(note: NoteType) {
-    return noteHashUrl(note).split("#")[1];
-  }
-
   function getLayerPosition(e: PointerEvent): [x: number, y: number] {
     // pointer position in window
     const { offsetX, offsetY } = e;
@@ -187,11 +183,10 @@ Assumes it's a child of a ViewerContext
 >
   {#each notes as note (note.id)}
     <a
-      id={getNoteId(note)}
-      class="note-tab"
       href={getViewerHref({ document, note, mode: $mode, embed })}
-      title={note.title}
+      class="note-tab"
       style:top="calc({note.y1} * 100%)"
+      title={note.title}
       on:click={(e) => openNote(e, note)}
     >
       <Tooltip caption={note.title}><NoteTab access={note.access} /></Tooltip>
@@ -200,34 +195,40 @@ Assumes it's a child of a ViewerContext
       href={getViewerHref({ document, note, mode: $mode, embed })}
       class="note-highlight {note.access}"
       class:active={$currentNote?.id === note.id}
-      title={note.title}
       style:top="{note.y1 * 100}%"
       style:left="{note.x1 * 100}%"
       style:width="{width(note) * 100}%"
       style:height="{height(note) * 100}%"
+      title={note.title}
       on:click={(e) => openNote(e, note)}
     >
       {note.title}
     </a>
   {/each}
 
-  {#if $currentNote && !Boolean($newNote) && $currentNote.page_number === page_number}
+  {#if $currentNote && !Boolean($newNote) && $currentNote.page_number === page_number && !isPageLevel($currentNote)}
     <div
       class="note card"
-      style={positionNote($currentNote, 1.5)}
+      style={positionNote($currentNote, 0.5)}
       transition:fly={{ duration: 250, y: "-1.1rem" }}
     >
-      {#if writing}
-        <EditNote
-          note={$currentNote}
-          {document}
-          {page_number}
-          on:close={closeNote}
-          on:success={(e) => onEditNoteSuccess(e, $currentNote)}
-        />
-      {:else}
-        <Note note={$currentNote} {scale} on:close={closeNote} />
-      {/if}
+      <Note note={$currentNote} {scale} on:close={closeNote} />
+    </div>
+  {/if}
+
+  {#if writing && $currentNote}
+    <div
+      class="note card"
+      style={positionNote($currentNote, 0.5)}
+      transition:fly={{ duration: 250, y: "-1.1rem" }}
+    >
+      <EditNote
+        note={$currentNote}
+        {document}
+        {page_number}
+        on:close={closeNote}
+        on:success={(e) => onEditNoteSuccess(e, $currentNote)}
+      />
     </div>
   {/if}
 

--- a/src/lib/components/viewer/Note.svelte
+++ b/src/lib/components/viewer/Note.svelte
@@ -30,7 +30,7 @@
   import Share from "../documents/Share.svelte";
 
   import { ALLOWED_ATTR, ALLOWED_TAGS } from "@/config/config.js";
-  import { width, height, isPageLevel } from "$lib/api/notes";
+  import { width, height, isPageLevel, noteHashUrl } from "$lib/api/notes";
   import { pageImageUrl } from "$lib/api/documents";
   import { getUserName } from "$lib/api/accounts";
   import { getViewerHref } from "$lib/utils/viewer";
@@ -86,6 +86,7 @@
   $: edit_link = getViewerHref({ document: doc, note, mode: "annotating" });
   $: canEdit = note.edit_access && !embed;
   $: note_url = getViewerHref({ document: doc, note });
+  $: id = noteHashUrl(note).split("#")[1];
 
   async function render(
     canvas: HTMLCanvasElement,
@@ -194,6 +195,7 @@
 </script>
 
 <div
+  {id}
   class="note {note.access} {$mode || 'notes'}"
   class:page_level
   style:--x1={note.x1}


### PR DESCRIPTION
Closes #1034 

Two main changes:
- move the `id` property inside the `Note` component, instead of in the link wrapping the `NoteTab`
- disable the card view for page-level notes, which display in full at the top of the page
