### PR TITLE
Migrate input components to Svelte 5

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -48,6 +48,6 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitOnceUploaded: true
-          # onlyChanged: true
-          # externals: |
-          #  - 'public/**'
+          onlyChanged: true
+          externals: |
+            - 'public/**'

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ static/viewer/*
 playwright-report
 test-results
 playwright/.auth
+.playwright-mcp/
 coverage
 certs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4368,9 +4368,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4532,9 +4532,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4368,12 +4368,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.8",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.8.tgz",
-      "integrity": "sha512-Y1fOuNDowLfgKOypdc9SPABfoWXuZHBOyCS4cD52IeZBhr4Md6CLLs6atcxVrzRmQ06E7hSlm5bHHApPKR/byA==",
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/better-opn": {
@@ -4529,9 +4532,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001760",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
-      "integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/lib/components/forms/AddOnDispatch.svelte
+++ b/src/lib/components/forms/AddOnDispatch.svelte
@@ -2,7 +2,10 @@
   import type { Snippet } from "svelte";
   import { writable } from "svelte/store";
 
-  export const values = writable({ event: "disabled", selection: null });
+  export const values = writable<Record<string, any>>({
+    event: "disabled",
+    selection: null,
+  });
 </script>
 
 <script lang="ts">
@@ -93,10 +96,10 @@
   afterNavigate(() => {
     // set initial values
     if (event) {
-      $values = {
+      $values = withDefaults({
         ...event.parameters,
         event: schedules[event.event],
-      };
+      });
     }
     // prefill values from search params
     new URLSearchParams($page.url.searchParams).forEach((v, k) => {
@@ -113,6 +116,43 @@
 
     return params;
   }
+
+  // A defined initial value for a field, matching the fallback of the input
+  // component `autofield` will pick. Svelte 5 refuses to `bind:value` an
+  // `undefined` to a prop that declares a fallback, so every field must start
+  // with a defined value.
+  function initialValue(params: any) {
+    if (params.default !== undefined) return params.default;
+
+    switch (String(params.type).toLowerCase()) {
+      case "boolean":
+        return false;
+      case "number":
+      case "integer":
+        return undefined; // the Number input accepts undefined
+      case "string":
+        return params.enum ? null : "";
+      default:
+        return ""; // unknown types fall back to the Text input
+    }
+  }
+
+  // Merge the schema's per-field defaults into a set of form values, filling in
+  // any field that is still undefined.
+  function withDefaults(base: Record<string, any> = {}) {
+    return Object.entries(properties).reduce(
+      (acc, [name, p]) => {
+        if (acc[name] === undefined) {
+          acc[name] = initialValue(objectify(p));
+        }
+        return acc;
+      },
+      { event: "disabled", selection: null, ...base } as Record<string, any>,
+    );
+  }
+
+  // Seed the store before the first render so no field binds to `undefined`.
+  $values = withDefaults($values);
 
   function capitalize(s: string) {
     return s.charAt(0).toUpperCase() + s.slice(1);

--- a/src/lib/components/forms/EditNote.svelte
+++ b/src/lib/components/forms/EditNote.svelte
@@ -5,7 +5,14 @@ This form deals with everything except coordinates, which should be passed in as
 Positioning and generating coordinates should happen outside of this form.
 -->
 <script lang="ts">
-  import type { Bounds, Document, Maybe, Note, Nullable } from "$lib/api/types";
+  import type {
+    Access,
+    Bounds,
+    Document,
+    Maybe,
+    Note,
+    Nullable,
+  } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
 
@@ -29,11 +36,16 @@ Positioning and generating coordinates should happen outside of this form.
 
   let {
     document,
-    note = $bindable({ title: "", content: "", access: "private" }),
+    note = { title: "", content: "", access: "private" },
     page_number = note.page_number,
     onclose,
     onsuccess,
   }: Props = $props();
+
+  // Overridable deriveds seed the form from `note`
+  let title = $derived(note.title ?? "");
+  let content = $derived(note.content ?? "");
+  let access: Access = $derived(note.access ?? "private");
 
   let coords = $derived([
     note.x1,
@@ -60,9 +72,9 @@ Positioning and generating coordinates should happen outside of this form.
     const { data, error: err } = await notesApi.create(
       document.id,
       {
-        title: note.title,
-        content: note.content ?? "",
-        access: note.access,
+        title,
+        content,
+        access,
         page_number: note.page_number ?? page_number ?? undefined,
         x1,
         x2,
@@ -97,9 +109,9 @@ Positioning and generating coordinates should happen outside of this form.
       document.id,
       note.id!,
       {
-        title: note.title,
-        content: note.content ?? "",
-        access: note.access,
+        title,
+        content,
+        access,
       },
       csrf_token,
     );
@@ -147,15 +159,15 @@ Positioning and generating coordinates should happen outside of this form.
       <Text
         name="title"
         placeholder={$_("annotate.fields.title")}
-        bind:value={note.title}
+        bind:value={title}
         required
       />
     </Field>
     <Field title={$_("annotate.fields.content")}>
-      <TextArea name="content" bind:value={note.content} />
+      <TextArea name="content" bind:value={content} />
     </Field>
 
-    <AccessLevel name="access" bind:selected={note.access} direction="row" />
+    <AccessLevel name="access" bind:selected={access} direction="row" />
 
     {#if error}
       <p class="error" role="alert">{error}</p>

--- a/src/lib/components/forms/EditNote.svelte
+++ b/src/lib/components/forms/EditNote.svelte
@@ -9,7 +9,6 @@ Positioning and generating coordinates should happen outside of this form.
 
   import { enhance } from "$app/forms";
 
-  import { createEventDispatcher } from "svelte";
   import { _ } from "svelte-i18n";
 
   import AccessLevel from "../inputs/AccessLevel.svelte";
@@ -21,26 +20,43 @@ Positioning and generating coordinates should happen outside of this form.
 
   import { canonicalUrl } from "$lib/api/documents";
 
-  export let document: Document;
-  export let note: Partial<Note> = {}; // for updating
-  export let page_number: Maybe<number> = note.page_number;
+  interface Props {
+    document: Document;
+    note?: Partial<Note>; // for updating
+    page_number?: Maybe<number>;
+    onclose?: () => void;
+    onsuccess?: (note: Note) => void;
+  }
 
-  const dispatch = createEventDispatcher();
+  let {
+    document,
+    note = $bindable({ title: "", content: "", access: "private" }),
+    page_number = note.page_number,
+    onclose,
+    onsuccess,
+  }: Props = $props();
 
-  $: coords = [note.x1, note.x2, note.y1, note.y2] as Partial<Bounds>;
-  $: canonical = canonicalUrl(document);
-  $: action = note.id
-    ? new URL("?/updateAnnotation", canonical).href
-    : new URL("?/createAnnotation", canonical).href;
-  $: page_level = !coords || coords.every((c) => !Boolean(c));
+  let coords = $derived([
+    note.x1,
+    note.x2,
+    note.y1,
+    note.y2,
+  ] as Partial<Bounds>);
+  let canonical = $derived(canonicalUrl(document));
+  let action = $derived(
+    note.id
+      ? new URL("?/updateAnnotation", canonical).href
+      : new URL("?/createAnnotation", canonical).href,
+  );
+  let page_level = $derived(!coords || coords.every((c) => !Boolean(c)));
 
-  function onSubmit({ formData, submitter }) {
+  function onSubmit({ submitter }) {
     submitter.disabled = true;
     return ({ result, update }) => {
       if (result.type === "success") {
-        dispatch("success", result.data.note);
+        onsuccess?.(result.data.note);
         update(result);
-        dispatch("close");
+        onclose?.();
       }
     };
   }
@@ -75,7 +91,7 @@ Positioning and generating coordinates should happen outside of this form.
     <Flex class="buttons" justify="between">
       <Flex>
         <Button type="submit" mode="primary">{$_("annotate.save")}</Button>
-        <Button type="reset" onclick={() => dispatch("close")}
+        <Button type="reset" onclick={() => onclose?.()}
           >{$_("annotate.cancel")}
         </Button>
       </Flex>

--- a/src/lib/components/forms/EditNote.svelte
+++ b/src/lib/components/forms/EditNote.svelte
@@ -5,9 +5,7 @@ This form deals with everything except coordinates, which should be passed in as
 Positioning and generating coordinates should happen outside of this form.
 -->
 <script lang="ts">
-  import type { Bounds, Document, Maybe, Note } from "$lib/api/types";
-
-  import { enhance } from "$app/forms";
+  import type { Bounds, Document, Maybe, Note, Nullable } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
 
@@ -18,7 +16,8 @@ Positioning and generating coordinates should happen outside of this form.
   import Text from "../inputs/Text.svelte";
   import TextArea from "../inputs/TextArea.svelte";
 
-  import { canonicalUrl } from "$lib/api/documents";
+  import * as notesApi from "$lib/api/notes";
+  import { getCsrfToken } from "$lib/utils/api";
 
   interface Props {
     document: Document;
@@ -42,27 +41,107 @@ Positioning and generating coordinates should happen outside of this form.
     note.y1,
     note.y2,
   ] as Partial<Bounds>);
-  let canonical = $derived(canonicalUrl(document));
-  let action = $derived(
-    note.id
-      ? new URL("?/updateAnnotation", canonical).href
-      : new URL("?/createAnnotation", canonical).href,
-  );
   let page_level = $derived(!coords || coords.every((c) => !Boolean(c)));
 
-  function onSubmit({ submitter }) {
-    submitter.disabled = true;
-    return ({ result, update }) => {
-      if (result.type === "success") {
-        onsuccess?.(result.data.note);
-        update(result);
-        onclose?.();
-      }
-    };
+  let loading = $state(false);
+  let error: Nullable<string> = $state(null);
+
+  /**
+   * Create a new note on this document, directly from the browser.
+   */
+  async function create(e: SubmitEvent) {
+    e.preventDefault();
+    loading = true;
+    error = null;
+
+    const csrf_token = getCsrfToken() ?? "";
+    const [x1, x2, y1, y2] = coords;
+
+    const { data, error: err } = await notesApi.create(
+      document.id,
+      {
+        title: note.title,
+        content: note.content ?? "",
+        access: note.access,
+        page_number: note.page_number ?? page_number ?? undefined,
+        x1,
+        x2,
+        y1,
+        y2,
+      },
+      csrf_token,
+    );
+
+    loading = false;
+
+    if (err) {
+      error = err.message;
+      return;
+    }
+
+    if (data) onsuccess?.(data);
+    onclose?.();
+  }
+
+  /**
+   * Update an existing note, directly from the browser.
+   */
+  async function update(e: SubmitEvent) {
+    e.preventDefault();
+    loading = true;
+    error = null;
+
+    const csrf_token = getCsrfToken() ?? "";
+
+    const { data, error: err } = await notesApi.update(
+      document.id,
+      note.id!,
+      {
+        title: note.title,
+        content: note.content ?? "",
+        access: note.access,
+      },
+      csrf_token,
+    );
+
+    loading = false;
+
+    if (err) {
+      error = err.message;
+      return;
+    }
+
+    if (data) onsuccess?.(data);
+    onclose?.();
+  }
+
+  /**
+   * Delete a note, directly from the browser.
+   */
+  async function remove() {
+    loading = true;
+    error = null;
+
+    const csrf_token = getCsrfToken() ?? "";
+
+    const { error: err } = await notesApi.remove(
+      document.id,
+      note.id!,
+      csrf_token,
+    );
+
+    loading = false;
+
+    if (err) {
+      error = err.message;
+      return;
+    }
+
+    onclose?.();
   }
 </script>
 
