### PR TITLE
Hide feedback button for non signed-in users

### DIFF
--- a/src/lib/components/layouts/Navigation.svelte
+++ b/src/lib/components/layouts/Navigation.svelte
@@ -73,6 +73,7 @@
       <HelpMenu />
     {/if}
 
+    <SignedIn>
     <Button
       minW={false}
       ghost
@@ -82,6 +83,7 @@
     >
       {$_("common.feedback")}
     </Button>
+    </SignedIn>
 
     {#if feedbackOpen}
       <Portal>


### PR DESCRIPTION
Would close at least part of
https://github.com/MuckRock/documentcloud-frontend/issues/1118

Need to figure out if we want to also hide "Report a problem" button on 404s, since this is another place that links to the feedback form. Can also include that in this PR if we decide to. 
