### PR TITLE
Set a big (and configurable) max width in SidebarItem

### DIFF
--- a/src/lib/components/sidebar/SidebarItem.svelte
+++ b/src/lib/components/sidebar/SidebarItem.svelte
@@ -139,6 +139,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    max-width: var(--max-width, 20ch);
   }
   .label:empty {
     display: none;

--- a/src/lib/components/sidebar/stories/SidebarItem.stories.svelte
+++ b/src/lib/components/sidebar/stories/SidebarItem.stories.svelte
@@ -81,6 +81,17 @@
   </div>
 </Story>
 
+<Story name="Absurdly long name">
+  <SidebarItem>
+    The International Consortium for the Real-Time Dissemination of Verified,
+    Unbiased, Cross-Platform, Community-Sourced, Multilingual, Deep-Dive
+    Investigative Journalism and Global News Analysis Network for Socioeconomic,
+    Environmental, Political, Technological, and Humanitarian Affairs Reporting
+    and Strategic Public Information Engagement Across All Media Channels
+    Initiative
+  </SidebarItem>
+</Story>
+
 <style>
   .maxW-16 {
     max-width: 16rem;


### PR DESCRIPTION
Closes #1132 

Just making sure stuff doesn't break if someone pushes the limit on name length.

<img width="742" alt="Screenshot 2025-05-28 at 11 47 55 AM" src="https://github.com/user-attachments/assets/f12ac783-70c6-4627-9308-844ffc86c6d1" />
<img width="782" alt="Screenshot 2025-05-28 at 11 47 41 AM" src="https://github.com/user-attachments/assets/0e5b4d73-493e-46e0-8fae-08e26fbc0a28" />