-<form {action} method="post" class:page_level use:enhance={onSubmit}>
+<form class:page_level onsubmit={note.id ? update : create}>
   <Flex direction="column" gap={1}>
     <Field title={$_("annotate.fields.title")} required>
       <Text
@@ -78,33 +157,33 @@ Positioning and generating coordinates should happen outside of this form.
 
     <AccessLevel name="access" bind:selected={note.access} direction="row" />
 
-    {#if note.id}
-      <input type="hidden" name="id" value={note.id} />
+    {#if error}
+      <p class="error" role="alert">{error}</p>
     {/if}
-    <input
-      type="hidden"
-      name="page_number"
-      value={note.page_number || page_number}
-    />
-    <input type="hidden" name="coords" value={JSON.stringify(coords)} />
 
     <Flex class="buttons" justify="between">
       <Flex>
-        <Button type="submit" mode="primary">{$_("annotate.save")}</Button>
-        <Button type="reset" onclick={() => onclose?.()}
-          >{$_("annotate.cancel")}
+        <Button type="submit" mode="primary" disabled={loading}>
+          {$_("annotate.save")}
+        </Button>
+        <Button type="reset" disabled={loading} onclick={() => onclose?.()}>
+          {$_("annotate.cancel")}
         </Button>
       </Flex>
 
       {#if note.id}
-        <Button
-          type="submit"
-          mode="danger"
-          formaction={new URL("?/deleteAnnotation", canonical).href}
-        >
+        <Button type="button" mode="danger" disabled={loading} onclick={remove}>
           {$_("dialog.delete")}
         </Button>
       {/if}
     </Flex>
   </Flex>
 </form>
+
+<style>
+  .error {
+    margin: 0;
+    color: var(--red-3, #cf2e2e);
+    font-size: 0.875rem;
+  }
+</style>

--- a/src/lib/components/forms/RevisionControl.svelte
+++ b/src/lib/components/forms/RevisionControl.svelte
@@ -37,7 +37,7 @@
       <Switch
         name="revision_control"
         checked={document.revision_control}
-        on:change={() => formRef.submit()}
+        onchange={() => formRef.submit()}
         {disabled}
       />
     </Field>

--- a/src/lib/components/forms/Share.svelte
+++ b/src/lib/components/forms/Share.svelte
@@ -26,7 +26,7 @@
   } from "../documents/CustomizeEmbed.svelte";
   import Field from "$lib/components/common/Field.svelte";
   import FieldLabel from "$lib/components/common/FieldLabel.svelte";
-  import Number from "$lib/components/inputs/Number.svelte";
+  import NumberInput from "$lib/components/inputs/Number.svelte";
   import Select from "$lib/components/inputs/Select.svelte";
   import Tab from "$lib/components/common/Tab.svelte";
   import Text from "$lib/components/inputs/Text.svelte";
@@ -173,7 +173,7 @@
         <div class="subselection">
           <Field>
             <FieldLabel>{$_("share.fields.page")}:</FieldLabel>
-            <Number bind:value={page} min={1} max={document.page_count} />
+            <NumberInput bind:value={page} min={1} max={document.page_count} />
           </Field>
         </div>
       {:else if currentTab === "note" && noteOptions && noteOptions.length > 0}

--- a/src/lib/components/forms/Upload.svelte
+++ b/src/lib/components/forms/Upload.svelte
@@ -79,7 +79,7 @@ progress through the three-part upload process.
   export let user = getCurrentUser();
   export let csrf_token: Maybe<string> = undefined;
 
-  let fileDropActive: boolean;
+  let fileDropActive: boolean = false;
 
   /**
    * Upload status

--- a/src/lib/components/forms/stories/EditNote.stories.svelte
+++ b/src/lib/components/forms/stories/EditNote.stories.svelte
@@ -1,16 +1,16 @@
 <script context="module" lang="ts">
   import type { Document } from "$lib/api/types";
 
-  import { Story } from "@storybook/addon-svelte-csf";
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import EditNote from "../EditNote.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Edit note",
     component: EditNote,
     parameters: {
       layout: "centered",
     },
-  };
+  });
 
   import doc from "@/test/fixtures/documents/document-expanded.json";
 
@@ -18,10 +18,9 @@
   const note = document.notes?.[0]!;
 </script>
 
-<Story name="New note">
-  <EditNote {document} page_number={note.page_number} />
-</Story>
+<Story name="New note" args={{ document, page_number: note.page_number }} />
 
-<Story name="Update note">
-  <EditNote {document} {note} page_number={note.page_number} />
-</Story>
+<Story
+  name="Update note"
+  args={{ document, note, page_number: note.page_number }}
+/>

--- a/src/lib/components/forms/tests/EditNote.test.ts
+++ b/src/lib/components/forms/tests/EditNote.test.ts
@@ -120,6 +120,85 @@ describe("EditNote", () => {
     expect(onclose).toHaveBeenCalledTimes(1);
   });
 
+  it("submits edited field values when creating a note", async () => {
+    vi.mocked(notesApi.create).mockResolvedValue({ data: noteFixture });
+
+    const { container } = render(EditNote, {
+      document: mockDocument,
+      note: { title: "Original", content: "Original body", access: "private" },
+    });
+
+    const title = container.querySelector(
+      "input[name='title']",
+    ) as HTMLInputElement;
+    const content = container.querySelector(
+      "textarea[name='content']",
+    ) as HTMLTextAreaElement;
+
+    await fireEvent.input(title, { target: { value: "Edited title" } });
+    await fireEvent.input(content, { target: { value: "Edited body" } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(notesApi.create).toHaveBeenCalledWith(
+      mockDocument.id,
+      expect.objectContaining({
+        title: "Edited title",
+        content: "Edited body",
+        access: "private",
+      }),
+      "test-csrf",
+    );
+  });
+
+  it("submits edited field values when updating a note", async () => {
+    vi.mocked(notesApi.update).mockResolvedValue({ data: noteFixture });
+
+    const { container } = render(EditNote, {
+      document: mockDocument,
+      note: { ...noteFixture },
+    });
+
+    const title = container.querySelector(
+      "input[name='title']",
+    ) as HTMLInputElement;
+
+    await fireEvent.input(title, { target: { value: "Updated title" } });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(notesApi.update).toHaveBeenCalledWith(
+      mockDocument.id,
+      noteFixture.id,
+      expect.objectContaining({
+        title: "Updated title",
+        content: noteFixture.content,
+        access: noteFixture.access,
+      }),
+      "test-csrf",
+    );
+  });
+
+  it("submits the selected access level", async () => {
+    vi.mocked(notesApi.create).mockResolvedValue({ data: noteFixture });
+
+    render(EditNote, {
+      document: mockDocument,
+      note: { title: "New note", content: "", access: "private" },
+    });
+
+    // AccessLevel renders a radio per level; pick a non-default one.
+    await fireEvent.click(screen.getByDisplayValue("public"));
+
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(notesApi.create).toHaveBeenCalledWith(
+      mockDocument.id,
+      expect.objectContaining({ access: "public" }),
+      "test-csrf",
+    );
+  });
+
   it("removes a note when the delete button is clicked", async () => {
     vi.mocked(notesApi.remove).mockResolvedValue({ data: null });
 

--- a/src/lib/components/forms/tests/EditNote.test.ts
+++ b/src/lib/components/forms/tests/EditNote.test.ts
@@ -1,0 +1,177 @@
+import type { Document, Note } from "$lib/api/types";
+
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+
+import EditNote from "../EditNote.svelte";
+import documentFixture from "@/test/fixtures/documents/document.json";
+import { note as noteFixture } from "@/test/fixtures/notes";
+
+// The component calls the notes API directly from the browser, so mock it.
+vi.mock("$lib/api/notes", () => ({
+  create: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
+}));
+
+// The CSRF token normally comes from a cookie.
+vi.mock("$lib/utils/api", () => ({
+  getCsrfToken: vi.fn(() => "test-csrf"),
+}));
+
+import * as notesApi from "$lib/api/notes";
+
+const mockDocument = documentFixture as Document;
+
+describe("EditNote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the create form without a delete button", () => {
+    render(EditNote, { document: mockDocument });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Delete" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a delete button when editing an existing note", () => {
+    render(EditNote, { document: mockDocument, note: { ...noteFixture } });
+
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  it("populates the fields from an existing note", () => {
+    const { container } = render(EditNote, {
+      document: mockDocument,
+      note: { ...noteFixture },
+    });
+
+    expect(screen.getByDisplayValue(noteFixture.title)).toBeInTheDocument();
+
+    const textarea = container.querySelector(
+      "textarea[name='content']",
+    ) as HTMLTextAreaElement;
+    expect(textarea.value).toBe(noteFixture.content);
+  });
+
+  it("creates a new note on submit and fires onsuccess + onclose", async () => {
+    vi.mocked(notesApi.create).mockResolvedValue({ data: noteFixture });
+
+    const onsuccess = vi.fn();
+    const onclose = vi.fn();
+
+    render(EditNote, {
+      document: mockDocument,
+      note: { title: "New note", content: "Body", access: "public" },
+      page_number: 3,
+      onsuccess,
+      onclose,
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(notesApi.create).toHaveBeenCalledWith(
+      mockDocument.id,
+      expect.objectContaining({
+        title: "New note",
+        content: "Body",
+        access: "public",
+        page_number: 3,
+      }),
+      "test-csrf",
+    );
+    expect(notesApi.update).not.toHaveBeenCalled();
+    expect(onsuccess).toHaveBeenCalledWith(noteFixture);
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates an existing note on submit and fires onsuccess + onclose", async () => {
+    const updated = { ...noteFixture, title: "Edited title" } as Note;
+    vi.mocked(notesApi.update).mockResolvedValue({ data: updated });
+
+    const onsuccess = vi.fn();
+    const onclose = vi.fn();
+
+    render(EditNote, {
+      document: mockDocument,
+      note: { ...noteFixture },
+      onsuccess,
+      onclose,
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(notesApi.update).toHaveBeenCalledWith(
+      mockDocument.id,
+      noteFixture.id,
+      expect.objectContaining({
+        title: noteFixture.title,
+        content: noteFixture.content,
+        access: noteFixture.access,
+      }),
+      "test-csrf",
+    );
+    expect(notesApi.create).not.toHaveBeenCalled();
+    expect(onsuccess).toHaveBeenCalledWith(updated);
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes a note when the delete button is clicked", async () => {
+    vi.mocked(notesApi.remove).mockResolvedValue({ data: null });
+
+    const onclose = vi.fn();
+
+    render(EditNote, {
+      document: mockDocument,
+      note: { ...noteFixture },
+      onclose,
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(notesApi.remove).toHaveBeenCalledWith(
+      mockDocument.id,
+      noteFixture.id,
+      "test-csrf",
+    );
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error and does not close when the API fails", async () => {
+    vi.mocked(notesApi.create).mockResolvedValue({
+      error: { status: 400, message: "Something went wrong" },
+    });
+
+    const onsuccess = vi.fn();
+    const onclose = vi.fn();
+
+    render(EditNote, {
+      document: mockDocument,
+      note: { title: "New note", content: "", access: "private" },
+      onsuccess,
+      onclose,
+    });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Something went wrong",
+    );
+    expect(onsuccess).not.toHaveBeenCalled();
+    expect(onclose).not.toHaveBeenCalled();
+  });
+
+  it("calls onclose when the cancel button is clicked", async () => {
+    const onclose = vi.fn();
+
+    render(EditNote, { document: mockDocument, onclose });
+
+    await fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onclose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/components/inputs/AccessLevel.svelte
+++ b/src/lib/components/inputs/AccessLevel.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   export interface Level {
     value: Access;
     title: string;
@@ -40,10 +40,19 @@
     },
   ];
 
-  export let name: string;
-  export let selected: Access = levels[0]!.value;
-  export let direction: "column" | "row" = "column";
-  export let required = false;
+  interface Props {
+    name: string;
+    selected?: Access | null;
+    direction?: "column" | "row";
+    required?: boolean;
+  }
+
+  let {
+    name,
+    selected = $bindable(levels[0]!.value),
+    direction = "column",
+    required = false,
+  }: Props = $props();
 </script>
 
 <Flex direction="column">
@@ -57,7 +66,7 @@
       <div class="option" class:selected={level.value === selected}>
         <label for={level.value} class="detail">
           <Flex gap={0.5}>
-            <svelte:component this={level.icon} />
+            <level.icon />
             <Flex direction="column" gap={0.125}>
               <p class="title">{level.title}</p>
               <p class="description">{level.description}</p>

--- a/src/lib/components/inputs/Checkbox.svelte
+++ b/src/lib/components/inputs/Checkbox.svelte
@@ -1,26 +1,34 @@
 <script lang="ts">
+  import type { HTMLInputAttributes } from "svelte/elements";
+
   import { Check16, Dash16 } from "svelte-octicons";
 
-  export let name: undefined | string = undefined;
-  export let disabled = false;
-  export let value = false;
-  export let indeterminate = false;
+  interface Props extends HTMLInputAttributes {
+    name?: undefined | string;
+    disabled?: boolean;
+    value?: boolean;
+    indeterminate?: boolean;
+    label?: string;
+  }
 
-  export let label = "";
-
-  let checkbox: HTMLInputElement;
+  let {
+    name = undefined,
+    disabled = false,
+    value = $bindable(false),
+    indeterminate = $bindable(false),
+    label = "",
+    ...rest
+  }: Props = $props();
 </script>
 
 <label>
   <input
     type="checkbox"
     {name}
-    bind:this={checkbox}
     {disabled}
     bind:checked={value}
     bind:indeterminate
-    on:input
-    on:change
+    {...rest}
   />
   <span>
     {#if value}

--- a/src/lib/components/inputs/Checkbox.svelte
+++ b/src/lib/components/inputs/Checkbox.svelte
@@ -23,12 +23,12 @@
 
 <label>
   <input
+    {...rest}
     type="checkbox"
     {name}
     {disabled}
     bind:checked={value}
     bind:indeterminate
-    {...rest}
   />
   <span>
     {#if value}

--- a/src/lib/components/inputs/Choices.svelte
+++ b/src/lib/components/inputs/Choices.svelte
@@ -1,12 +1,24 @@
 <script lang="ts">
-  export let name: string;
-  export let defaultValue: string = "";
-  export let value: null | string = defaultValue || null;
-  export let required: boolean = false;
-  export let choices: string[] = [];
+  import type { HTMLInputAttributes } from "svelte/elements";
+
+  interface Props extends HTMLInputAttributes {
+    name: string;
+    defaultValue?: string;
+    value?: null | string;
+    required?: boolean;
+    choices?: string[];
+  }
+
+  let {
+    name,
+    defaultValue = "",
+    value = $bindable(defaultValue || null),
+    required = false,
+    choices = [],
+  }: Props = $props();
 </script>
 
-<select {required} {name} bind:value on:input on:focus on:change on:blur>
+<select {required} {name} bind:value>
   {#if !required}
     <option value="">---</option>
   {/if}

--- a/src/lib/components/inputs/Dropzone.svelte
+++ b/src/lib/components/inputs/Dropzone.svelte
@@ -31,7 +31,7 @@
   }
 
   function dragover(e: DragEvent) {
-    e.preventDefault;
+    e.preventDefault();
     active = true;
   }
 

--- a/src/lib/components/inputs/Dropzone.svelte
+++ b/src/lib/components/inputs/Dropzone.svelte
@@ -6,23 +6,37 @@
   https://developer.mozilla.org/en-US/docs/Web/API/File_API/Using_files_from_web_applications#selecting_files_using_drag_and_drop
 -->
 <script lang="ts">
-  export let onDrop: (files: FileList) => void;
-  export let active = false;
-  export let disabled = false;
+  import type { Snippet } from "svelte";
+  interface Props {
+    onDrop: (files: FileList) => void;
+    active?: boolean;
+    disabled?: boolean;
+    children?: Snippet<[any]>;
+  }
+
+  let {
+    onDrop,
+    active = $bindable(false),
+    disabled = false,
+    children,
+  }: Props = $props();
 
   let dropDepth = 0;
 
-  function enter() {
+  function enter(e: DragEvent) {
+    e.preventDefault();
     if (disabled) return;
     dropDepth++;
     active = true;
   }
 
-  function dragover() {
+  function dragover(e: DragEvent) {
+    e.preventDefault;
     active = true;
   }
 
-  function leave() {
+  function leave(e: DragEvent) {
+    e.preventDefault();
     if (disabled) return;
     dropDepth--;
     if (dropDepth > 0) return;
@@ -30,6 +44,7 @@
   }
 
   function handleDrop(e: DragEvent) {
+    e.preventDefault();
     if (disabled) return;
     const files = e.dataTransfer?.files;
     if (files) onDrop(files);
@@ -41,12 +56,12 @@
   role="button"
   tabindex="0"
   aria-dropeffect="execute"
-  on:dragenter|preventDefault={enter}
-  on:dragover|preventDefault={dragover}
-  on:dragleave|preventDefault={leave}
-  on:drop|preventDefault={handleDrop}
+  ondragenter={enter}
+  ondragover={dragover}
+  ondragleave={leave}
+  ondrop={handleDrop}
 >
-  <slot {active} {disabled} />
+  {@render children?.({ active, disabled })}
 </div>
 
 <style>

--- a/src/lib/components/inputs/Field.svelte
+++ b/src/lib/components/inputs/Field.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from "svelte";
   import { clean } from "$lib/utils/markup";
 
   interface Props {
@@ -7,8 +8,8 @@
     inline?: boolean;
     required?: boolean;
     sronly?: boolean;
-    children?: import("svelte").Snippet;
-    error?: import("svelte").Snippet;
+    children?: Snippet;
+    error?: Snippet;
   }
 
   let {

--- a/src/lib/components/inputs/Language.svelte
+++ b/src/lib/components/inputs/Language.svelte
@@ -12,13 +12,22 @@
     value: string;
   }
 
-  export let name = "language";
-  export let value: Item = {
-    value: DEFAULT_LANGUAGE,
-    label: LANGUAGE_MAP.get(DEFAULT_LANGUAGE) ?? DEFAULT_LANGUAGE,
-  };
-  export let required = false;
-  export let placeholder: string = "Language";
+  interface Props {
+    name?: string;
+    value?: Item;
+    required?: boolean;
+    placeholder?: string;
+  }
+
+  let {
+    name = "language",
+    value = $bindable({
+      value: DEFAULT_LANGUAGE,
+      label: LANGUAGE_MAP.get(DEFAULT_LANGUAGE) ?? DEFAULT_LANGUAGE,
+    }),
+    required = false,
+    placeholder = "Language",
+  }: Props = $props();
 
   const options: Item[] = LANGUAGE_CODES.map((code, i) => ({
     value: code,

--- a/src/lib/components/inputs/Number.svelte
+++ b/src/lib/components/inputs/Number.svelte
@@ -3,18 +3,25 @@
 -->
 
 <script lang="ts">
-  export let name: null | string = null;
-  export let placeholder = "";
-  export let value: undefined | number = undefined;
-  export let autofocus = false;
-  export let required = false;
-  export let disabled = false;
-  export let min: undefined | number = undefined;
-  export let max: undefined | number = undefined;
-  export let step: undefined | number = undefined;
+  import type { HTMLInputAttributes } from "svelte/elements";
+
+  interface Props extends HTMLInputAttributes {}
+
+  let {
+    name = null,
+    placeholder = "",
+    value = $bindable(undefined),
+    autofocus = false,
+    required = false,
+    disabled = false,
+    min = undefined,
+    max = undefined,
+    step = undefined,
+    ...rest
+  }: Props = $props();
 </script>
 
-<!-- svelte-ignore a11y-autofocus -->
+<!-- svelte-ignore a11y_autofocus -->
 <input
   type="number"
   {name}
@@ -25,11 +32,8 @@
   {min}
   {max}
   {step}
+  {...rest}
   bind:value
-  on:change
-  on:input
-  on:focus
-  on:blur
 />
 
 <style>

--- a/src/lib/components/inputs/Number.svelte
+++ b/src/lib/components/inputs/Number.svelte
@@ -23,6 +23,7 @@
 
 <!-- svelte-ignore a11y_autofocus -->
 <input
+  {...rest}
   type="number"
   {name}
   {placeholder}
@@ -32,7 +33,6 @@
   {min}
   {max}
   {step}
-  {...rest}
   bind:value
 />
 

--- a/src/lib/components/inputs/ProjectAccess.svelte
+++ b/src/lib/components/inputs/ProjectAccess.svelte
@@ -1,7 +1,7 @@
 <!-- @component
 Project access input
 -->
-<script context="module" lang="ts">
+<script module lang="ts">
   import type { ProjectAccess } from "$lib/api/types";
 
   export interface Level {
@@ -34,8 +34,13 @@ Project access input
     },
   ];
 
-  export let name: string = "access";
-  export let selected = levels[0]?.value;
+  interface Props {
+    name?: string;
+    selected?: any;
+  }
+
+  let { name = "access", selected = $bindable(levels[0]?.value) }: Props =
+    $props();
 </script>
 
 <Flex direction="column" gap={0.5}>

--- a/src/lib/components/inputs/Switch.svelte
+++ b/src/lib/components/inputs/Switch.svelte
@@ -1,11 +1,22 @@
 <script lang="ts">
   import type { Nullable } from "$lib/api/types";
 
-  export let name: Nullable<string> = null;
-  export let checked = false;
-  export let disabled = false;
+  interface Props {
+    name?: Nullable<string>;
+    checked?: boolean;
+    disabled?: boolean;
+    onchange?: (e: Event) => void;
+  }
+
+  let {
+    name = null,
+    checked = $bindable(false),
+    disabled = false,
+    onchange,
+  }: Props = $props();
 
   function handleClick(event: MouseEvent) {
+    event.preventDefault();
     const state = (event.target as HTMLButtonElement).getAttribute(
       "aria-checked",
     );
@@ -19,9 +30,15 @@
     role="switch"
     aria-checked={checked}
     title={name}
-    on:click|preventDefault={handleClick}
+    onclick={handleClick}
   ></button>
-  <input {name} type="checkbox" bind:checked class="hidden" on:change />
+  <input
+    {name}
+    type="checkbox"
+    bind:checked
+    class="hidden"
+    onchange={(e) => onchange?.(e)}
+  />
 </div>
 
 <style>

--- a/src/lib/components/inputs/Text.svelte
+++ b/src/lib/components/inputs/Text.svelte
@@ -3,32 +3,15 @@
 -->
 
 <script lang="ts">
-  export let name: null | string = null;
-  export let placeholder = "";
-  export let value = "";
-  export let autofocus = false;
-  export let required = false;
-  export let disabled = false;
-  export let readonly = false;
-  export let autocomplete: string | undefined = undefined;
+  import type { HTMLInputAttributes } from "svelte/elements";
+
+  interface Props extends HTMLInputAttributes {}
+
+  let { value = $bindable(""), ...rest }: Props = $props();
 </script>
 
-<!-- svelte-ignore a11y-autofocus -->
-<input
-  type="text"
-  {name}
-  {placeholder}
-  {required}
-  {disabled}
-  {autofocus}
-  {readonly}
-  {autocomplete}
-  bind:value
-  on:change
-  on:input
-  on:focus
-  on:blur
-/>
+<!-- svelte-ignore a11y_autofocus -->
+<input type="text" {...rest} bind:value />
 
 <style>
   input {

--- a/src/lib/components/inputs/Text.svelte
+++ b/src/lib/components/inputs/Text.svelte
@@ -11,7 +11,7 @@
 </script>
 
 <!-- svelte-ignore a11y_autofocus -->
-<input type="text" {...rest} bind:value />
+<input {...rest} type="text" bind:value />
 
 <style>
   input {

--- a/src/lib/components/inputs/TextArea.svelte
+++ b/src/lib/components/inputs/TextArea.svelte
@@ -1,7 +1,7 @@
 <!-- @component
 A text area for writing text
 -->
-<script lang="ts" context="module">
+<script lang="ts" module>
   import { browser } from "$app/environment";
 
   /**
@@ -11,7 +11,7 @@ A text area for writing text
   export function autoResize(textarea: HTMLTextAreaElement, offset = 2) {
     if (browser && CSS.supports("field-sizing", "content")) return;
     const resize = () => {
-      textarea.style.height = "auto"; // reset the height
+      textarea.style.height = "auto";
       textarea.style.height = `${textarea.scrollHeight + offset}px`;
     };
 
@@ -33,10 +33,14 @@ A text area for writing text
 </script>
 
 <script lang="ts">
-  export let value = "";
+  import type { HTMLTextareaAttributes } from "svelte/elements";
+
+  interface Props extends HTMLTextareaAttributes {}
+
+  let { value = $bindable(""), ...rest }: Props = $props();
 </script>
 
-<textarea bind:value use:autoResize {...$$restProps}></textarea>
+<textarea bind:value use:autoResize {...rest}></textarea>
 
 <style>
   textarea {

--- a/src/lib/components/inputs/generator.ts
+++ b/src/lib/components/inputs/generator.ts
@@ -1,4 +1,4 @@
-import type { ComponentType } from "svelte";
+import type { Component } from "svelte";
 
 import ArrayField from "./ArrayField.svelte";
 import Checkbox from "./Checkbox.svelte";
@@ -7,7 +7,7 @@ import Text from "./Text.svelte";
 import Choices from "./Choices.svelte";
 
 // https://json-schema.org/understanding-json-schema/reference/type.html
-const fields = {
+const fields: Record<string, Component<any> | null> = {
   string: Text,
   number: Number,
   integer: Number,
@@ -23,7 +23,7 @@ const fields = {
  * Automatically get a form field component based on the property type of a JSON schema object
  *
  */
-export function autofield(params: any, fallback = Text): ComponentType {
+export function autofield(params: any, fallback = Text): Component<any> {
   const type = String(params.type).toLowerCase();
 
   if (!fields[type]) {

--- a/src/lib/components/inputs/stories/AccessLevel.stories.svelte
+++ b/src/lib/components/inputs/stories/AccessLevel.stories.svelte
@@ -1,5 +1,4 @@
 <script module lang="ts">
-  import type { ComponentProps } from "svelte";
   import { defineMeta } from "@storybook/addon-svelte-csf";
   import AccessLevel from "../AccessLevel.svelte";
 
@@ -9,14 +8,10 @@
     tags: ["autodocs"],
     parameters: { layout: "centered" },
   });
-
-  const args: Partial<ComponentProps<typeof AccessLevel>> = {
-    selected: "private",
-  };
 </script>
 
-<Story name="Private" {args} />
-<Story name="Organization" args={{ ...args, selected: "organization" }} />
-<Story name="Public" args={{ ...args, selected: "public" }} />
-<Story name="Row" args={{ ...args, direction: "row" }} />
-<Story name="Required" args={{ required: true, selected: undefined }} />
+<Story name="Private" args={{ selected: "private" }} />
+<Story name="Organization" args={{ selected: "organization" }} />
+<Story name="Public" args={{ selected: "public" }} />
+<Story name="Row" args={{ selected: "private", direction: "row" }} />
+<Story name="Required" args={{ required: true, selected: null }} />

--- a/src/lib/components/inputs/stories/AccessLevel.stories.svelte
+++ b/src/lib/components/inputs/stories/AccessLevel.stories.svelte
@@ -1,25 +1,22 @@
-<script context="module" lang="ts">
-  import { Story, Template } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import type { ComponentProps } from "svelte";
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import AccessLevel from "../AccessLevel.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Inputs /Access Level",
     component: AccessLevel,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
-  };
+  });
 
-  let args = {
+  const args: Partial<ComponentProps<typeof AccessLevel>> = {
     selected: "private",
   };
 </script>
-
-<Template let:args>
-  <AccessLevel {...args} />
-</Template>
 
 <Story name="Private" {args} />
 <Story name="Organization" args={{ ...args, selected: "organization" }} />
 <Story name="Public" args={{ ...args, selected: "public" }} />
 <Story name="Row" args={{ ...args, direction: "row" }} />
-<Story name="Required" args={{ required: true, selected: null }} />
+<Story name="Required" args={{ required: true, selected: undefined }} />

--- a/src/lib/components/inputs/stories/Checkbox.stories.svelte
+++ b/src/lib/components/inputs/stories/Checkbox.stories.svelte
@@ -1,22 +1,18 @@
-<script context="module" lang="ts">
-  import { Story, Template } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import Checkbox from "../Checkbox.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Inputs /Checkbox",
     component: Checkbox,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
-  };
+  });
 </script>
