### PR TITLE
Render Markdown in project descriptions

### DIFF
--- a/src/lib/components/projects/ProjectHeader.svelte
+++ b/src/lib/components/projects/ProjectHeader.svelte
@@ -47,7 +47,7 @@
     {/if}
   </Flex>
   {#if project.description}
-    <div class="description">{@html renderMarkdown(project.description ?? "")}</div>
+    <div class="description">{@html renderMarkdown(project.description)}</div>
   {/if}
 </div>
 

--- a/src/lib/components/projects/ProjectHeader.svelte
+++ b/src/lib/components/projects/ProjectHeader.svelte
@@ -7,6 +7,7 @@
   import Flex from "$lib/components/common/Flex.svelte";
   import ProjectPin from "./ProjectPin.svelte";
   import { remToPx } from "$lib/utils/layout";
+  import { renderMarkdown } from "$lib/utils/markup";
 
   interface Props {
     project: Project;
@@ -46,7 +47,7 @@
     {/if}
   </Flex>
   {#if project.description}
-    <p class="description">{project.description}</p>
+    <div class="description">{@html renderMarkdown(project.description ?? "")}</div>
   {/if}
 </div>
 
@@ -72,6 +73,12 @@
   }
   .description {
     line-height: 1.4;
+    & > :global(*) {
+      margin-top: 0;
+    }
+    & > :global(*:last-child) {
+      margin-bottom: 0;
+    }
   }
   .twoColumn .description {
     columns: 2;

--- a/src/lib/components/projects/ProjectListItem.svelte
+++ b/src/lib/components/projects/ProjectListItem.svelte
@@ -42,7 +42,7 @@
       {/if}
     </div>
     {#if project.description}
-      <div class="description">{@html renderMarkdown(project.description ?? "", { allowedTags: listItemTags })}</div>
+      <div class="description">{@html renderMarkdown(project.description, { allowedTags: listItemTags })}</div>
     {/if}
   </div>
 </a>

--- a/src/lib/components/projects/ProjectListItem.svelte
+++ b/src/lib/components/projects/ProjectListItem.svelte
@@ -7,7 +7,11 @@
   import ProjectPin from "./ProjectPin.svelte";
 
   import { canonicalUrl } from "$lib/api/projects";
-  import { clean } from "$lib/utils/markup";
+  import { renderMarkdown } from "$lib/utils/markup";
+  import { ALLOWED_TAGS } from "@/config/config.js";
+
+  // Strip anchor tags to avoid invalid nested <a> inside the card link
+  const listItemTags = ALLOWED_TAGS.filter((tag: string) => tag !== "a");
 
   interface Props {
     project: Project;
@@ -38,7 +42,7 @@
       {/if}
     </div>
     {#if project.description}
-      <div class="description">{@html clean(project.description ?? "")}</div>
+      <div class="description">{@html renderMarkdown(project.description ?? "", { allowedTags: listItemTags })}</div>
     {/if}
   </div>
 </a>

--- a/src/lib/utils/tests/markup.test.ts
+++ b/src/lib/utils/tests/markup.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { clean, renderMarkdown } from "../markup";
+import { ALLOWED_TAGS } from "@/config/config.js";
 
 describe("clean() security tests", () => {
   // Test allowed tags work correctly
@@ -330,5 +331,15 @@ describe("renderMarkdown() security tests", () => {
     const result = renderMarkdown(input);
     // Images aren't in the allowed tags, so they should be removed
     expect(result).not.toContain("<img");
+  });
+
+  test("strips anchor tags when excluded from allowedTags", () => {
+    const input = "[Example](https://example.com)";
+    const tagsWithoutAnchors = ALLOWED_TAGS.filter(
+      (tag: string) => tag !== "a",
+    );
+    const result = renderMarkdown(input, { allowedTags: tagsWithoutAnchors });
+    expect(result).not.toContain("<a");
+    expect(result).toContain("Example");
   });
 });


### PR DESCRIPTION
## Summary

Closes #1294. Project descriptions now render Markdown (links, bold, italic, lists, etc.) using the same `renderMarkdown()` utility that document descriptions and flatpages already use.

**Changes:**
- **ProjectHeader.svelte** — switched from raw text to `renderMarkdown()`, changed `<p>` to `<div>` to avoid invalid nested paragraphs from Markdown output, added margin normalization for block-level content
- **ProjectListItem.svelte** — switched from `clean()` (HTML-only sanitization) to `renderMarkdown()` with anchor tags excluded from `allowedTags` to prevent invalid nested `<a>` elements (the card is already wrapped in a link)
- **markup.test.ts** — added test verifying that `renderMarkdown()` strips anchor tags when `a` is excluded from `allowedTags`

## How it works

The `renderMarkdown()` function in `markup.ts` was already available — it parses Markdown via `marked`, then sanitizes the HTML output through `sanitize-html` with the project's existing allowlist (`ALLOWED_TAGS` / `ALLOWED_ATTR`). This PR just wires it into the two project description rendering sites.

The nested anchor issue: `ProjectListItem` wraps the entire card in an `<a>`, so Markdown links like `[docs](https://...)` would create `<a>` inside `<a>` (invalid HTML, unpredictable browser behavior, screen reader issues). The fix passes a filtered tag list that excludes `a` — link text still renders, just without the anchor wrapper.

## Test plan

- [x] All 46 markup tests pass (45 existing + 1 new)
- [x] Full test suite passes (405 tests, 47 files)
- [ ] Create a project with a Markdown description like `Check out [the report](https://example.com) for details` and verify the link renders on the project detail page
- [ ] Verify the project list view shows the description text without a clickable inner link
- [ ] Verify plain text descriptions still render correctly
- [ ] Verify HTML in descriptions is sanitized (e.g., `<script>` tags stripped)