### PR TITLE
Migrate toolbars to Svelte 5 syntax

### DIFF
--- a/src/lib/components/addons/DocumentList.svelte
+++ b/src/lib/components/addons/DocumentList.svelte
@@ -50,7 +50,9 @@
         </div>
       {/if}
       <PageToolbar>
-        <Search name="q" {query} slot="center" />
+        {#snippet center()}
+          <Search name="q" {query} />
+        {/snippet}
       </PageToolbar>
     </Flex>
     <svelte:fragment>
@@ -67,29 +69,30 @@
     </svelte:fragment>
 
     <PageToolbar slot="footer">
-      <label slot="left" class="select-all">
-        <input
-          type="checkbox"
-          name="select_all"
-          checked={$selected.length === $visible.size}
-          indeterminate={$selected.length > 0 &&
-            $selected.length < $visible.size}
-          on:change={selectAll}
-        />
-        {#if $selected.length > 0}
-          {$selected.length.toLocaleString()} {$_("inputs.selected")}
-        {:else}
-          {$_("inputs.selectAll")}
-        {/if}
-      </label>
-
-      <svelte:fragment slot="right">
+      {#snippet left()}
+        <label class="select-all">
+          <input
+            type="checkbox"
+            name="select_all"
+            checked={$selected.length === $visible.size}
+            indeterminate={$selected.length > 0 &&
+              $selected.length < $visible.size}
+            on:change={selectAll}
+          />
+          {#if $selected.length > 0}
+            {$selected.length.toLocaleString()} {$_("inputs.selected")}
+          {:else}
+            {$_("inputs.selectAll")}
+          {/if}
+        </label>
+      {/snippet}
+      {#snippet right()}
         {#if $visible && $total}
           {$_("inputs.resultsCount", {
             values: { n: $visible.size, total: $total },
           })}
         {/if}
-      </svelte:fragment>
+      {/snippet}
     </PageToolbar>
   </ContentLayout>
 </div>

--- a/src/lib/components/common/Tooltip.svelte
+++ b/src/lib/components/common/Tooltip.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Component } from "svelte";
+  import type { Component, Snippet } from "svelte";
   import type { Maybe } from "$lib/api/types";
 
   import { writable } from "svelte/store";
@@ -18,7 +18,7 @@
     placement?: Placement;
     offset?: number;
     arrow?: boolean;
-    children?: import("svelte").Snippet;
+    children?: Snippet;
   }
 
   let {

--- a/src/lib/components/layouts/AddOnBrowser.svelte
+++ b/src/lib/components/layouts/AddOnBrowser.svelte
@@ -63,7 +63,9 @@
     <main>
       <ContentLayout>
         <PageToolbar slot="header">
-          <Search name="query" {query} slot="center" />
+          {#snippet center()}
+            <Search name="query" {query} />
+          {/snippet}
         </PageToolbar>
         {#if showTip}
           <div class="tip">
@@ -110,7 +112,7 @@
         {/await}
 
         <PageToolbar slot="footer">
-          <svelte:fragment slot="center">
+          {#snippet center()}
             {#await addons}
               <Paginator />
             {:then { data: page }}
@@ -125,7 +127,7 @@
                 }}
               />
             {/await}
-          </svelte:fragment>
+          {/snippet}
         </PageToolbar>
       </ContentLayout>
     </main>

--- a/src/lib/components/toolbars/AnnotationToolbar.svelte
+++ b/src/lib/components/toolbars/AnnotationToolbar.svelte
@@ -7,7 +7,7 @@
   import Tooltip from "$lib/components/common/Tooltip.svelte";
   import { getViewerHref } from "$lib/utils/viewer";
 
-  let width: number;
+  let width: number | undefined = $state();
 </script>
 
 <div class="toolbar" bind:clientWidth={width}>

--- a/src/lib/components/toolbars/DocumentListToolbar.svelte
+++ b/src/lib/components/toolbars/DocumentListToolbar.svelte
@@ -11,35 +11,41 @@
 
   import { remToPx } from "$lib/utils/layout";
 
-  export let query: string = "";
+  interface Props {
+    query?: string;
+  }
 
-  let headerToolbarWidth: number;
+  let { query = "" }: Props = $props();
+
+  let headerToolbarWidth: number = $state(800);
 </script>
 
 <PageToolbar bind:width={headerToolbarWidth}>
-  <div class="items" slot="center">
-    <div style:flex="1 1 auto">
-      <Search name="q" {query} placeholder={$_("common.search")} />
-      <p class="help" class:hide={headerToolbarWidth < remToPx(38)}>
-        {@html $_("search.help")}
-        <a target="_blank" href="/help/search/">
-          {$_("search.more")}
-        </a>
-      </p>
+  {#snippet center()}
+    <div class="items">
+      <div style:flex="1 1 auto">
+        <Search name="q" {query} placeholder={$_("common.search")} />
+        <p class="help" class:hide={headerToolbarWidth < remToPx(38)}>
+          {@html $_("search.help")}
+          <a target="_blank" href="/help/search/">
+            {$_("search.more")}
+          </a>
+        </p>
+      </div>
+      <div class="margin-xs" class:hide={headerToolbarWidth < remToPx(38)}>
+        <Dropdown>
+          <NavItem slot="anchor">
+            <Eye16 slot="start" />
+            {$_("documentBrowser.fieldsAnchor")}
+            <ChevronDown12 slot="end" />
+          </NavItem>
+          <Menu slot="inner">
+            <VisibleFields />
+          </Menu>
+        </Dropdown>
+      </div>
     </div>
-    <div class="margin-xs" class:hide={headerToolbarWidth < remToPx(38)}>
-      <Dropdown>
-        <NavItem slot="anchor">
-          <Eye16 slot="start" />
-          {$_("documentBrowser.fieldsAnchor")}
-          <ChevronDown12 slot="end" />
-        </NavItem>
-        <Menu slot="inner">
-          <VisibleFields />
-        </Menu>
-      </Dropdown>
-    </div>
-  </div>
+  {/snippet}
 </PageToolbar>
 
 <style>

--- a/src/lib/components/toolbars/LoadingToolbar.svelte
+++ b/src/lib/components/toolbars/LoadingToolbar.svelte
@@ -2,18 +2,24 @@
   import type { Nullable } from "$lib/api/types";
   import PageToolbar from "./PageToolbar.svelte";
 
-  export let progress: Nullable<number> = null;
+  interface Props {
+    progress?: Nullable<number>;
+  }
+
+  let { progress = null }: Props = $props();
 </script>
 
 <PageToolbar>
-  <div class="container" slot="center">
-    <p>Loading PDF…</p>
-    {#if progress}
-      <progress value={progress} data-chromatic="ignore"></progress>
-    {:else}
-      <progress data-chromatic="ignore"></progress>
-    {/if}
-  </div>
+  {#snippet center()}
+    <div class="container">
+      <p>Loading PDF…</p>
+      {#if progress}
+        <progress value={progress} data-chromatic="ignore"></progress>
+      {:else}
+        <progress data-chromatic="ignore"></progress>
+      {/if}
+    </div>
+  {/snippet}
 </PageToolbar>
 
 <style>

--- a/src/lib/components/toolbars/PageToolbar.svelte
+++ b/src/lib/components/toolbars/PageToolbar.svelte
@@ -4,23 +4,32 @@
   It's slotted for composition based on the page it's on.
 -->
 <script lang="ts">
-  export let width: undefined | number = undefined;
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    width?: undefined | number;
+    left?: Snippet;
+    center?: Snippet;
+    right?: Snippet;
+  }
+
+  let { width = $bindable(undefined), left, center, right }: Props = $props();
 </script>
 
 <div class="toolbar" bind:clientWidth={width}>
-  {#if $$slots.left}
+  {#if left}
     <div class="left">
-      <slot name="left" />
+      {@render left()}
     </div>
   {/if}
-  {#if $$slots.center}
+  {#if center}
     <div class="center">
-      <slot name="center" />
+      {@render center()}
     </div>
   {/if}
-  {#if $$slots.right}
+  {#if right}
     <div class="right">
-      <slot name="right" />
+      {@render right()}
     </div>
   {/if}
 </div>

--- a/src/lib/components/toolbars/PaginationToolbar.svelte
+++ b/src/lib/components/toolbars/PaginationToolbar.svelte
@@ -35,18 +35,20 @@
   const currentMode = getCurrentMode();
   const currentPage = getCurrentPage();
 
-  let sectionsOpen = false;
-  let width: number;
+  let sectionsOpen = $state(false);
+  let width: number = $state(800);
 
-  $: BREAKPOINTS = {
+  let BREAKPOINTS = $derived({
     TWO_ROWS: width <= remToPx(34),
-  };
+  });
 
-  $: document = $documentStore;
-  $: sections = document.sections ?? [];
-  $: totalPages = document.page_count;
-  $: showPDF = ["document", "annotating", "redacting"].includes($currentMode);
-  $: canEditSections = !embed && document.edit_access;
+  let document = $derived($documentStore);
+  let sections = $derived(document.sections ?? []);
+  let totalPages = $derived(document.page_count);
+  let showPDF = $derived(
+    ["document", "annotating", "redacting"].includes($currentMode),
+  );
+  let canEditSections = $derived(!embed && document.edit_access);
 
   // pagination
   function next() {
@@ -145,7 +147,9 @@
 {#if canEditSections && sectionsOpen}
   <Portal>
     <Modal on:close={() => (sectionsOpen = false)}>
-      <h1 slot="title">{$_("sections.edit")}</h1>
+      {#snippet title()}
+        <h1>{$_("sections.edit")}</h1>
+      {/snippet}
       <EditSections {document} on:close={() => (sectionsOpen = false)} />
     </Modal>
   </Portal>

--- a/src/lib/components/toolbars/ReadingToolbar.svelte
+++ b/src/lib/components/toolbars/ReadingToolbar.svelte
@@ -38,9 +38,9 @@ Assumes it's a child of a ViewerContext
     isEmbedded,
   } from "$lib/components/viewer/ViewerContext.svelte";
 
-  export let query = getQuery($page.url, "q");
+  let { query = getQuery($page.url, "q") } = $props();
 
-  let width: number;
+  let width: number = $state(800);
 
   const documentStore = getDocument();
   const mode = getCurrentMode();
@@ -76,21 +76,23 @@ Assumes it's a child of a ViewerContext
     search: Search16,
   };
 
-  $: document = $documentStore;
-  $: canWrite = !embed && document.edit_access;
-  $: BREAKPOINTS = {
+  let document = $derived($documentStore);
+  let canWrite = $derived(!embed && document.edit_access);
+  let BREAKPOINTS = $derived({
     READ_MENU: width > remToPx(52),
     WRITE_MENU: width < remToPx(37),
     SEARCH_MENU: width < remToPx(24),
-  };
+  });
 
-  $: current = Array.from(readModeDropdownItems ?? []).find(
-    ([value]) => value === $mode,
-  )?.[1];
+  let current = $derived(
+    Array.from(readModeDropdownItems ?? []).find(
+      ([value]) => value === $mode,
+    )?.[1],
+  );
 </script>
 
 <PageToolbar bind:width>
-  <svelte:fragment slot="left">
+  {#snippet left()}
     {#if BREAKPOINTS.READ_MENU}
       <div class="tabs" role="tablist">
         {#each readModeTabs.entries() as [value, name]}
@@ -98,7 +100,10 @@ Assumes it's a child of a ViewerContext
             active={$mode === value}
             href={getViewerHref({ document, mode: value, embed, query })}
           >
-            <svelte:component this={icons[value]} />
+            {@const TabIcon = icons[value]}
+            {#if TabIcon}
+              <TabIcon />
+            {/if}
             {name}
           </Tab>
         {/each}
@@ -106,7 +111,10 @@ Assumes it's a child of a ViewerContext
     {:else}
       <Dropdown position="bottom-start">
         <NavItem slot="anchor">
-          <svelte:component this={icons[$mode]} slot="start" />
+          {@const CurrentModeIcon = icons[$mode]}
+          {#if CurrentModeIcon}
+            <CurrentModeIcon slot="start" />
+          {/if}
           {current}
           <ChevronDown12 slot="end" />
         </NavItem>
@@ -118,7 +126,10 @@ Assumes it's a child of a ViewerContext
               preserveQS
               on:click={close}
             >
-              <svelte:component this={icons[value]} slot="icon" />
+              {@const ReadModeIcon = icons[value]}
+              {#if ReadModeIcon}
+                <ReadModeIcon slot="icon" />
+              {/if}
               {name}
             </MenuItem>
           {/each}
@@ -129,7 +140,10 @@ Assumes it's a child of a ViewerContext
                 href={getViewerHref({ document, mode: value, embed })}
                 on:click={close}
               >
-                <svelte:component this={icons[value]} slot="icon" />
+                {@const WriteModeIcon = icons[value]}
+                {#if WriteModeIcon}
+                  <WriteModeIcon slot="icon" />
+                {/if}
                 {name}
               </MenuItem>
             {/each}
@@ -137,33 +151,38 @@ Assumes it's a child of a ViewerContext
         </Menu>
       </Dropdown>
     {/if}
-  </svelte:fragment>
-  <Flex justify="end" slot="right">
-    {#if !BREAKPOINTS.WRITE_MENU && canWrite}
-      {#each writeModes as [value, name]}
-        <Button
-          ghost
-          href={getViewerHref({ document, mode: value, embed, query })}
-        >
-          <span class="icon"><svelte:component this={icons[value]} /></span>
-          {name}
-        </Button>
-      {/each}
-    {/if}
-    {#if BREAKPOINTS.SEARCH_MENU}
-      <Dropdown position="bottom-end">
-        <Button minW={false} ghost slot="anchor">
-          <Search16 />
-          {$_("common.search")}
-        </Button>
-        <Menu slot="inner">
-          <Search name="q" {query} otherParams={{ mode: "search" }} />
-        </Menu>
-      </Dropdown>
-    {:else}
-      <Search name="q" {query} otherParams={{ mode: "search" }} />
-    {/if}
-  </Flex>
+  {/snippet}
+  {#snippet right()}
+    <Flex justify="end">
+      {#if !BREAKPOINTS.WRITE_MENU && canWrite}
+        {#each writeModes as [value, name]}
+          <Button
+            ghost
+            href={getViewerHref({ document, mode: value, embed, query })}
+          >
+            {@const WriteModeIcon = icons[value]}
+            {#if WriteModeIcon}
+              <span class="icon"><WriteModeIcon /></span>
+            {/if}
+            {name}
+          </Button>
+        {/each}
+      {/if}
+      {#if BREAKPOINTS.SEARCH_MENU}
+        <Dropdown position="bottom-end">
+          <Button slot="anchor" minW={false} ghost>
+            <Search16 />
+            {$_("common.search")}
+          </Button>
+          <Menu slot="inner">
+            <Search name="q" {query} otherParams={{ mode: "search" }} />
+          </Menu>
+        </Dropdown>
+      {:else}
+        <Search name="q" {query} otherParams={{ mode: "search" }} />
+      {/if}
+    </Flex>
+  {/snippet}
 </PageToolbar>
 
 <style>

--- a/src/lib/components/toolbars/RedactionToolbar.svelte
+++ b/src/lib/components/toolbars/RedactionToolbar.svelte
@@ -28,17 +28,17 @@ Assumes it's a child of a ViewerContext
   import { getDocument } from "../viewer/ViewerContext.svelte";
 
   const documentStore = getDocument();
-  $: document = $documentStore;
+  let document = $derived($documentStore);
 
-  let width: number;
-  let confirmOpen = false;
+  let width: number = $state(800);
+  let confirmOpen = $state(false);
 
-  $: BREAKPOINTS = {
+  let BREAKPOINTS = $derived({
     SHOW_LABELS: width > remToPx(32),
     X_SMALL: width < remToPx(24),
-  };
+  });
 
-  $: hasRedactions = $redactions.length > 0;
+  let hasRedactions = $derived($redactions.length > 0);
 
   function onCancel() {
     const href = getViewerHref({ document });
@@ -105,7 +105,9 @@ Assumes it's a child of a ViewerContext
 {#if confirmOpen}
   <Portal>
     <Modal on:close={() => (confirmOpen = false)}>
-      <h1 slot="title">{$_("redact.confirmTitle")}</h1>
+      {#snippet title()}
+        <h1>{$_("redact.confirmTitle")}</h1>
+      {/snippet}
       <ConfirmRedaction {document} on:close={() => (confirmOpen = false)} />
     </Modal>
   </Portal>

--- a/src/lib/components/toolbars/stories/AnnotationToolbar.stories.svelte
+++ b/src/lib/components/toolbars/stories/AnnotationToolbar.stories.svelte
@@ -1,33 +1,21 @@
-<script lang="ts" context="module">
-  import type { Meta } from "@storybook/svelte";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import AnnotationToolbar from "../AnnotationToolbar.svelte";
-  import { Template, Story } from "@storybook/addon-svelte-csf";
 
-  import { document } from "@/test/fixtures/documents";
-
-  export const meta: Meta = {
+  const { Story } = defineMeta({
     title: "Toolbars / Annotation",
     component: AnnotationToolbar,
     parameters: {
       layout: "fullscreen",
     },
-  };
-
-  let args = {
-    document,
-  };
+  });
 </script>
 
-<Template let:args>
-  <AnnotationToolbar {...args} />
-</Template>
+<Story name="Default" />
 
-<Story name="Default" {args} />
-
-<Story name="Desktop" {args} />
+<Story name="Desktop" />
 
 <Story
-  {args}
   name="Tablet (H)"
   parameters={{
     viewport: { defaultOrientation: "landscape", defaultViewport: "tablet" },
@@ -39,7 +27,6 @@
   parameters={{
     viewport: { defaultOrientation: "tablet", defaultViewport: "tablet" },
   }}
-  {args}
 />
 
 <Story
@@ -47,7 +34,6 @@
   parameters={{
     viewport: { defaultOrientation: "portrait", defaultViewport: "mobile2" },
   }}
-  {args}
 />
 
 <Story
@@ -55,5 +41,4 @@
   parameters={{
     viewport: { defaultOrientation: "portrait", defaultViewport: "mobile1" },
   }}
-  {args}
 />

--- a/src/lib/components/toolbars/stories/LoadingToolbar.stories.svelte
+++ b/src/lib/components/toolbars/stories/LoadingToolbar.stories.svelte
@@ -1,24 +1,15 @@
-<script lang="ts" context="module">
-  import type { Meta } from "@storybook/svelte";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import LoadingToolbar from "../LoadingToolbar.svelte";
-  import { Story, Template } from "@storybook/addon-svelte-csf";
 
-  export const meta: Meta = {
+  const { Story } = defineMeta({
     title: "Toolbars / Loading",
     component: LoadingToolbar,
     parameters: {
       layout: "fullscreen",
     },
-  };
-
-  let args = {
-    progress: 0.5,
-  };
+  });
 </script>
 
-<Template let:args>
-  <LoadingToolbar {...args} />
-</Template>
-
-<Story name="With Progress" {args} />
-<Story name="Indeterminate" args={{ ...args, progress: undefined }} />
+<Story name="With Progress" args={{ progress: 0.5 }} />
+<Story name="Indeterminate" args={{ progress: undefined }} />

--- a/src/lib/components/toolbars/stories/PageToolbar.stories.svelte
+++ b/src/lib/components/toolbars/stories/PageToolbar.stories.svelte
@@ -1,35 +1,45 @@
-<script context="module" lang="ts">
-  import { Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import PageToolbar from "../PageToolbar.svelte";
   import Checkbox from "../../inputs/Checkbox.svelte";
   import Paginator from "$lib/components/common/Paginator.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Toolbars / Page Toolbar",
     component: PageToolbar,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
-  };
+  });
 </script>
 
-<Story name="slots">
+<Story name="slots" asChild>
   <PageToolbar>
-    <p slot="left">Left</p>
-    <p slot="center">Center</p>
-    <p slot="right">Right</p>
+    {#snippet left()}
+      <p>Left</p>
+    {/snippet}
+    {#snippet center()}
+      <p>Center</p>
+    {/snippet}
+    {#snippet right()}
+      <p>Right</p>
+    {/snippet}
   </PageToolbar>
 </Story>
 
-<Story name="paginator">
+<Story name="paginator" asChild>
   <PageToolbar>
-    <Checkbox label="Select all" slot="left" />
-
-    <Paginator slot="center" has_next has_previous page={1} totalPages={100} />
-
-    <select name="per_page" slot="right">
-      <option value="25">25 results per page</option>
-      <option value="50">50 results per page</option>
-      <option value="100">100 results per page</option>
-    </select>
+    {#snippet left()}
+      <Checkbox label="Select all" />
+    {/snippet}
+    {#snippet center()}
+      <Paginator has_next has_previous page={1} totalPages={100} />
+    {/snippet}
+    {#snippet right()}
+      <select name="per_page">
+        <option value="25">25 results per page</option>
+        <option value="50">50 results per page</option>
+        <option value="100">100 results per page</option>
+      </select>
+    {/snippet}
   </PageToolbar>
 </Story>

--- a/src/lib/components/toolbars/stories/PaginationToolbar.stories.svelte
+++ b/src/lib/components/toolbars/stories/PaginationToolbar.stories.svelte
@@ -1,35 +1,28 @@
-<script lang="ts" context="module">
-  import type { Meta } from "@storybook/svelte";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import PaginationToolbar from "../PaginationToolbar.svelte";
-  import { Template, Story } from "@storybook/addon-svelte-csf";
 
-  import { document } from "@/test/fixtures/documents";
-
-  export const meta: Meta = {
+  const { Story } = defineMeta({
     title: "Toolbars / Pagination",
     component: PaginationToolbar,
     parameters: {
       layout: "fullscreen",
     },
-  };
-
-  let args = {
-    document,
-  };
+    render: template,
+  });
 </script>
 
-<Template let:args>
+{#snippet template()}
   <div class="vh justify-end">
-    <PaginationToolbar {...args} />
+    <PaginationToolbar />
   </div>
-</Template>
+{/snippet}
 
-<Story name="Default" {args} />
+<Story name="Default" />
 
-<Story name="Desktop" {args} />
+<Story name="Desktop" />
 
 <Story
-  {args}
   name="Tablet (H)"
   parameters={{
     viewport: { defaultOrientation: "landscape", defaultViewport: "tablet" },
@@ -41,7 +34,6 @@
   parameters={{
     viewport: { defaultOrientation: "tablet", defaultViewport: "tablet" },
   }}
-  {args}
 />
 
 <Story
@@ -49,7 +41,6 @@
   parameters={{
     viewport: { defaultOrientation: "portrait", defaultViewport: "mobile2" },
   }}
-  {args}
 />
 
 <Story
@@ -57,7 +48,6 @@
   parameters={{
     viewport: { defaultOrientation: "portrait", defaultViewport: "mobile1" },
   }}
-  {args}
 />
 
 <style>

--- a/src/lib/components/toolbars/stories/ReadingToolbar.stories.svelte
+++ b/src/lib/components/toolbars/stories/ReadingToolbar.stories.svelte
@@ -1,33 +1,21 @@
-<script lang="ts" context="module">
-  import type { Meta } from "@storybook/svelte";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import ReadingToolbar from "../ReadingToolbar.svelte";
-  import { Template, Story } from "@storybook/addon-svelte-csf";
 
-  import { document } from "@/test/fixtures/documents";
-
-  export const meta: Meta = {
+  const { Story } = defineMeta({
     title: "Toolbars / Reading",
     component: ReadingToolbar,
     parameters: {
       layout: "fullscreen",
     },
-  };
-
-  let args = {
-    document,
-  };
+  });
 </script>
 
-<Template let:args>
-  <ReadingToolbar {...args} />
-</Template>
+<Story name="Default" />
 
-<Story name="Default" {args} />
-
-<Story name="Desktop" {args} />
+<Story name="Desktop" />
 
 <Story
-  {args}
   name="Tablet (H)"
   parameters={{
     viewport: { defaultOrientation: "landscape", defaultViewport: "tablet" },
@@ -39,7 +27,6 @@
   parameters={{
     viewport: { defaultOrientation: "tablet", defaultViewport: "tablet" },
   }}
-  {args}
 />
 
 <Story
@@ -47,7 +34,6 @@
   parameters={{
     viewport: { defaultOrientation: "portrait", defaultViewport: "mobile2" },
   }}
-  {args}
 />
 
 <Story
@@ -55,5 +41,4 @@
   parameters={{
     viewport: { defaultOrientation: "portrait", defaultViewport: "mobile1" },
   }}
-  {args}
 />

--- a/src/lib/components/toolbars/stories/RedactionToolbar.stories.svelte
+++ b/src/lib/components/toolbars/stories/RedactionToolbar.stories.svelte
@@ -1,33 +1,21 @@
-<script lang="ts" context="module">
-  import type { Meta } from "@storybook/svelte";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import RedactionToolbar from "../RedactionToolbar.svelte";
-  import { Template, Story } from "@storybook/addon-svelte-csf";
 
-  import { document } from "@/test/fixtures/documents";
-
-  export const meta: Meta = {
+  const { Story } = defineMeta({
     title: "Toolbars / Redaction",
     component: RedactionToolbar,
     parameters: {
       layout: "fullscreen",
     },
-  };
-
-  let args = {
-    document,
-  };
+  });
 </script>
 
-<Template let:args>
-  <RedactionToolbar {...args} />
-</Template>
+<Story name="Default" />
 
-<Story name="Default" {args} />
-
-<Story name="Desktop" {args} />
+<Story name="Desktop" />
 
 <Story
-  {args}
   name="Tablet (H)"
   parameters={{
     viewport: { defaultOrientation: "landscape", defaultViewport: "tablet" },
@@ -39,7 +27,6 @@
   parameters={{
     viewport: { defaultOrientation: "tablet", defaultViewport: "tablet" },
   }}
-  {args}
 />
 
 <Story
@@ -47,7 +34,6 @@
   parameters={{
     viewport: { defaultOrientation: "portrait", defaultViewport: "mobile2" },
   }}
-  {args}
 />
 
 <Story
@@ -55,5 +41,4 @@
   parameters={{
     viewport: { defaultOrientation: "portrait", defaultViewport: "mobile1" },
   }}
-  {args}
 />

--- a/src/routes/(app)/projects/+page.svelte
+++ b/src/routes/(app)/projects/+page.svelte
@@ -75,12 +75,13 @@
         </div>
       {/if}
       <PageToolbar>
-        <Search
-          slot="center"
-          name="query"
-          placeholder={$_("projects.placeholder.projects")}
-          {query}
-        />
+        {#snippet center()}
+          <Search
+            name="query"
+            placeholder={$_("projects.placeholder.projects")}
+            {query}
+          />
+        {/snippet}
       </PageToolbar>
       {#if $sidebars["action"] === false}
         <div class="toolbar w-auto">
@@ -102,13 +103,14 @@
     {/each}
 
     <PageToolbar slot="footer">
-      <Paginator
-        slot="center"
-        has_next={Boolean(next)}
-        has_previous={Boolean(previous)}
-        on:next={() => paginate(next)}
-        on:previous={() => paginate(previous)}
-      />
+      {#snippet center()}
+        <Paginator
+          has_next={Boolean(next)}
+          has_previous={Boolean(previous)}
+          on:next={() => paginate(next)}
+          on:previous={() => paginate(previous)}
+        />
+      {/snippet}
     </PageToolbar>
   </ContentLayout>
 


### PR DESCRIPTION
Closes #1247 

No big changes here, just migrating a folder of components to Svelte 5 syntax.