### PR TITLE
Log requests as a line of JSON for easier parsing

### DIFF
--- a/src/lib/utils/logging.ts
+++ b/src/lib/utils/logging.ts
@@ -15,7 +15,8 @@ export function log(event: RequestEvent, response: Response): void {
   const { method, url } = event.request;
   const cache = response.headers.get("cache-control") ?? "";
   const etag = response.headers.get("etag") ?? "";
-
+  const last_modified = response.headers.get("Last-Modified") ?? "";
+  /* 
   const row = [
     new Date(),
     method,
@@ -26,5 +27,18 @@ export function log(event: RequestEvent, response: Response): void {
     cache,
   ].filter(Boolean);
 
-  f(...row);
+  f(...row); */
+
+  const row = {
+    timestamp: new Date().toJSON(),
+    method,
+    url,
+    status,
+    route: event.route.id,
+    etag,
+    cache,
+    last_modified,
+  };
+
+  f(JSON.stringify(row));
 }


### PR DESCRIPTION
Closes #1117 

This doesn't change anything about error logging, so we may have to filter out errors to put requests in a database.