### PR TITLE
Re-add afterLoad to loadNote to improve compatibility

### DIFF
--- a/src/embed/iframeSizer.js
+++ b/src/embed/iframeSizer.js
@@ -32,7 +32,7 @@ export function informSize(
   update();
 }
 
-export function setupResizeEvent(iframe) {
+export function setupResizeEvent(iframe, cb) {
   window.addEventListener("message", (event) => {
     if (event.source == iframe.contentWindow) {
       const { width, height, updateStyleProps } = event.data;
@@ -67,6 +67,7 @@ export function setupResizeEvent(iframe) {
             iframe.style.minHeight = "" + height + "px";
           }
         }
+        if (cb) cb({ el: iframe });
       }
     }
   });

--- a/src/embed/noteLoader.js
+++ b/src/embed/noteLoader.js
@@ -3,7 +3,7 @@ import { APP_URL } from "../config/embed.js";
 
 const enhanced = "DC-embed-enhanced";
 
-function loadNote(src) {
+function loadNote(src, opts) {
   const parts = src.split("/").slice(-3);
   if (parts.length != 3) return;
   const slugId = parts[0];
@@ -23,7 +23,7 @@ function loadNote(src) {
     const iframe = document.createElement("iframe");
     iframe.style = "border: none; width: 100%;";
     iframe.src = new URL(`documents/${id}/annotations/${noteId}`, APP_URL).href;
-    setupResizeEvent(iframe);
+    setupResizeEvent(iframe, opts && opts.afterLoad ? opts.afterLoad : null);
 
     noteElem.appendChild(iframe);
   });


### PR DESCRIPTION
Adds an optional `opts` argument to `loadNote` in `noteLoader.js`, which accepts an `afterLoad` callback and fires it after the note `iframe` emits a load event and passes an object with a single property `el` containing the note's containing element. This is a restoration of a part of the original `loadNote`'s API to improve compatibility with historic custom journalism, which used this to render notes as inline document cite overlays.

The [original](https://github.com/documentcloud/documentcloud-notes/blob/3650f9efcb1cff369bdcf0172ead32dd37dc0c2b/src/js/note_embed.js#L115) fired after calling `render()` on the note, which set its innerHTML. It's a choice to treat the iframe load event as the equivalent (as opposed to say, a resize event). Because we're setting this in a loop, it's a possibility this would call multiple times if the same note were to be rendered multiple times in a document. The original passed a `note` object, which in addition to `el` also exposed `render()` and `setElement()` as well as some other methods. It's possible that code that depended on one of those would break with this shim, but I'm choosing not to add those at this point.

In local testing, appears to solve the issue posed by the [legacy ProPublica piece](https://www.propublica.org/article/tylenol-mcneil-fda-use-only-as-directed) which prompted this PR.

Closes #1325