### PR TITLE
catch more redirects

### DIFF
--- a/src/routes/(app)/+page.ts
+++ b/src/routes/(app)/+page.ts
@@ -1,6 +1,8 @@
 import { redirect } from "@sveltejs/kit";
 import { userDocs } from "$lib/utils/search";
 
+export const trailingSlash = "ignore";
+
 export async function load({ parent, url }) {
   const { me } = await parent();
   const u = new URL(url);
@@ -8,9 +10,9 @@ export async function load({ parent, url }) {
   if (me) {
     u.pathname = "/documents/";
     u.searchParams.set("q", userDocs(me));
-    return redirect(302, u);
+    return redirect(307, u);
   }
 
   u.pathname = "/home/";
-  return redirect(302, u);
+  return redirect(307, u);
 }

--- a/src/routes/(app)/app/+page.ts
+++ b/src/routes/(app)/app/+page.ts
@@ -8,5 +8,5 @@ export function load({ url }) {
   // change the path but preserve other parts of the URL
   u.pathname = "/documents/";
 
-  return redirect(302, u);
+  return redirect(308, u);
 }

--- a/src/routes/(pages)/home/+page.ts
+++ b/src/routes/(pages)/home/+page.ts
@@ -10,7 +10,7 @@ import { getMe } from "$lib/api/accounts";
 
 marked.use(gfmHeadingId());
 
-export const trailingSlash = "always";
+export const trailingSlash = "ignore";
 
 export async function load({ fetch, setHeaders }) {
   const [{ data: page, error: err }, me] = await Promise.all([

--- a/static/_redirects
+++ b/static/_redirects
@@ -8,3 +8,5 @@
 
 # old URLs
 /search/ /documents/
+/app /documents/
+/api/oembed.json https://api.www.documentcloud.org/api/oembed/


### PR DESCRIPTION
Tweaking some redirects to reduce unnecessary requests:

- `/app` ignores trailing slashes, so we don't do `/app` -> `/app/` -> `/documents/`
- `/home` ignores trailing slashes because we don't care
- `/api/oembed.json` in `_redirects` because CF doesn't always catch that