-
-<Template let:args>
-  <Checkbox {...args} />
-</Template>
 
 <Story name="off" />
 
-<Story name="on" args={{ checked: true }} />
+<Story name="on" args={{ value: true }} />
 
 <Story name="some" args={{ indeterminate: true }} />
 

--- a/src/lib/components/inputs/stories/Dropzone.stories.svelte
+++ b/src/lib/components/inputs/stories/Dropzone.stories.svelte
@@ -1,23 +1,27 @@
-<script context="module" lang="ts">
-  import { Story, Template } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import type { ComponentProps } from "svelte";
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import { action } from "@storybook/addon-actions";
   import Dropzone from "../Dropzone.svelte";
 
-  let args = {
-    active: false,
-    disabled: false,
-    onDrop: action("Drop"),
-  };
-
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Inputs /Dropzone",
     component: Dropzone,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
+    render: template,
+  });
+
+  type Args = ComponentProps<typeof Dropzone>;
+
+  const args = {
+    active: false,
+    disabled: false,
+    onDrop: action("Drop"),
   };
 </script>
 
-<Template let:args>
+{#snippet template(args: Args)}
   <Dropzone {...args}>
     <svelte:fragment let:active let:disabled>
       <div class="dropzone" class:active class:disabled>
@@ -31,9 +35,9 @@
       </div>
     </svelte:fragment>
   </Dropzone>
-</Template>
+{/snippet}
 
-<Story name="Default" />
+<Story name="Default" {args} />
 <Story name="Active" args={{ ...args, active: true }} />
 <Story name="Disabled" args={{ ...args, disabled: true }} />
 

--- a/src/lib/components/inputs/stories/Dropzone.stories.svelte
+++ b/src/lib/components/inputs/stories/Dropzone.stories.svelte
@@ -23,7 +23,7 @@
 
 {#snippet template(args: Args)}
   <Dropzone {...args}>
-    <svelte:fragment let:active let:disabled>
+    {#snippet children({ active, disabled })}
       <div class="dropzone" class:active class:disabled>
         <p>Drop files here</p>
         <dl>
@@ -33,7 +33,7 @@
           <dd>{String(disabled)}</dd>
         </dl>
       </div>
-    </svelte:fragment>
+    {/snippet}
   </Dropzone>
 {/snippet}
 

--- a/src/lib/components/inputs/stories/File.stories.svelte
+++ b/src/lib/components/inputs/stories/File.stories.svelte
@@ -1,24 +1,28 @@
-<script context="module" lang="ts">
-  import { Template, Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import type { ComponentProps } from "svelte";
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import { action } from "@storybook/addon-actions";
   import File from "../File.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Inputs /File",
     component: File,
     tags: ["autodocs"],
-  };
+    render: template,
+  });
 
-  let args = {
+  type Args = ComponentProps<typeof File>;
+
+  const args = {
     name: "fileInput",
     multiple: false,
     onFileSelect: action("File Select"),
   };
 </script>
 
-<Template let:args>
+{#snippet template(args: Args)}
   <File {...args}>Select Files</File>
-</Template>
+{/snippet}
 
 <Story name="Default" {args} />
 <Story name="Multiple" args={{ ...args, multiple: true }} />

--- a/src/lib/components/inputs/stories/Language.stories.svelte
+++ b/src/lib/components/inputs/stories/Language.stories.svelte
@@ -1,28 +1,28 @@
-<script context="module" lang="ts">
-  import { Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import Language from "../Language.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Inputs /Language",
     component: Language,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
-  };
+  });
 </script>
 
-<Story name="default">
+<Story name="default" asChild>
   <div>
     <Language placeholder="Language" />
   </div>
 </Story>
 
-<Story name="Required">
+<Story name="Required" asChild>
   <div>
     <Language placeholder="Select a language" required />
   </div>
 </Story>
 
-<Story name="With Pre-selected Value">
+<Story name="With Pre-selected Value" asChild>
   <div>
     <Language
       placeholder="Language"
@@ -31,19 +31,19 @@
   </div>
 </Story>
 
-<Story name="Custom Name Attribute">
+<Story name="Custom Name Attribute" asChild>
   <div>
     <Language name="document_language" placeholder="Document Language" />
   </div>
 </Story>
 
-<Story name="Custom Placeholder">
+<Story name="Custom Placeholder" asChild>
   <div>
     <Language placeholder="Choose document language..." />
   </div>
 </Story>
 
-<Story name="Required With French Pre-selected">
+<Story name="Required With French Pre-selected" asChild>
   <div>
     <Language
       placeholder="Language"

--- a/src/lib/components/inputs/stories/ProjectAccess.stories.svelte
+++ b/src/lib/components/inputs/stories/ProjectAccess.stories.svelte
@@ -1,14 +1,12 @@
-<script context="module" lang="ts">
-  import { Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import ProjectAccess from "../ProjectAccess.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Inputs /Project access",
     component: ProjectAccess,
     parameters: { layout: "centered" },
-  };
+  });
 </script>
 
