### PR TITLE
Remove csrf bypass for dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11025,9 +11025,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.43.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.43.4.tgz",
-      "integrity": "sha512-GfvOq3A/qMRhj2L9eKjxaI8FLqZDh5SY74YzhRKT//u2AvQw96ksEfjuHviC4jg9U08mBVB0Y47EwEJHO4BB4Q==",
+      "version": "2.43.8",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.43.8.tgz",
+      "integrity": "sha512-z21dG8W4g6XtAnK8bMpaSahtPOV6JVhghhco1+GR4H39XEgIxrjIpRoT1Js84c7TmhBzbTkVpZVVPFNNPFsXkQ==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -29,10 +29,6 @@ export default {
       "@/test": "./src/test",
       "@/test/*": "./src/test/*",
     },
-    csrf: {
-      // BUG: https://github.com/sveltejs/kit/issues/8026
-      checkOrigin: process.env.DOCKER === "true" ? false : true,
-    },
   },
 
   // Consult https://svelte.dev/docs#compile-time-svelte-preprocess


### PR DESCRIPTION
CSRF checks now only happen in production, so we no longer need this bypass for when we're running local dev using docker.