### PR TITLE
Catch IO errors in infinite scroll

### DIFF
--- a/src/lib/components/documents/ResultsList.svelte
+++ b/src/lib/components/documents/ResultsList.svelte
@@ -127,7 +127,12 @@
       });
     });
 
-    io.observe(el);
+    try {
+      // sometimes this breaks, so just let the user click the button
+      io.observe(el);
+    } catch (e) {
+      console.error(e);
+    }
     return io;
   }
 


### PR DESCRIPTION
Closes #1180 

If `IntersectionObserver.observe` fails for any reason, we already have a button there to load the next batch of documents. This lets our infinite scroll fail without breaking the page.

I'm not really sure how to test this, TBH, because I've never been able to reproduce the error.