### PR TITLE
Don't expand bulk update calls

### DIFF
--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -423,9 +423,6 @@ export async function edit_many(
 ) {
   const endpoint = new URL("documents/", BASE_API_URL);
 
-  // return the same data we get from search
-  endpoint.searchParams.set("expand", DEFAULT_EXPAND.join(","));
-
   const resp = await fetch(endpoint, {
     credentials: "include",
     method: "PATCH",

--- a/src/lib/api/tests/documents.test.ts
+++ b/src/lib/api/tests/documents.test.ts
@@ -537,7 +537,7 @@ describe("document write methods", () => {
     expect(error).toBeUndefined();
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL("documents/?expand=user%2Corganization%2Cprojects", BASE_API_URL),
+      new URL("documents/", BASE_API_URL),
       {
         credentials: "include",
         method: "PATCH",

--- a/src/lib/components/addons/tests/__snapshots__/AddOnListItem.test.ts.snap
+++ b/src/lib/components/addons/tests/__snapshots__/AddOnListItem.test.ts.snap
@@ -20,7 +20,7 @@ exports[`AddOnListItem 1`] = `
             style="display: contents; --fill: var(--gray-3);"
           >
             <button
-              class="pin svelte-1pb8719"
+              class="pin svelte-ne3jki"
               style="--padding:0.25em; --border-radius:4px;"
             >
               <svg
@@ -101,7 +101,7 @@ exports[`AddOnListItem 2`] = `
             style="display: contents; --fill: var(--gray-3);"
           >
             <button
-              class="pin svelte-1pb8719"
+              class="pin svelte-ne3jki"
               style="--padding:0.25em; --border-radius:4px;"
             >
               <svg

--- a/src/lib/components/addons/tests/__snapshots__/AddOnListItem.test.ts.snap
+++ b/src/lib/components/addons/tests/__snapshots__/AddOnListItem.test.ts.snap
@@ -20,7 +20,7 @@ exports[`AddOnListItem 1`] = `
             style="display: contents; --fill: var(--gray-3);"
           >
             <button
-              class="pin svelte-ne3jki"
+              class="pin svelte-1pb8719"
               style="--padding:0.25em; --border-radius:4px;"
             >
               <svg
@@ -101,7 +101,7 @@ exports[`AddOnListItem 2`] = `
             style="display: contents; --fill: var(--gray-3);"
           >
             <button
-              class="pin svelte-ne3jki"
+              class="pin svelte-1pb8719"
               style="--padding:0.25em; --border-radius:4px;"
             >
               <svg

--- a/src/lib/components/forms/EditMany.svelte
+++ b/src/lib/components/forms/EditMany.svelte
@@ -51,7 +51,7 @@ Usually this will be rendered inside a modal, but it doesn't have to be.
       submitter.disabled = false;
       if (result.type === "failure") {
         console.error(result);
-        error = result.data.error;
+        error = result.data;
       }
 
       if (result.type === "success") {

--- a/src/routes/(app)/documents/+page.server.ts
+++ b/src/routes/(app)/documents/+page.server.ts
@@ -39,7 +39,7 @@ export const actions = {
     }, {});
 
     const ids = String(form.get("documents")).split(",");
-
+    console.log(`BULK DATA: ${form.get("documents")}`);
     // send a request for each key on each document
     // this might be a bunch of requests all at once
     const promises = Object.entries(data)
@@ -80,6 +80,7 @@ export const actions = {
     const form = await request.formData();
 
     const ids = String(form.get("documents")).split(",");
+    console.log(`BULK DELETE: ${form.get("documents")}`);
 
     const { error } = await destroy_many(ids, csrf_token, fetch);
 
@@ -103,7 +104,7 @@ export const actions = {
     const form = await request.formData();
 
     const ids = String(form.get("documents")).split(",");
-
+    console.log(`BULK EDIT: ${form.get("documents")}`);
     form.delete("documents");
 
     // @ts-ignore


### PR DESCRIPTION
Addressing https://github.com/MuckRock/documentcloud/issues/284

The `expand` flag was creating a slow request on the backend, even for one document, so this removes it for now.