### PR TITLE
Add redirects for bare ID routes

### DIFF
--- a/src/lib/components/common/RelativeTime.svelte
+++ b/src/lib/components/common/RelativeTime.svelte
@@ -42,7 +42,11 @@
   }
 </script>
 
-<time datetime={date.toISOString()} title={date.toISOString()}>
+<time
+  datetime={date.toISOString()}
+  title={date.toISOString()}
+  data-chromatic="ignore"
+>
   {formatTimeAgo(date)}
 </time>
 

--- a/src/lib/components/documents/Revisions.svelte
+++ b/src/lib/components/documents/Revisions.svelte
@@ -31,13 +31,13 @@
       </td>
     </tr>
   {:else}
-    <tr class="empty"
-      ><td>
+    <tr class="empty">
+      <td>
         <Empty icon={History24}>
           {$_("dialogRevisionsDialog.empty")}
         </Empty>
-      </td></tr
-    >
+      </td>
+    </tr>
   {/each}
 </table>
 

--- a/src/routes/(app)/documents/[id]/+page.ts
+++ b/src/routes/(app)/documents/[id]/+page.ts
@@ -1,0 +1,22 @@
+// redirect /documents/id/ to /documents/id-slug/
+import { error, redirect } from "@sveltejs/kit";
+import * as documents from "$lib/api/documents";
+
+// save a redirect
+export const trailingSlash = "ignore";
+
+/** @type {import('./$types').PageLoad} */
+export async function load({ params, fetch, url }) {
+  const { data: document, error: err } = await documents.get(+params.id, fetch);
+  if (err) {
+    console.warn(err.status, url.href);
+    return error(err.status, err.message);
+  }
+
+  if (!document) {
+    return error(404, "Document not found");
+  }
+  const canonical = documents.canonicalUrl(document);
+
+  return redirect(308, canonical);
+}

--- a/src/routes/embed/documents/[id]/+page.ts
+++ b/src/routes/embed/documents/[id]/+page.ts
@@ -16,7 +16,7 @@ export async function load({ params, fetch, url }) {
   if (!document) {
     return error(404, "Document not found");
   }
-  const canonical = documents.embedUrl(document);
+  const canonical = documents.embedUrl(document, url.searchParams);
 
   return redirect(308, canonical);
 }

--- a/src/routes/embed/documents/[id]/+page.ts
+++ b/src/routes/embed/documents/[id]/+page.ts
@@ -1,0 +1,22 @@
+// redirect /documents/id/ to /documents/id-slug/
+import { error, redirect } from "@sveltejs/kit";
+import * as documents from "$lib/api/documents";
+
+// save a redirect
+export const trailingSlash = "ignore";
+
+/** @type {import('./$types').PageLoad} */
+export async function load({ params, fetch, url }) {
+  const { data: document, error: err } = await documents.get(+params.id, fetch);
+  if (err) {
+    console.warn(err.status, url.href);
+    return error(err.status, err.message);
+  }
+
+  if (!document) {
+    return error(404, "Document not found");
+  }
+  const canonical = documents.embedUrl(document);
+
+  return redirect(308, canonical);
+}


### PR DESCRIPTION
This handles a URL structure we used to support -- `/documents/<id>/` -- which will now redirect to the canonical or embed route, as appropriate.

Closes #1111 

Test URLs:
- App: https://deploy-preview-1114.muckcloud.com/documents/20006908
- Embed: https://deploy-preview-1114.muckcloud.com/documents/20006908?embed=1&title=0

Those should redirect to working URLs with slugs.