### PR TITLE
Switch to generic cache control headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,10 +3,10 @@
 # cached forever
 
 /assets/*.css
-  Cache-Control: public, max-age=604800, immutable
+  cache-control: public, max-age=604800, immutable
 
 /assets/*.js
-  Cache-Control: public, max-age=604800, immutable
+  cache-control: public, max-age=604800, immutable
 
 
 # favicon.png and global.css are checked into the repo and change infrequently
@@ -14,5 +14,5 @@
 # will set to cache for one day in the browser
 
 /favicon.png
-  Cache-Control: public, max-age=86400, s-maxage=604800, immutable
+  cache-control: public, max-age=86400, s-maxage=604800, immutable
 

--- a/src/routes/(app)/add-ons/+layout.ts
+++ b/src/routes/(app)/add-ons/+layout.ts
@@ -9,7 +9,7 @@ export async function load({ parent, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "cache-control": `public, max-age=${VIEWER_MAX_AGE}`,
     });
   }
 

--- a/src/routes/(app)/add-ons/+layout.ts
+++ b/src/routes/(app)/add-ons/+layout.ts
@@ -9,7 +9,7 @@ export async function load({ parent, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "Cloudflare-CDN-Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
     });
   }
 

--- a/src/routes/(app)/documents/+page.ts
+++ b/src/routes/(app)/documents/+page.ts
@@ -27,7 +27,7 @@ export async function load({ url, fetch, data, parent, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "Cloudflare-CDN-Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
     });
   }
 

--- a/src/routes/(app)/documents/+page.ts
+++ b/src/routes/(app)/documents/+page.ts
@@ -27,7 +27,7 @@ export async function load({ url, fetch, data, parent, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "cache-control": `public, max-age=${VIEWER_MAX_AGE}`,
     });
   }
 

--- a/src/routes/(app)/documents/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.ts
@@ -48,7 +48,7 @@ export async function load({
 
   if (!me) {
     setHeaders({
-      "Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "cache-control": `public, max-age=${VIEWER_MAX_AGE}`,
       "last-modified": new Date(document.updated_at).toUTCString(),
     });
   }

--- a/src/routes/(app)/documents/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.ts
@@ -48,7 +48,7 @@ export async function load({
 
   if (!me) {
     setHeaders({
-      "Cloudflare-CDN-Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
       "last-modified": new Date(document.updated_at).toUTCString(),
     });
   }

--- a/src/routes/(app)/projects/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/projects/[id]-[slug]/+page.ts
@@ -55,7 +55,7 @@ export async function load({ params, url, parent, data, fetch, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "cache-control": `public, max-age=${VIEWER_MAX_AGE}`,
       "last-modified": new Date(project.data.updated_at).toUTCString(),
     });
   }

--- a/src/routes/(app)/projects/[id]-[slug]/+page.ts
+++ b/src/routes/(app)/projects/[id]-[slug]/+page.ts
@@ -55,7 +55,7 @@ export async function load({ params, url, parent, data, fetch, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "Cloudflare-CDN-Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
+      "Cache-Control": `public, max-age=${VIEWER_MAX_AGE}`,
       "last-modified": new Date(project.data.updated_at).toUTCString(),
     });
   }

--- a/src/routes/(pages)/about/+page.ts
+++ b/src/routes/(pages)/about/+page.ts
@@ -19,7 +19,7 @@ export async function load({ fetch, setHeaders }) {
   }
 
   setHeaders({
-    "Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
+    "cache-control": `public, max-age=${PAGE_MAX_AGE}`,
   });
 
   return data;

--- a/src/routes/(pages)/about/+page.ts
+++ b/src/routes/(pages)/about/+page.ts
@@ -19,7 +19,7 @@ export async function load({ fetch, setHeaders }) {
   }
 
   setHeaders({
-    "Cloudflare-CDN-Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
   });
 
   return data;

--- a/src/routes/(pages)/help/[...path]/+page.ts
+++ b/src/routes/(pages)/help/[...path]/+page.ts
@@ -19,7 +19,7 @@ export async function load({ fetch, params, setHeaders }) {
   }
 
   setHeaders({
-    "Cloudflare-CDN-Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
   });
 
   return data;

--- a/src/routes/(pages)/help/[...path]/+page.ts
+++ b/src/routes/(pages)/help/[...path]/+page.ts
@@ -19,7 +19,7 @@ export async function load({ fetch, params, setHeaders }) {
   }
 
   setHeaders({
-    "Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
+    "cache-control": `public, max-age=${PAGE_MAX_AGE}`,
   });
 
   return data;

--- a/src/routes/(pages)/home/+page.server.ts
+++ b/src/routes/(pages)/home/+page.server.ts
@@ -26,7 +26,7 @@ export async function load({ fetch, cookies, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "Cloudflare-CDN-Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
+      "Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
     });
   }
 

--- a/src/routes/(pages)/home/+page.server.ts
+++ b/src/routes/(pages)/home/+page.server.ts
@@ -26,7 +26,7 @@ export async function load({ fetch, cookies, setHeaders }) {
 
   if (!me) {
     setHeaders({
-      "Cache-Control": `public, max-age=${PAGE_MAX_AGE}`,
+      "cache-control": `public, max-age=${PAGE_MAX_AGE}`,
     });
   }
 

--- a/src/routes/embed/documents/[id]-[slug]/+page.ts
+++ b/src/routes/embed/documents/[id]-[slug]/+page.ts
@@ -25,7 +25,7 @@ export async function load({ fetch, url, params, depends, setHeaders }) {
   let settings: Partial<EmbedSettings> = getEmbedSettings(url.searchParams);
 
   setHeaders({
-    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]-[slug]/+page.ts
+++ b/src/routes/embed/documents/[id]-[slug]/+page.ts
@@ -25,7 +25,7 @@ export async function load({ fetch, url, params, depends, setHeaders }) {
   let settings: Partial<EmbedSettings> = getEmbedSettings(url.searchParams);
 
   setHeaders({
-    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]-[slug]/preview/+page.ts
+++ b/src/routes/embed/documents/[id]-[slug]/preview/+page.ts
@@ -26,7 +26,7 @@ export async function load({ fetch, url, params, depends, setHeaders }) {
   let settings: Partial<EmbedSettings> = getEmbedSettings(url.searchParams);
 
   setHeaders({
-    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]-[slug]/preview/+page.ts
+++ b/src/routes/embed/documents/[id]-[slug]/preview/+page.ts
@@ -26,7 +26,7 @@ export async function load({ fetch, url, params, depends, setHeaders }) {
   let settings: Partial<EmbedSettings> = getEmbedSettings(url.searchParams);
 
   setHeaders({
-    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]/annotations/[note_id]/+page.ts
+++ b/src/routes/embed/documents/[id]/annotations/[note_id]/+page.ts
@@ -16,7 +16,7 @@ export async function load({ params, fetch, setHeaders }) {
   }
 
   setHeaders({
-    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]/annotations/[note_id]/+page.ts
+++ b/src/routes/embed/documents/[id]/annotations/[note_id]/+page.ts
@@ -16,7 +16,7 @@ export async function load({ params, fetch, setHeaders }) {
   }
 
   setHeaders({
-    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]/annotations/[note_id]/preview/+page.ts
+++ b/src/routes/embed/documents/[id]/annotations/[note_id]/preview/+page.ts
@@ -16,7 +16,7 @@ export async function load({ params, fetch, setHeaders, url }) {
   }
 
   setHeaders({
-    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]/annotations/[note_id]/preview/+page.ts
+++ b/src/routes/embed/documents/[id]/annotations/[note_id]/preview/+page.ts
@@ -16,7 +16,7 @@ export async function load({ params, fetch, setHeaders, url }) {
   }
 
   setHeaders({
-    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]/pages/[page]/+page.ts
+++ b/src/routes/embed/documents/[id]/pages/[page]/+page.ts
@@ -17,7 +17,7 @@ export async function load({ params, fetch, setHeaders }) {
   }
 
   setHeaders({
-    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]/pages/[page]/+page.ts
+++ b/src/routes/embed/documents/[id]/pages/[page]/+page.ts
@@ -17,7 +17,7 @@ export async function load({ params, fetch, setHeaders }) {
   }
 
   setHeaders({
-    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]/pages/[page]/preview/+page.ts
+++ b/src/routes/embed/documents/[id]/pages/[page]/preview/+page.ts
@@ -13,7 +13,7 @@ export async function load({ params, fetch, setHeaders, url }) {
   }
 
   setHeaders({
-    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/documents/[id]/pages/[page]/preview/+page.ts
+++ b/src/routes/embed/documents/[id]/pages/[page]/preview/+page.ts
@@ -13,7 +13,7 @@ export async function load({ params, fetch, setHeaders, url }) {
   }
 
   setHeaders({
-    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(document.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/projects/[project_id]-[slug]/+page.ts
+++ b/src/routes/embed/projects/[project_id]-[slug]/+page.ts
@@ -50,7 +50,7 @@ export async function load({ params, fetch, url, setHeaders }) {
   }
 
   setHeaders({
-    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(project.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/projects/[project_id]-[slug]/+page.ts
+++ b/src/routes/embed/projects/[project_id]-[slug]/+page.ts
@@ -50,7 +50,7 @@ export async function load({ params, fetch, url, setHeaders }) {
   }
 
   setHeaders({
-    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(project.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/projects/[project_id]-[slug]/preview/+page.ts
+++ b/src/routes/embed/projects/[project_id]-[slug]/preview/+page.ts
@@ -16,7 +16,7 @@ export async function load({ params, fetch, setHeaders }) {
   }
 
   setHeaders({
-    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "cache-control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(project.data.updated_at).toUTCString(),
   });
 

--- a/src/routes/embed/projects/[project_id]-[slug]/preview/+page.ts
+++ b/src/routes/embed/projects/[project_id]-[slug]/preview/+page.ts
@@ -16,7 +16,7 @@ export async function load({ params, fetch, setHeaders }) {
   }
 
   setHeaders({
-    "Cloudflare-CDN-Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
+    "Cache-Control": `public, max-age=${EMBED_MAX_AGE}`,
     "last-modified": new Date(project.data.updated_at).toUTCString(),
   });
 


### PR DESCRIPTION
Switches `Cloudflare-CDN-Cache-Control` to `Cache-Control` everywhere, since we only have one CDN now.

This will also allow browsers to cache pages, so we should watch for any staleness. 