### PR TITLE
Enable sorting options for project embeds

### DIFF
--- a/src/lib/api/embed.ts
+++ b/src/lib/api/embed.ts
@@ -1,5 +1,5 @@
 // api utilities for embeds
-import type { Document, Note, Project } from "./types";
+import type { Document, Maybe, Note, Project } from "./types";
 import { BASE_API_URL, EMBED_URL } from "@/config/config.js";
 import * as documents from "$lib/api/documents";
 import * as notes from "$lib/api/notes";
@@ -67,7 +67,10 @@ export function note(document: Document, note: Note, debug: boolean = false) {
 <script src="${resize.href}"></script>`;
 }
 
-export function project(project: Project) {
-  const embedSrc = projects.embedUrl(project);
+export function project(
+  project: Project,
+  params: Maybe<URLSearchParams> = undefined,
+) {
+  const embedSrc = projects.embedUrl(project, params);
   return `<iframe src="${embedSrc.href}" width="100%" height="600px"></iframe>`;
 }

--- a/src/lib/api/projects.ts
+++ b/src/lib/api/projects.ts
@@ -1,5 +1,5 @@
 // api methods for projects
-import type { Page } from "$lib/api/types";
+import type { Maybe, Page } from "$lib/api/types";
 import type {
   APIResponse,
   Document,
@@ -303,6 +303,21 @@ export function canonicalUrl(project: Project): URL {
   return new URL(`/projects/${project.id}-${project.slug}/`, APP_URL);
 }
 
-export function embedUrl(project: Project): URL {
-  return new URL(`/projects/${project.id}-${project.slug}/?embed=1`, EMBED_URL);
+export function embedUrl(
+  project: Project,
+  params: Maybe<URLSearchParams> = undefined,
+): URL {
+  const url = new URL(
+    `/projects/${project.id}-${project.slug}/?embed=1`,
+    EMBED_URL,
+  );
+
+  if (params) {
+    url.search = new URLSearchParams([
+      ...url.searchParams,
+      ...params,
+    ]).toString();
+  }
+
+  return url;
 }

--- a/src/lib/api/tests/embed.test.ts
+++ b/src/lib/api/tests/embed.test.ts
@@ -70,4 +70,14 @@ describe("embed tests", () => {
 
     expect(iframe).toEqual(result);
   });
+
+  test("project embed with params", () => {
+    const iframe = embed.project(
+      project,
+      new URLSearchParams("test=yes&first=1"),
+    );
+    const result = `<iframe src="${EMBED_URL}projects/215178-ocr-reprise/?embed=1&test=yes&first=1" width="100%" height="600px"></iframe>`;
+
+    expect(iframe).toEqual(result);
+  });
 });

--- a/src/lib/api/tests/projects.test.ts
+++ b/src/lib/api/tests/projects.test.ts
@@ -406,6 +406,19 @@ describe("project utils", () => {
       new URL(`/projects/${project.id}-${project.slug}/?embed=1`, EMBED_URL),
     );
   });
+
+  test("projects.embedUrl with params", () => {
+    const url = projects.embedUrl(
+      project,
+      new URLSearchParams("test=yes&first=1"),
+    );
+    expect(url).toStrictEqual(
+      new URL(
+        `/projects/${project.id}-${project.slug}/?embed=1&test=yes&first=1`,
+        EMBED_URL,
+      ),
+    );
+  });
 });
 
 describe("manage project documents", () => {

--- a/src/routes/embed/projects/[project_id]-[slug]/+page.ts
+++ b/src/routes/embed/projects/[project_id]-[slug]/+page.ts
@@ -36,7 +36,14 @@ export async function load({ params, fetch, url, setHeaders }) {
     return error(404, "Project not found");
   }
 
-  const documents = search(`+project:${project_id}`, undefined, fetch);
+  // build our search query, handle sorting options
+  let query = [`+project:${project_id}`];
+  if (url.searchParams.get("sort")) {
+    const sort = url.searchParams.get("sort") ?? "";
+    query.push(`sort:${sort}`);
+  }
+
+  const documents = search(query.join(" ").trim(), undefined, fetch);
 
   if (url.pathname !== embedUrl(project.data).pathname) {
     return redirect(302, embedUrl(project.data));

--- a/src/routes/embed/projects/[project_id]-[slug]/preview/+page.svelte
+++ b/src/routes/embed/projects/[project_id]-[slug]/preview/+page.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
+  import { page } from "$app/state";
+
   import * as embed from "$lib/api/embed";
 
   let { data } = $props();
 
   let project = $derived(data.project);
-  let iframe = $derived(embed.project(project));
+  let params = $derived(
+    [...page.url.searchParams].filter(([k, v]) => k !== "embed"),
+  );
+  let iframe = $derived(embed.project(project, new URLSearchParams(params)));
 </script>
 
 <svelte:head>

--- a/src/routes/embed/projects/[project_id]-[slug]/preview/+page.ts
+++ b/src/routes/embed/projects/[project_id]-[slug]/preview/+page.ts
@@ -1,9 +1,9 @@
-import { error, redirect } from "@sveltejs/kit";
+import { error } from "@sveltejs/kit";
 
 import { EMBED_MAX_AGE } from "@/config/config.js";
 import { get } from "$lib/api/projects";
 
-export async function load({ params, fetch, url, setHeaders }) {
+export async function load({ params, fetch, setHeaders }) {
   let { project_id } = params;
   let project = await get(+project_id, fetch);
 


### PR DESCRIPTION
Minimum shippable version of #1277 

This allows sorting documents in project embeds (and only in embeds) by setting a `sort` query param. There's no UI yet, but it's enough to test the idea.

Demo: https://deploy-preview-1278.muckcloud.com/projects/200000-mitchs-project/preview/?embed=1&sort=title
