### PR TITLE
Adds oembed redirect and a home for more redirects

### DIFF
--- a/src/routes/(redirects)/README.md
+++ b/src/routes/(redirects)/README.md
@@ -1,0 +1,3 @@
+# Redirects
+
+Routes in this directory are simple redirects, usually for handling URLs from previous versions of DocumentCloud.

--- a/src/routes/(redirects)/api/oembed.json/+server.ts
+++ b/src/routes/(redirects)/api/oembed.json/+server.ts
@@ -1,0 +1,12 @@
+import { redirect } from "@sveltejs/kit";
+import { DC_BASE } from "@/config/config.js";
+
+export const trailingSlash = "never";
+
+export async function GET({ url }) {
+  const oembed = new URL("/api/oembed/", DC_BASE);
+
+  oembed.search = url.search;
+
+  return redirect(308, oembed);
+}

--- a/src/routes/(redirects)/app/+server.ts
+++ b/src/routes/(redirects)/app/+server.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from "@sveltejs/kit";
 
-export function load({ url }) {
+export function GET({ url }) {
   const u = new URL(url);
 
   // change the path but preserve other parts of the URL


### PR DESCRIPTION
I saw 404s on `/api/oembed.json/`, so this ensures we normalize the URL and redirect correctly. Once this merges, we can remove the version in the CF dashboard.

I also added a `(redirects)` directory so these stay in one place and don't clutter up other routes. The `/app` redirect is there now.