### PR TITLE
Hide the Upload by Email option

### DIFF
--- a/src/lib/components/accounts/UserMenu.svelte
+++ b/src/lib/components/accounts/UserMenu.svelte
@@ -7,20 +7,17 @@
     type Placement,
   } from "$lib/components/common/Dropdown.svelte";
 
-  import Portal from "$lib/components/layouts/Portal.svelte";
+  import Avatar from "./Avatar.svelte";
   import NavItem from "$lib/components/common/NavItem.svelte";
   import {
     ChevronDown12,
     Gear16,
-    Paperclip16,
     ChevronUp12,
     SignOut16,
   } from "svelte-octicons";
   import Menu from "$lib/components/common/Menu.svelte";
-  import Mailkey from "./Mailkey.svelte";
 
   import { SQUARELET_BASE, SIGN_OUT_URL } from "@/config/config.js";
-  import Avatar from "./Avatar.svelte";
   import { remToPx } from "$lib/utils/layout";
   import { getUserName } from "$lib/api/accounts";
 
@@ -32,11 +29,6 @@
   let { user, position = "bottom-end" }: Props = $props();
 
   let width: number | undefined = $state();
-
-  let mailkeyOpen = $state(false);
-  function setMailkeyOpen(open?: boolean) {
-    mailkeyOpen = open ?? !mailkeyOpen;
-  }
 </script>
 
 <svelte:window bind:innerWidth={width} />
@@ -60,27 +52,13 @@
       <Gear16 slot="start" />
       {$_("authSection.user.acctSettings")}
     </NavItem>
-    <NavItem
-      hover
-      on:click={() => {
-        setMailkeyOpen(true);
-        close();
-      }}
-    >
-      <Paperclip16 slot="start" />
-      {$_("authSection.user.uploadEmail")}
-    </NavItem>
+
     <NavItem href={SIGN_OUT_URL} on:click={close}>
       <SignOut16 slot="start" />
       {$_("authSection.user.signOut")}
     </NavItem>
   </Menu>
 </Dropdown>
-{#if mailkeyOpen}
-  <Portal>
-    <Mailkey on:close={() => setMailkeyOpen(false)} />
-  </Portal>
-{/if}
 
 <style>
   .dropdownArrow {

--- a/src/lib/components/accounts/stories/Avatar.stories.svelte
+++ b/src/lib/components/accounts/stories/Avatar.stories.svelte
@@ -1,39 +1,37 @@
-<script lang="ts" context="module">
-  import { Story, Template } from "@storybook/addon-svelte-csf";
+<script lang="ts" module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
 
   import { me, organization } from "@/test/fixtures/accounts";
 
   import Avatar from "../Avatar.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Accounts / Avatar",
     component: Avatar,
     parameters: { layout: "centered" },
-  };
+  });
 </script>
 
-<Template let:args>
-  <Avatar {...args} />
-</Template>
-
 <Story name="With Image (User)" args={{ user: me }} />
+
 <Story
   name="Without Image (User)"
   args={{
     user: {
       ...me,
-      avatar_url: null,
+      avatar_url: undefined,
     },
   }}
 />
 
 <Story name="With Image (Org)" args={{ org: organization }} />
+
 <Story
   name="Without Image (Org)"
   args={{
     org: {
       ...organization,
-      avatar_url: null,
+      avatar_url: "",
     },
   }}
 />

--- a/src/lib/components/accounts/stories/Mailkey.stories.svelte
+++ b/src/lib/components/accounts/stories/Mailkey.stories.svelte
@@ -1,25 +1,21 @@
-<script lang="ts" context="module">
-  import { Story, Template } from "@storybook/addon-svelte-csf";
-  import { action } from "@storybook/addon-actions";
+<script lang="ts" module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
 
   import Mailkey from "../Mailkey.svelte";
   import { mailkey } from "@/test/handlers/accounts";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Accounts / Mailkey",
     component: Mailkey,
     parameters: { layout: "fullscreen" },
-  };
+  });
 </script>
-
-<Template let:args>
-  <Mailkey on:close={action("close")} />
-</Template>
 
 <Story
   name="Success"
   parameters={{ msw: { handlers: [mailkey.create, mailkey.delete] } }}
 />
+
 <Story
   name="Error"
   parameters={{ msw: { handlers: [mailkey.createError, mailkey.deleteError] } }}

--- a/src/lib/components/accounts/stories/Unverified.stories.svelte
+++ b/src/lib/components/accounts/stories/Unverified.stories.svelte
@@ -1,18 +1,16 @@
-<script context="module" lang="ts">
-  import { Story } from "@storybook/addon-svelte-csf";
+<script lang="ts" module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import Unverified from "../Unverified.svelte";
 
   import { me } from "@/test/fixtures/accounts";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Accounts / Unverified",
     component: Unverified,
     parameters: { layout: "centered" },
