### PR TITLE
Wrap unbroken words in DocumentListItem

### DIFF
--- a/src/lib/components/documents/DocumentListItem.svelte
+++ b/src/lib/components/documents/DocumentListItem.svelte
@@ -216,6 +216,10 @@ If we're in an embed, we want to open links to documents in new tabs and hide th
     margin: 0;
   }
 
+  .title {
+    overflow-wrap: anywhere;
+  }
+
   .ellipsis {
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/lib/components/documents/stories/DocumentListItem.stories.svelte
+++ b/src/lib/components/documents/stories/DocumentListItem.stories.svelte
@@ -108,10 +108,27 @@
 />
 
 <Story
-  name="Truncate Title"
+  name="Wrap title"
   args={{
     document: {
       ...expanded,
+      description:
+        "Makes David Cameron the new prime minister and installs Nick Clegg as his deputy",
+    },
+    visibleFields: {
+      ...defaultVisibleFields,
+      description: true,
+      fullTitle: false,
+    },
+  }}
+/>
+
+<Story
+  name="Wrap title without breaks"
+  args={{
+    document: {
+      ...expanded,
+      title: "Makes%20David%20Cameron%20the%20new%20prime%20minister%20and%20installs%20Nick%20Clegg%20as%20his%20deputy",
       description:
         "Makes David Cameron the new prime minister and installs Nick Clegg as his deputy",
     },


### PR DESCRIPTION
During a demo, I noticed that some scraper-generated documents have URI encoded titles—these weren't wrapping, because there were no white-space breaks inside them. This guards against the list items overflowing the container.

To review: see the new storybook in Chromatic; I also renamed "Truncate title" to "Wrap title" to better reflect the goal of that story.