-<Story name="default">
-  <ProjectAccess />
-</Story>
+<Story name="default" />

--- a/src/lib/components/inputs/stories/Select.stories.svelte
+++ b/src/lib/components/inputs/stories/Select.stories.svelte
@@ -1,12 +1,12 @@
-<script context="module" lang="ts">
-  import { Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import Select from "../Select.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Inputs / Select",
     component: Select,
     tags: ["autodocs"],
-  };
+  });
 
   const name = "select";
   const options = [
@@ -19,7 +19,7 @@
   ];
 </script>
 
-<Story name="Empty">
+<Story name="Empty" asChild>
   <Select
     {name}
     {options}
@@ -29,7 +29,7 @@
   />
 </Story>
 
-<Story name="Clearable">
+<Story name="Clearable" asChild>
   <Select
     {name}
     {options}
@@ -40,7 +40,7 @@
   />
 </Story>
 
-<Story name="Multiple">
+<Story name="Multiple" asChild>
   <Select
     {name}
     {options}
@@ -51,7 +51,7 @@
   />
 </Story>
 
-<Story name="With Placeholder">
+<Story name="With Placeholder" asChild>
   <Select
     {name}
     {options}
@@ -62,7 +62,7 @@
   />
 </Story>
 
-<Story name="With Selection">
+<Story name="With Selection" asChild>
   <Select
     {name}
     {options}
