### PR TITLE
Handle errors in Reprocess.svelte so the page doesn't crash

### DIFF
--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -2,6 +2,7 @@
  * Lots of duplicated code here that should get consolidated at some point.
  */
 import type {
+  APIError,
   APIResponse,
   Data,
   DataUpdate,
@@ -287,7 +288,7 @@ export async function process(
   }[],
   csrf_token: string,
   fetch = globalThis.fetch,
-): Promise<APIResponse<null, unknown>> {
+): Promise<APIResponse<null, string[]>> {
   const endpoint = new URL("documents/process/", BASE_API_URL);
 
   const resp = await fetch(endpoint, {
@@ -301,7 +302,7 @@ export async function process(
     body: JSON.stringify(documents),
   }).catch(console.warn);
 
-  return getApiResponse<null, unknown>(resp);
+  return getApiResponse<null, string[]>(resp);
 }
 
 /**
@@ -423,8 +424,11 @@ export async function edit_many(
   documents: Partial<Document>[],
   csrf_token: string,
   fetch = globalThis.fetch,
-) {
+): Promise<APIResponse<DocumentResults, ValidationError>> {
   const endpoint = new URL("documents/", BASE_API_URL);
+
+  if (documents.length === 0)
+    return { data: { results: [], count: 0, next: null, previous: null } };
 
   const resp = await fetch(endpoint, {
     credentials: "include",

--- a/src/lib/api/tests/documents.test.ts
+++ b/src/lib/api/tests/documents.test.ts
@@ -549,6 +549,16 @@ describe("document write methods", () => {
         body: JSON.stringify(update),
       },
     );
+
+    const nothing = await documents.edit_many([], "token", mockFetch);
+
+    expect(error).toBeUndefined();
+    expect(nothing.data).toEqual({
+      results: [],
+      count: 0,
+      next: null,
+      previous: null,
+    });
   });
 
   test("documents.add_tags", async ({ document }) => {

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import type { LayoutData } from "./$types";
+  import type { Maybe, Org, User } from "$lib/api/types";
 
   import { setContext } from "svelte";
   import { writable, type Writable } from "svelte/store";
 
   import AppLayout from "$lib/components/layouts/AppLayout.svelte";
-  import type { Maybe, Org, User } from "$lib/api/types";
 
   export let data: LayoutData;
 


### PR DESCRIPTION
I'd still like to add more realtime updates to processing, but this will at least prevent the page from breaking.