### PR TITLE
Use cloudflare-specific cache header

### DIFF
--- a/src/routes/(app)/add-ons/+layout.ts
+++ b/src/routes/(app)/add-ons/+layout.ts
@@ -9,7 +9,7 @@ export async function load({ parent, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "cache-control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "Cloudflare-CDN-Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
     });
   }
 

--- a/src/routes/(app)/documents/+page.ts
+++ b/src/routes/(app)/documents/+page.ts
@@ -27,7 +27,7 @@ export async function load({ url, fetch, data, parent, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "cache-control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "Cloudflare-CDN-Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
     });
   }
 

--- a/src/routes/(app)/documents/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.ts
@@ -50,7 +50,7 @@ export async function load({
 
   if (!me) {
     setHeaders({
-      "cache-control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "Cloudflare-CDN-Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
       "last-modified": new Date(document.updated_at).toUTCString(),
     });
   }

--- a/src/routes/(app)/projects/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/projects/[id]-[slug]/+page.ts
@@ -55,7 +55,7 @@ export async function load({ params, url, parent, data, fetch, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "cache-control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "Cloudflare-CDN-Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
       "last-modified": new Date(project.data.updated_at).toUTCString(),
     });
   }

--- a/src/routes/(pages)/about/+page.ts
+++ b/src/routes/(pages)/about/+page.ts
@@ -19,7 +19,7 @@ export async function load({ fetch, setHeaders }) {
   }
 
   setHeaders({
-    "cache-control": `public, max-age=${PAGE_MAX_AGE}`,
+    "Cloudflare-CDN-Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
   });
 
   return data;

--- a/src/routes/(pages)/help/[...path]/+page.ts
+++ b/src/routes/(pages)/help/[...path]/+page.ts
@@ -19,7 +19,7 @@ export async function load({ fetch, params, setHeaders }) {
   }
 
   setHeaders({
-    "cache-control": `public, max-age=${PAGE_MAX_AGE}`,
+    "Cloudflare-CDN-Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
   });
 
   return data;

--- a/src/routes/(pages)/home/+page.ts
+++ b/src/routes/(pages)/home/+page.ts
@@ -28,7 +28,7 @@ export async function load({ fetch, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "cache-control": `public, max-age=${PAGE_MAX_AGE}`,
+      "Cloudflare-CDN-Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
     });
   }
 

--- a/src/routes/embed/documents/[id]-[slug]/+page.ts
+++ b/src/routes/embed/documents/[id]-[slug]/+page.ts
@@ -26,7 +26,7 @@ export async function load({ fetch, url, params, depends, setHeaders }) {
   let settings: Partial<EmbedSettings> = getEmbedSettings(url.searchParams);
 
   setHeaders({
-    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]/annotations/[note_id]/+page.ts
+++ b/src/routes/embed/documents/[id]/annotations/[note_id]/+page.ts
@@ -16,7 +16,7 @@ export async function load({ params, fetch, setHeaders }) {
   }
 
   setHeaders({
-    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]/pages/[page]/+page.ts
+++ b/src/routes/embed/documents/[id]/pages/[page]/+page.ts
@@ -18,7 +18,7 @@ export async function load({ params, fetch, setHeaders }) {
   }
 
   setHeaders({
-    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/projects/[project_id]-[slug]/+page.ts
+++ b/src/routes/embed/projects/[project_id]-[slug]/+page.ts
@@ -44,7 +44,7 @@ export async function load({ params, fetch, url, setHeaders }) {
   }
 
   setHeaders({
-    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(project.data.updated_at).toUTCString(),
   });
 


### PR DESCRIPTION
This changes our cache header from `cache-control` to `Cloudflare-CDN-Cache-Control`, which means only Cloudflare actually caches it. Both netlify and browsers will ignore this header.

Part of #1146 
