### PR TITLE
Link page notes in the sidebar to the page, not the note

### DIFF
--- a/src/lib/components/documents/Data.svelte
+++ b/src/lib/components/documents/Data.svelte
@@ -2,7 +2,7 @@
   import type { Document } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
-  import { ChevronDown12, Pencil16, Tag16, Tag24 } from "svelte-octicons";
+  import { Pencil16, Tag16, Tag24 } from "svelte-octicons";
 
   import Action from "$lib/components/common/Action.svelte";
   import Empty from "$lib/components/common/Empty.svelte";
@@ -11,7 +11,7 @@
   import SidebarItem from "$lib/components/sidebar/SidebarItem.svelte";
 
   // editing UI
-  import EditData from "@/lib/components/forms/EditData.svelte";
+  import EditData from "$lib/components/forms/EditData.svelte";
   import Modal from "$lib/components/layouts/Modal.svelte";
   import Portal from "$lib/components/layouts/Portal.svelte";
 

--- a/src/lib/components/documents/Projects.svelte
+++ b/src/lib/components/documents/Projects.svelte
@@ -4,14 +4,14 @@
   import { _ } from "svelte-i18n";
   import { FileDirectory16, FileDirectory24, Pencil16 } from "svelte-octicons";
 
-  import Action from "@/lib/components/common/Action.svelte";
-  import Empty from "@/lib/components/common/Empty.svelte";
-  import SidebarGroup from "@/lib/components/sidebar/SidebarGroup.svelte";
-  import SidebarItem from "@/lib/components/sidebar/SidebarItem.svelte";
+  import Action from "$lib/components/common/Action.svelte";
+  import Empty from "$lib/components/common/Empty.svelte";
+  import SidebarGroup from "$lib/components/sidebar/SidebarGroup.svelte";
+  import SidebarItem from "$lib/components/sidebar/SidebarItem.svelte";
 
-  import Modal from "@/lib/components/layouts/Modal.svelte";
-  import Portal from "@/lib/components/layouts/Portal.svelte";
-  import Projects from "@/lib/components/forms/Projects.svelte";
+  import Modal from "$lib/components/layouts/Modal.svelte";
+  import Portal from "$lib/components/layouts/Portal.svelte";
+  import Projects from "$lib/components/forms/Projects.svelte";
 
   import { canonicalUrl } from "$lib/api/projects";
 

--- a/src/lib/components/layouts/DocumentLayout.svelte
+++ b/src/lib/components/layouts/DocumentLayout.svelte
@@ -13,7 +13,7 @@ Assumes it's a child of a ViewerContext
   import DocumentMetadata from "../documents/Metadata.svelte";
   import Flex from "../common/Flex.svelte";
   import Metadata from "../common/Metadata.svelte";
-  import Notes from "../documents/sidebar/Notes.svelte";
+  import Notes from "../viewer/sidebar/Notes.svelte";
   import Projects from "../documents/Projects.svelte";
   import SidebarLayout from "./SidebarLayout.svelte";
   import Viewer from "../viewer/Viewer.svelte";

--- a/src/lib/components/viewer/sidebar/Notes.svelte
+++ b/src/lib/components/viewer/sidebar/Notes.svelte
@@ -4,13 +4,13 @@
   import { _ } from "svelte-i18n";
   import { Note16, Note24 } from "svelte-octicons";
 
-  import Button from "../../common/Button.svelte";
-  import Empty from "@/lib/components/common/Empty.svelte";
-  import SidebarGroup from "@/lib/components/sidebar/SidebarGroup.svelte";
-  import SidebarItem from "@/lib/components/sidebar/SidebarItem.svelte";
+  import Button from "$lib/components/common/Button.svelte";
+  import Empty from "$lib/components/common/Empty.svelte";
+  import SidebarGroup from "$lib/components/sidebar/SidebarGroup.svelte";
+  import SidebarItem from "$lib/components/sidebar/SidebarItem.svelte";
 
-  import { canonicalUrl } from "$lib/api/documents";
-  import { noteUrl } from "$lib/api/notes";
+  import { canonicalUrl, pageUrl } from "$lib/api/documents";
+  import { noteUrl, isPageLevel } from "$lib/api/notes";
 
   export let document: Document;
 
@@ -26,8 +26,11 @@
 
   <ol class="notes">
     {#each notes as note}
+      {@const href = isPageLevel(note)
+        ? pageUrl(document, note.page_number + 1).href
+        : noteUrl(document, note).href}
       <li>
-        <SidebarItem href={noteUrl(document, note).href} small>
+        <SidebarItem {href} small>
           <span class="note_title">{note.title}</span>
           <span class="page_number" slot="start">
             {$_("sidebar.toc.pageAbbrev")}


### PR DESCRIPTION
This is the more straightforward fix for #1034. I'm just linking to the page in the sidebar, not the specific note. This gets the user to the right place but doesn't interfere with editing. It also removes issue of the page level note opening in a modal with no way to close it.