### PR TITLE
Allow fullscreen

### DIFF
--- a/src/lib/api/embed.ts
+++ b/src/lib/api/embed.ts
@@ -31,7 +31,7 @@ export function document(document: Document, params: URLSearchParams): string {
 
   const embedSrc = documents.embedUrl(document, params);
   embedSrc.searchParams.set("embed", "1");
-  return `<iframe src="${embedSrc.href}" width="${width}" height="${height}" style="${style}"></iframe>`;
+  return `<iframe src="${embedSrc.href}" width="${width}" height="${height}" style="${style}" allow="fullscreen"></iframe>`;
 }
 
 export function page(document: Document, page: number = 1): string {


### PR DESCRIPTION
Lost the `allow="fullscreen"` attribute in the last PR. This adds it back.