-  };
+  });
 
   const user = { ...me, verified_journalist: false };
 </script>
 
-<Story name="default">
-  <Unverified {user} />
-</Story>
+<Story name="default" args={{ user }} />

--- a/src/lib/components/accounts/stories/UserMenu.stories.svelte
+++ b/src/lib/components/accounts/stories/UserMenu.stories.svelte
@@ -1,18 +1,14 @@
-<script lang="ts" context="module">
-  import { Story, Template } from "@storybook/addon-svelte-csf";
+<script lang="ts" module>
+  import { defineMeta } from "@storybook/addon-svelte-csf";
 
   import UserMenu from "../UserMenu.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Accounts / User Menu",
     component: UserMenu,
     parameters: { layout: "centered" },
-  };
+  });
 </script>
-
-<Template let:args>
-  <UserMenu {...args} />
-</Template>
 
 <Story
   name="Signed In"
@@ -31,6 +27,7 @@
         slug: "lasserallan",
         monthly_credits: 2000,
         purchased_credits: 0,
+        uuid: "org-9ae6ba3f-d5d4-456c-a7b7-0e83512dfd98",
       },
       organizations: [40742, 125],
       admin_organizations: [40742],
@@ -40,12 +37,13 @@
     },
   }}
 />
+
 <Story
   name="Missing Avatar"
   args={{
     user: {
       id: 110237,
-      avatar_url: null,
+      avatar_url: undefined,
       name: "Allan Lasser",
       organization: {
         id: 40742,
@@ -66,13 +64,14 @@
     },
   }}
 />
+
 <Story
   name="Missing Name"
   args={{
     user: {
       id: 110237,
-      avatar_url: null,
-      name: null,
+      avatar_url: undefined,
+      name: undefined,
       organization: {
         id: 40742,
         avatar_url:

--- a/src/lib/components/accounts/tests/__snapshots__/UserMenu.test.ts.snap
+++ b/src/lib/components/accounts/tests/__snapshots__/UserMenu.test.ts.snap
@@ -4,7 +4,6 @@ exports[`UserMenu 1`] = `
 <div>
   <!---->
   <!---->
-  <!---->
    
   <div
     class="anchor svelte-s83qhf"
@@ -113,40 +112,6 @@ exports[`UserMenu 1`] = `
       <!---->
        
       <!---->
-      <span
-        class="navItem container svelte-1qzwmj4 hover"
-        role="button"
-        tabindex="0"
-        title=""
-      >
-        <svg
-          class="octicon octicon-paperclip"
-          height="16"
-          slot="start"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <!---->
-          <path
-            d="M12.212 3.02a1.753 1.753 0 0 0-2.478.003l-5.83 5.83a3.007 3.007 0 0 0-.88 2.127c0 .795.315 1.551.88 2.116.567.567 1.333.89 2.126.89.79 0 1.548-.321 2.116-.89l5.48-5.48a.75.75 0 0 1 1.061 1.06l-5.48 5.48a4.492 4.492 0 0 1-3.177 1.33c-1.2 0-2.345-.487-3.187-1.33a4.483 4.483 0 0 1-1.32-3.177c0-1.195.475-2.341 1.32-3.186l5.83-5.83a3.25 3.25 0 0 1 5.553 2.297c0 .863-.343 1.691-.953 2.301L7.439 12.39c-.375.377-.884.59-1.416.593a1.998 1.998 0 0 1-1.412-.593 1.992 1.992 0 0 1 0-2.828l5.48-5.48a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-5.48 5.48a.492.492 0 0 0 0 .707.499.499 0 0 0 .352.154.51.51 0 0 0 .356-.154l5.833-5.827a1.755 1.755 0 0 0 0-2.481Z"
-          />
-        </svg>
-        <!---->
-         
-        <span
-          class="label svelte-1qzwmj4"
-        >
-          Upload via Email
-          <!---->
-        </span>
-         
-        <!---->
-      </span>
-      
-      <!---->
-       
-      <!---->
       <a
         class="navItem container svelte-1qzwmj4"
         href="https://api.dev.documentcloud.org/accounts/logout/"
@@ -182,9 +147,6 @@ exports[`UserMenu 1`] = `
     </div>
     <!---->
   </div>
-  <!---->
-   
-  <!---->
   
   
 </div>


### PR DESCRIPTION
Took the option out of the user menu and removed related imports. Easy to put back if we solve https://github.com/MuckRock/documentcloud/issues/374.

Also updated storybook files in `src/lib/components/accounts` to use the new CSF format while I was here.