### PR TITLE
Resize on an interval again

### DIFF
--- a/src/lib/utils/embed.ts
+++ b/src/lib/utils/embed.ts
@@ -215,18 +215,18 @@ export function timeoutify(fn: Function, timeout = 100) {
 
 /**
  * Use postMessage to inform parent windows of the size of an embedded iframe.
- * Set continuous: true to send a new message on each resize event.
+ * Set timeout: number to send a new message on each resize event, buffered by a timer.
  */
 export function informSize({
   element,
   useScrollDimension = true,
   updateStyleProps = false,
-  continuous = true,
+  timeout = 500,
 }: {
   element: HTMLElement;
   useScrollDimension?: boolean;
   updateStyleProps?: boolean;
-  continuous?: boolean;
+  timeout?: number | false;
 }) {
   if (!element) return;
 
@@ -248,9 +248,9 @@ export function informSize({
       "*",
     );
   };
-  if (continuous) {
+  if (timeout) {
     // Trigger event now and any time the window resizes
-    window.addEventListener("resize", timeoutify(update));
+    window.addEventListener("resize", timeoutify(update, timeout));
   }
   update();
 }

--- a/src/routes/embed/documents/[id]/annotations/[note_id]/+page.svelte
+++ b/src/routes/embed/documents/[id]/annotations/[note_id]/+page.svelte
@@ -52,9 +52,7 @@
   <meta property="og:image" content={src} />
 </svelte:head>
 
-<svelte:window
-  on:load={() => informSize({ element: elem, continuous: false })}
-/>
+<svelte:window on:load={() => informSize({ element: elem, timeout: 500 })} />
 
 <div bind:this={elem}>
   <EmbedLayout canonicalUrl={viewerUrl}>

--- a/src/routes/embed/documents/[id]/pages/[page]/+page.svelte
+++ b/src/routes/embed/documents/[id]/pages/[page]/+page.svelte
@@ -84,7 +84,7 @@
 
 <svelte:window
   on:keydown={onKeyup}
-  on:load={() => informSize({ element: elem })}
+  on:load={() => informSize({ element: elem, timeout: 500 })}
 />
 
 <div class="dc-embed" bind:this={elem}>
@@ -110,7 +110,7 @@
       })}
       width="{width}px"
       height="{height}px"
-      on:load={() => informSize({ element: elem, continuous: false })}
+      on:load={() => informSize({ element: elem, timeout: false })}
     />
 
     <!-- Place notes on image -->


### PR DESCRIPTION
Note and page embeds weren't resizing because sometimes the `postMessage` wasn't happening at the right time. This restores old behavior where it sends on each window resize, throttled to each half second.

See it live here: https://muckrock.github.io/documentcloud-embed-examples/note.html

Closes #1158 