### PR TITLE
Fixes for embeds

### DIFF
--- a/src/lib/components/embeds/DocumentEmbed.svelte
+++ b/src/lib/components/embeds/DocumentEmbed.svelte
@@ -48,9 +48,7 @@
       <Metadata key={$_("titleHeader.contributedBy")}>{contributedBy}</Metadata>
     </header>
   {/if}
-  <main>
-    <Viewer />
-  </main>
+  <Viewer />
 </div>
 
 <style>
@@ -67,10 +65,6 @@
     justify-content: space-between;
     padding: 0.5rem 1rem;
     border-bottom: 1px solid var(--gray-2);
-  }
-  main {
-    flex: 1 1 auto;
-    overflow-y: auto;
   }
   h1 {
     flex: 0 1 auto;

--- a/src/lib/components/layouts/EmbedLayout.svelte
+++ b/src/lib/components/layouts/EmbedLayout.svelte
@@ -86,6 +86,7 @@
 
 <style>
   .container {
+    max-height: 100vh;
     height: 100%;
     display: flex;
     flex-direction: column;

--- a/src/routes/embed/documents/[id]/annotations/[note_id]/+page.svelte
+++ b/src/routes/embed/documents/[id]/annotations/[note_id]/+page.svelte
@@ -58,15 +58,28 @@
   on:load={() => informSize({ element: elem, timeout: 500, debug })}
 />
 
-<div bind:this={elem}>
+<div class="embed-container" bind:this={elem}>
   <EmbedLayout canonicalUrl={viewerUrl}>
-    <div class="card">
-      <Note document={writable(doc)} {note} />
+    <div class="note-container">
+      <div class="card">
+        <Note document={writable(doc)} {note} />
+      </div>
     </div>
   </EmbedLayout>
 </div>
 
 <style>
+  .embed-container {
+    height: 100%;
+  }
+  .note-container {
+    min-height: 100%;
+    overflow-y: auto;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+  }
   .card {
     margin: 1rem;
     width: calc(100% - 2rem);

--- a/src/routes/embed/stories/note-embed.stories.svelte
+++ b/src/routes/embed/stories/note-embed.stories.svelte
@@ -33,9 +33,18 @@
 </script>
 
 <Story name="default">
-  <NoteEmbed {data} />
+  <div class="vh100">
+    <NoteEmbed {data} />
+  </div>
 </Story>
 
 <Story name="bigger note">
   <NoteEmbed data={{ ...data, note: bigNote }} />
 </Story>
+
+<style>
+  .vh100 {
+    height: 100vh;
+    margin: 0;
+  }
+</style>


### PR DESCRIPTION
- Document embeds don't lose their toolbars when scrolling
- Note embeds overflow scroll when the container is too small and center when the  container is too big. This lets us safely set a default height of 400-500px for note embeds.