### PR TITLE
Only hide fullscreen embed action when explicitly disabled

### DIFF
--- a/src/lib/components/layouts/EmbedLayout.svelte
+++ b/src/lib/components/layouts/EmbedLayout.svelte
@@ -64,7 +64,8 @@
           </Button>
         </Tooltip>
       {/if}
-      {#if settings.fullscreen && isFullscreenSupported}
+      <!-- Fullscreen must be explictly disabled in settings -->
+      {#if settings.fullscreen !== 0 && isFullscreenSupported}
         <Tooltip
           caption={$_(
             isFullscreen ? "embed.exitFullscreen" : "embed.enterFullscreen",

--- a/src/lib/utils/tests/embed.test.ts
+++ b/src/lib/utils/tests/embed.test.ts
@@ -32,6 +32,7 @@ describe("embed settings", () => {
       pdf: false,
       onlyshoworg: true,
       title: 0,
+      fullscreen: 1
     });
   });
 });

--- a/src/routes/embed/documents/[id]-[slug]/+page.ts
+++ b/src/routes/embed/documents/[id]-[slug]/+page.ts
@@ -24,7 +24,6 @@ export async function load({ fetch, url, params, depends, setHeaders }) {
   }
 
   let settings: Partial<EmbedSettings> = getEmbedSettings(url.searchParams);
-  console.log(settings.fullscreen);
 
   setHeaders({
     "cache-control": `public, max-age=${EMBED_MAX_AGE}`,

--- a/src/routes/embed/documents/[id]-[slug]/+page.ts
+++ b/src/routes/embed/documents/[id]-[slug]/+page.ts
@@ -24,6 +24,7 @@ export async function load({ fetch, url, params, depends, setHeaders }) {
   }
 
   let settings: Partial<EmbedSettings> = getEmbedSettings(url.searchParams);
+  console.log(settings.fullscreen);
 
   setHeaders({
     "cache-control": `public, max-age=${EMBED_MAX_AGE}`,


### PR DESCRIPTION
Attempted fix for #1112

The default value for `fullscreen` is `null`, so when we checked `settings.fullscreen`, it would return false by default when we want true. So now we check for an explicit opt-out, `settings.fullscreen !== 0`.

This fix is reflected by changes to our Storybook diffs.