### PR TITLE
Redirect old note embed routes

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -5,6 +5,12 @@
 # sometimes asset paths get mislaid
 /documents/_app/* /_app/:splat
 /documents/:id/_app/* /_app/:splat
+/documents/service-worker.js /service-worker.js
 
 # old URLs
 /search/ /documents/
+/api/oembed.json https://api.www.documentcloud.org/api/oembed/
+
+# old embeds
+/documents/:doc_id-:slug/annotations/:id https://embed.documentcloud.org/documents/:doc_id/annotations/:id/
+/documents/:doc_id-:slug/pages/:n https://embed.documentcloud.org/documents/:doc_id/pages/:n/

--- a/static/_redirects
+++ b/static/_redirects
@@ -12,5 +12,5 @@
 /api/oembed.json https://api.www.documentcloud.org/api/oembed/
 
 # old embeds
-/documents/:doc_id-:slug/annotations/:id https://embed.documentcloud.org/documents/:doc_id/annotations/:id/
-/documents/:doc_id-:slug/pages/:n https://embed.documentcloud.org/documents/:doc_id/pages/:n/
+/documents/:doc-:slug/annotations/:id https://embed.documentcloud.org/documents/:doc/annotations/:id/
+/documents/:doc-:slug/pages/:n https://embed.documentcloud.org/documents/:doc/pages/:n/


### PR DESCRIPTION
Turn `https://embed.documentcloud.org/documents/3955403-Wyatt-Address-Unveiling/annotations/371712.html/` into `https://embed.documentcloud.org/documents/3955403/annotations/371712/`