### PR TITLE
Adds a `/translate-changes` skill for Claude Code

### DIFF
--- a/.claude/skills/translate-changes/LANGUAGE_CODES.md
+++ b/.claude/skills/translate-changes/LANGUAGE_CODES.md
@@ -1,0 +1,147 @@
+# Language File Reference
+
+## Supported Languages
+
+| Language | File | Code | Notes |
+|----------|------|------|-------|
+| English (source) | en.json | en | Source of truth for all translations |
+| German | de.json | de | Formal "Sie" form |
+| Spanish | es.json | es | Latin American Spanish |
+| French | fr.json | fr | Standard French |
+| Italian | it.json | it | Standard Italian |
+| Russian | ru.json | ru | Includes ICU plural rules |
+| Ukrainian | uk.json | uk | Includes ICU plural rules |
+
+## File Locations
+
+All files are located in: `/src/langs/json/`
+
+## JSON Structure
+
+Each language file maintains the same nested key structure as `en.json`:
+
+```json
+{
+  "dialog": {
+    "save": "Save",
+    "cancel": "Cancel"
+  },
+  "addonDispatchDialog": {
+    "signedOut": "You must <a href=\"{href}\">sign in</a>..."
+  }
+}
+```
+
+## Special Formatting
+
+### HTML Tags
+
+Many strings contain HTML for links or formatting:
+```json
+"signedOut": "You must <a href=\"{href}\">sign in</a> before..."
+```
+
+Translations MUST preserve the HTML structure exactly.
+
+### Variable Placeholders
+
+Strings may contain variables in curly braces:
+- `{href}` - URLs
+- `{n}` - Numbers
+- `{name}` - Names or identifiers
+
+These MUST remain unchanged in translations.
+
+### ICU MessageFormat
+
+Some strings use ICU MessageFormat for pluralization:
+
+```json
+"labelSelected": "{n, plural, one {# document} other {# documents}}"
+```
+
+Russian and Ukrainian have complex plural rules:
+```json
+"labelSelected": "{n, plural, one {# документ} few {# документа} many {# документов} other {# документов}}"
+```
+
+## Translation Style Guidelines
+
+### German (de.json)
+- Use formal "Sie" form
+- Compound nouns are common
+- Example: "anmelden" (sign in), "ausführen" (execute)
+
+### Spanish (es.json)
+- Latin American Spanish preferred
+- Use "usted" form (formal)
+- Example: "iniciar sesión" (sign in), "ejecutar" (execute)
+
+### French (fr.json)
+- Use "vous" form (formal)
+- Elision rules apply (l' before vowels)
+- Example: "se connecter" (sign in), "exécuter" (execute)
+
+### Italian (it.json)
+- Use "Lei" form (formal in some contexts) or informal based on existing patterns
+- Example: "accedere" (sign in), "eseguire" (execute)
+
+### Russian (ru.json)
+- Cyrillic alphabet
+- Complex case and gender agreement
+- Example: "войти" (sign in), "запустить" (execute)
+
+### Ukrainian (uk.json)
+- Cyrillic alphabet (different from Russian)
+- Similar grammar to Russian but distinct vocabulary
+- Example: "увійти" (sign in), "запустити" (execute)
+
+## Encoding
+
+All JSON files use Unicode escape sequences for non-ASCII characters:
+- `é` becomes `\u00e9`
+- `ñ` becomes `\u00f1`
+- Cyrillic characters are also escaped
+
+The Edit tool handles this automatically - no manual encoding needed.
+
+## Verification Commands
+
+### Check a specific key across all languages
+```bash
+for file in src/langs/json/{de,es,fr,it,ru,uk}.json; do
+  echo "=== $file ==="
+  jq -r '.addonDispatchDialog.signedOut // "MISSING"' "$file"
+done
+```
+
+### Validate JSON syntax
+```bash
+for file in src/langs/json/*.json; do
+  echo "Validating $file..."
+  jq empty "$file" && echo "✓ Valid"
+done
+```
+
+### Compare keys between en.json and another language
+```bash
+diff \
+  <(jq -r 'keys | .[]' src/langs/json/en.json) \
+  <(jq -r 'keys | .[]' src/langs/json/de.json)
+```
+
+## Common Issues
+
+### Missing keys
+- Only translate MODIFIED keys, not missing ones
+- Many existing keys are intentionally untranslated
+
+### Formatting
+- JSON must remain valid after edits
+- Maintain consistent indentation (2 spaces)
+- Commas must be correct (no trailing comma on last item)
+
+### Context
+- Consider the full key path for context
+- Dialog buttons differ from page headers
+- Form labels differ from help text

--- a/.claude/skills/translate-changes/SKILL.md
+++ b/.claude/skills/translate-changes/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: translate-changes
+description: Detects changes to en.json in current branch and translates modified strings to other language files (de, es, fr, it, ru, uk). Only translates modifications, not missing keys.
+allowed-tools: Read, Edit, Bash, Glob, Grep
+---
+
+# Translation Updates Skill
+
+Automatically translates changes made to `src/langs/json/en.json` in the current branch to all other language files.
+
+## Important: Only Modified Keys
+
+This skill ONLY translates keys that have been **modified or added in the current branch**. It does NOT translate pre-existing keys that are missing translations.
+
+## How it works
+
+1. **Detect changes**: Uses `git diff` to find modified keys in en.json (both uncommitted and committed changes)
+2. **Extract modified keys**: Parses the diff to identify new or changed English strings
+3. **Translate**: Generates appropriate translations for each supported language
+4. **Update files**: Applies translations to language-specific JSON files
+
+## Supported Languages
+
+- German (de.json)
+- Spanish (es.json)
+- French (fr.json)
+- Italian (it.json)
+- Russian (ru.json)
+- Ukrainian (uk.json)
+
+All files are located in `src/langs/json/`
+
+## Usage
+
+After modifying strings in `en.json`, simply ask:
+
+```
+translate the changes to en.json
+```
+
+Or invoke the skill directly:
+
+```
+/translate-changes
+```
+
+## Workflow
+
+### Step 1: Detect modifications
+
+The skill detects changes from two sources:
+
+```bash
+# Uncommitted changes (working directory + staged)
+git diff HEAD -- src/langs/json/en.json
+
+# Committed changes in current branch
+git diff main...HEAD -- src/langs/json/en.json
+```
+
+This captures both uncommitted modifications and changes committed in the current branch compared to main.
+
+### Step 2: Parse changes
+
+Look for lines starting with `+` in the diff that contain JSON keys:
+- Lines like `+    "keyName": "Value"` indicate additions or modifications
+- Ignore lines that are just structural changes (commas, brackets)
+
+### Step 3: Extract key paths
+
+For each modified line, determine:
+- The full JSON path (e.g., `addonDispatchDialog.signedOut`)
+- The new English value
+
+### Step 4: Translate
+
+For each modified key:
+1. Generate translations for all 6 languages
+2. Maintain the same HTML structure (e.g., `<a href="{href}">text</a>`)
+3. Preserve placeholders like `{href}`, `{n}`, etc.
+4. Match the tone and formality of existing translations in that language
+
+### Step 5: Update files
+
+For each language file:
+1. Read the current content
+2. Locate the key to update using the JSON path
+3. Use Edit tool to update the specific key
+4. Preserve JSON formatting and structure
+
+## Translation Guidelines
+
+- **Maintain HTML**: If English has HTML tags, keep them in translations
+- **Preserve placeholders**: Variables like `{href}`, `{n}`, etc. must stay unchanged
+- **Match formality**: Use the same level of formality as existing translations
+- **ICU format**: Respect plural rules (e.g., `{n, plural, one {...} other {...}}`)
+- **Context aware**: Consider the key path for context (e.g., button vs paragraph text)
+
+## Example Translations
+
+English:
+```json
+"signedOut": "You must <a href=\"{href}\">sign in</a> before dispatching this add-on."
+```
+
+Translations should maintain:
+- The `<a href="{href}">` structure
+- The `{href}` placeholder
+- Appropriate word order for each language
+
+## Output Format
+
+After translating, show:
+1. Summary of changes detected
+2. List of keys modified
+3. Confirmation of files updated
+4. Verification command to check results
+
+## Verification
+
+After updates, verify with:
+```bash
+for file in src/langs/json/{de,es,fr,it,ru,uk}.json; do
+  echo "=== $file ==="
+  jq -r '.path.to.modified.key // "MISSING"' "$file"
+done
+```
+
+## Notes
+
+- JSON files use Unicode escape sequences (e.g., `\u00e9` for é)
+- The Edit tool will preserve this encoding automatically
+- Always use Edit tool, not Bash sed/awk, to maintain JSON validity
+- Files should remain valid JSON after updates

--- a/.claude/skills/translate-changes/scripts/extract-changes.sh
+++ b/.claude/skills/translate-changes/scripts/extract-changes.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Extract git diff for en.json and show modified keys
+# This script identifies keys that were added or modified in the current branch
+# Detects both committed changes and uncommitted working directory changes
+
+set -euo pipefail
+
+LANG_FILE="src/langs/json/en.json"
+BASE_BRANCH="${1:-main}"
+
+echo "=== Changes to en.json ===" >&2
+echo "" >&2
+
+# Combine uncommitted changes and committed branch changes
+# First, get uncommitted changes (working directory + staged)
+uncommitted_diff=$(git diff HEAD -- "$LANG_FILE" 2>/dev/null || true)
+
+# Then, get committed changes in branch
+committed_diff=$(git diff "$BASE_BRANCH"...HEAD -- "$LANG_FILE" 2>/dev/null || true)
+
+# Combine both diffs and extract modified lines
+# Only lines starting with + that contain key definitions (not just commas or context)
+{
+  if [ -n "$uncommitted_diff" ]; then
+    echo "$uncommitted_diff"
+  fi
+  if [ -n "$committed_diff" ]; then
+    echo "$committed_diff"
+  fi
+} | \
+  grep -E '^\+[^+]' | \
+  grep -E '^\+\s*"[^"]+"\s*:' | \
+  sed 's/^+\s*//' | \
+  sort -u | \
+  head -30
+
+echo "" >&2
+echo "Note: Showing up to 30 modified lines (uncommitted + committed)." >&2
+echo "Uncommitted: 'git diff HEAD -- $LANG_FILE'" >&2
+echo "Committed: 'git diff $BASE_BRANCH...HEAD -- $LANG_FILE'" >&2


### PR DESCRIPTION
This will find any changes to `en.json` in the current branch, comitted or uncomitted. Then, it will update our other localization files in kind, translating the changed English into each language.

Claude's Sonnet model is pretty good at simple localizations. If we want to upgrade this approach to use a different service, we could enhance the skill to make a call to a third-party API (e.g. Google Translate) to retrieve localizations, instead.

In basic testing, it appears that Claude will preserve our `{bracketed}` formatting and not translate those directives into the local language. Adding additional examples into the "Special Formatting" section of `LANGUAGE_CODES.md` would make this more robust.

If we wanted to go _even further_, we could add a GitHub Action that tests whether the current PR introduces any untranslated strings in to the codebase. That feels heavy handed for now, but it's fun to think about!