### PR TITLE
Add a basic user-agent

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -24,6 +24,7 @@ export async function handleFetch({ event, request, fetch }) {
       "x-bypass-rate-limit",
       env.BYPASS_RATE_LIMIT_SECRET ?? "",
     );
+    request.headers.append("user-agent", "MuckRock/documentcloud-frontend");
   }
 
   return fetch(request);


### PR DESCRIPTION
Adds `user-agent: MuckRock/documentcloud-frontend` to SSR requests. We can potentially add more detail, but this gets us started.

Closes #1332 