@@ -73,7 +73,7 @@
   />
 </Story>
 
-<Story name="With Selection, not object">
+<Story name="With Selection, not object" asChild>
   <Select
     {name}
     {options}
@@ -83,6 +83,6 @@
   />
 </Story>
 
-<Story name="Disabled">
+<Story name="Disabled" asChild>
   <Select {name} {options} disabled />
 </Story>

--- a/src/lib/components/inputs/stories/Switch.stories.svelte
+++ b/src/lib/components/inputs/stories/Switch.stories.svelte
@@ -1,23 +1,19 @@
-<script context="module" lang="ts">
-  import { Template, Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import Switch from "../Switch.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Inputs /Switch",
     component: Switch,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
-  };
+  });
 
-  let args = {
+  const args = {
     checked: false,
     disabled: false,
   };
 </script>
-
-<Template let:args>
-  <Switch {...args} />
-</Template>
 
 <Story name="Off" {args} />
 <Story name="On" args={{ ...args, checked: true }} />

--- a/src/lib/components/inputs/stories/Text.stories.svelte
+++ b/src/lib/components/inputs/stories/Text.stories.svelte
@@ -1,22 +1,18 @@
-<script context="module" lang="ts">
-  import { Template, Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import Text from "../Text.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Inputs /Text",
     component: Text,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
-  };
+  });
 
-  let args = {
+  const args = {
     name: "textInput",
   };
 </script>
-
-<Template let:args>
-  <Text {...args} />
-</Template>
 
 <Story name="Empty" {args} />
 

--- a/src/lib/components/inputs/stories/Textarea.stories.svelte
+++ b/src/lib/components/inputs/stories/Textarea.stories.svelte
@@ -1,23 +1,27 @@
-<script context="module" lang="ts">
-  import { Template, Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import type { ComponentProps } from "svelte";
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import TextArea from "../TextArea.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Forms / Inputs /TextArea",
     component: TextArea,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
-  };
+    render: template,
+  });
 
-  let args = {
+  type Args = ComponentProps<typeof TextArea>;
+
+  const args = {
     name: "textInput",
     value: "",
   };
 </script>
 
-<Template let:args>
+{#snippet template(args: Args)}
   <div><TextArea {...args} /></div>
-</Template>
+{/snippet}
 
 <Story name="Empty" {args} />
 

--- a/src/lib/components/sidebar/Documents.svelte
+++ b/src/lib/components/sidebar/Documents.svelte
@@ -103,7 +103,7 @@
     {/snippet}
 
     {#snippet action()}
-      <Button ghost minW={false} mode="primary" size="small" href="/documents">
+      <Button ghost minW={false} mode="primary" size="small" href="/documents/">
         <Search16 height="14" width="14" />
         {$_("common.explore")}
       </Button>

--- a/src/lib/components/sidebar/SidebarGroup.svelte
+++ b/src/lib/components/sidebar/SidebarGroup.svelte
@@ -30,11 +30,23 @@
     }
   }
 
-  function onClick() {
+  // The action (e.g. a link or button) lives inside the clickable header but
+  // has its own behavior. Don't toggle when the event came from such a control,
+  // and don't stop propagation — that would break SvelteKit's client-side nav,
+  // whose click listener sits above us on <html>.
+  function fromAction(event: Event): boolean {
+    const el = event.target as Element | null;
+    return !!el?.closest("a, button");
+  }
+
+  function onClick(event: MouseEvent) {
+    if (fromAction(event)) return;
     toggle(collapsed);
   }
 
-  function onKeydown({ key }) {
+  function onKeydown(event: KeyboardEvent) {
+    if (fromAction(event)) return;
+    const { key } = event;
     if (["Enter", " "].includes(key)) {
       toggle(collapsed);
     } else if (["ArrowDown", "ArrowRight"].includes(key)) {
@@ -59,9 +71,8 @@
       </span>
       {#if title}<span class="title">{@render title?.()}</span>{/if}
       {#if action}
-        <span role="button" tabindex="0">
-          {@render action?.()}
-        </span>{/if}
+        {@render action?.()}
+      {/if}
     </header>
   {/if}
   {#if !collapsed}

--- a/src/lib/components/sidebar/tests/SidebarGroup.demo.svelte
+++ b/src/lib/components/sidebar/tests/SidebarGroup.demo.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import SidebarGroup from "../SidebarGroup.svelte";
+
+  interface Props {
+    name?: string;
+    collapsed?: boolean;
+  }
+
+  let { name = undefined, collapsed = false }: Props = $props();
+</script>
+
+<SidebarGroup {name} {collapsed}>
+  {#snippet title()}
+    <span>Group title</span>
+  {/snippet}
+
+  {#snippet action()}
+    <a href="#explore">Explore</a>
+  {/snippet}
+
+  <p>Body content</p>
+</SidebarGroup>

--- a/src/lib/components/sidebar/tests/SidebarGroup.test.ts
+++ b/src/lib/components/sidebar/tests/SidebarGroup.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+
+import SidebarGroupDemo from "./SidebarGroup.demo.svelte";
+
+describe("SidebarGroup", () => {
+  it("toggles collapsed state when the header is clicked", async () => {
+    const user = userEvent.setup();
+    render(SidebarGroupDemo);
+
+    // Body is visible to start
+    expect(screen.getByText("Body content")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Group title"));
+
+    expect(screen.queryByText("Body content")).not.toBeInTheDocument();
+  });
+
+  it("does not toggle when the action link is clicked", async () => {
+    const user = userEvent.setup();
+    render(SidebarGroupDemo);
+
+    expect(screen.getByText("Body content")).toBeInTheDocument();
+
+    // Clicking the action (a link) should let it navigate, not collapse the group
+    await user.click(screen.getByRole("link", { name: "Explore" }));
+
+    expect(screen.getByText("Body content")).toBeInTheDocument();
+  });
+
+  it("does not stop propagation on the action click (so SvelteKit can route)", async () => {
+    const user = userEvent.setup();
+    render(SidebarGroupDemo);
+
+    let reachedAncestor = false;
+    // SvelteKit's client router listens on a shared ancestor (<html>); a link
+    // click must reach it. Simulate that with an ancestor-level listener.
+    const onAncestorClick = () => (reachedAncestor = true);
+    document.documentElement.addEventListener("click", onAncestorClick);
+
+    await user.click(screen.getByRole("link", { name: "Explore" }));
+
+    expect(reachedAncestor).toBe(true);
+
+    document.documentElement.removeEventListener("click", onAncestorClick);
+  });
+});

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -153,10 +153,10 @@ Assumes it's a child of a ViewerContext
   }
 
   function onEditNoteSuccess(
-    e: CustomEvent<Maybe<Nullable<NoteType>>>,
+    note: Maybe<Nullable<NoteType>>,
     oldNote: Maybe<Nullable<NoteType>>,
   ) {
-    const editedNote = e.detail;
+    const editedNote = note;
     // Make an optimistic update to the `$documentStore`,
     // which should be overwritten by invalidation.
     // Start by removing the old note from the notes array.
@@ -223,8 +223,8 @@ Assumes it's a child of a ViewerContext
           note={$currentNote}
           {document}
           {page_number}
-          on:close={closeNote}
-          on:success={(e) => onEditNoteSuccess(e, $currentNote)}
+          onclose={closeNote}
+          onsuccess={(note) => onEditNoteSuccess(note, $currentNote)}
         />
       {:else}
         {#key $currentNote.id}
@@ -257,8 +257,8 @@ Assumes it's a child of a ViewerContext
         <EditNote
           {document}
           bind:note={$newNote}
-          on:close={closeNote}
-          on:success={(e) => onEditNoteSuccess(e, undefined)}
+          onclose={closeNote}
+          onsuccess={(note) => onEditNoteSuccess(note, undefined)}
         />
       </div>
     {/if}

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -256,7 +256,7 @@ Assumes it's a child of a ViewerContext
       >
         <EditNote
           {document}
-          bind:note={$newNote}
+          note={$newNote}
           onclose={closeNote}
           onsuccess={(note) => onEditNoteSuccess(note, undefined)}
         />

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -177,6 +177,12 @@ Selectable text can be rendered in one of two ways:
 
   // if I click on a note, pass click events through to underlying note text
   function checkForHighlightClick(click: MouseEvent) {
+    // The open note card (the read view or the edit form) and note tabs handle
+    // their own clicks. Don't forward those clicks to a highlight just because
+    // they overlap its bounds — otherwise clicking inside an open EditNote form
+    // reopens the note beneath it and editing becomes impossible.
+    if ((click.target as HTMLElement)?.closest(".note.card, .note-tab")) return;
+
     const clickX = click.clientX;
     const clickY = click.clientY;
 

--- a/src/lib/components/viewer/PageActions.svelte
+++ b/src/lib/components/viewer/PageActions.svelte
@@ -140,7 +140,7 @@
       <EditNote
         {document}
         page_number={page_number - 1}
-        on:close={() => (pageNote = false)}
+        onclose={() => (pageNote = false)}
       />
     </Modal>
   </Portal>

--- a/src/routes/(app)/documents/[id]-[slug]/+page.server.ts
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.server.ts
@@ -1,12 +1,11 @@
 import type { Actions } from "./$types";
-import type { Access, Document, Note } from "$lib/api/types";
+import type { Document } from "$lib/api/types";
 
 import { fail } from "@sveltejs/kit";
 import { setFlash, redirect } from "sveltekit-flash-message/server";
 
 import { CSRF_COOKIE_NAME, EMBED_URL } from "@/config/config.js";
 import { destroy, edit, redact } from "$lib/api/documents";
-import * as notes from "$lib/api/notes";
 
 export function load({ cookies, request, url }) {
   const inIframe = request.headers.get("Sec-Fetch-Dest") === "iframe";
@@ -153,112 +152,5 @@ export const actions = {
 
     setFlash({ message: "Updated ownership", status: "success" }, cookies);
     return data;
-  },
-
-  async createAnnotation({ cookies, request, fetch, params }) {
-    const csrf_token = cookies.get(CSRF_COOKIE_NAME);
-    if (!csrf_token) {
-      return fail(403, { message: "Missing CSRF token" });
-    }
-    const form = await request.formData();
-
-    const [x1, x2, y1, y2] = JSON.parse(form.get("coords") as string);
-
-    const note: Partial<Note> = {
-      title: form.get("title") as string,
-      content: (form.get("content") as string) ?? "",
-      access: form.get("access") as Access,
-      page_number: form.get("page_number")
-        ? Number(form.get("page_number"))
-        : undefined,
-      x1,
-      x2,
-      y1,
-      y2,
-    };
-
-    const { data: created, error } = await notes.create(
-      params.id,
-      note,
-      csrf_token,
-      fetch,
-    );
-
-    if (error) {
-      setFlash({ message: error.message, status: "error" }, cookies);
-      return fail(error.status, {
-        message: error.message,
-        errors: error.errors,
-      });
-    }
-
-    setFlash({ message: "Note created", status: "success" }, cookies);
-    return {
-      success: true,
-      note: created,
-    };
-  },
-
-  async updateAnnotation({ cookies, request, fetch, params }) {
-    const csrf_token = cookies.get(CSRF_COOKIE_NAME);
-    if (!csrf_token) {
-      return fail(403, { message: "Missing CSRF token" });
-    }
-    const form = await request.formData();
-
-    const note_id = form.get("id");
-
-    // only limited update options for now
-    const note: Partial<Note> = {
-      title: form.get("title") as string,
-      content: (form.get("content") as string) ?? "",
-      access: form.get("access") as Access,
-    };
-
-    const { data: updated, error } = await notes.update(
-      params.id,
-      Number(note_id),
-      note,
-      csrf_token,
-      fetch,
-    );
-
-    if (error) {
-      setFlash({ message: error.message, status: "error" }, cookies);
-      return fail(error.status, {
-        message: error.message,
-        errors: error.errors,
-      });
-    }
-
-    setFlash({ message: "Note updated", status: "success" }, cookies);
-    return {
-      success: true,
-      note: updated,
-    };
-  },
-
-  async deleteAnnotation({ cookies, request, fetch, params }) {
-    const csrf_token = cookies.get(CSRF_COOKIE_NAME);
-    if (!csrf_token) {
-      return fail(403, { message: "Missing CSRF token" });
-    }
-    const form = await request.formData();
-
-    const note_id = Number(form.get("id"));
-
-    if (!note_id) return fail(400, { id: "missing" });
-
-    const { error } = await notes.remove(params.id, note_id, csrf_token, fetch);
-
-    if (error) {
-      setFlash({ message: error.message, status: "error" }, cookies);
-      return fail(error.status, { message: error.message });
-    }
-
-    setFlash({ message: "Note deleted", status: "success" }, cookies);
-    return {
-      success: true,
-    };
   },
 } satisfies Actions;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "noUncheckedIndexedAccess": true,
     "strictNullChecks": true,
+    "strict": false,
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": [


### PR DESCRIPTION
Closes #1239 

Migrates inputs but doesn't address the bigger question in #586. Introduces better default binding, so partially addresses #1088. Will come back to both of those issues once this merges.

This touches a lot of files because we have lots of inputs and we use them all over.