### PR TITLE
E2E coverage: document & note lifecycles (notes, redaction, edit metadata, reprocess)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -134,13 +134,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -160,14 +160,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -190,22 +190,22 @@
       "license": "MIT"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
-      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
       "license": "MIT OR Apache-2.0",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
-      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+        "workerd": ">1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260409.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260409.1.tgz",
-      "integrity": "sha512-h/bkaC0HJL63aqAGnV0oagqpBiTSstabODThkeMSbG8kctl0Jb4jlq1pNHJPmYGazFNtfyagrUZFb6HN22GX7w==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260617.1.tgz",
+      "integrity": "sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==",
       "cpu": [
         "x64"
       ],
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260409.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260409.1.tgz",
-      "integrity": "sha512-HTAC+B9uSYcm+GjN3UYJjuun19GqYtK1bAFJ0KECXyfsgIDwH1MTzxbTxzJpZUbWLw8s0jcwCU06MWZj6cgnxQ==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==",
       "cpu": [
         "arm64"
       ],
@@ -246,9 +246,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260409.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260409.1.tgz",
-      "integrity": "sha512-QIoNq5cgmn1ko8qlngmgZLXQr2KglrjvIwVFOyJI3rbIpt8631n/YMzHPiOWgt38Cb6tcni8fXOzkcvIX2lBDg==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260617.1.tgz",
+      "integrity": "sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==",
       "cpu": [
         "x64"
       ],
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260409.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260409.1.tgz",
-      "integrity": "sha512-HJGBMTfPDb0GCjwdxWFx63wS20TYDVmtOuA5KVri/CiFnit71y++kmseVmemjsgLFFIzoEAuFG/xUh1FJLo6tg==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260617.1.tgz",
+      "integrity": "sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==",
       "cpu": [
         "arm64"
       ],
@@ -278,9 +278,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260409.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260409.1.tgz",
-      "integrity": "sha512-GttFO0+TvE0rJNQbDlxC6kq2Q7uFxoZRo74Z9d/trUrLgA14HEVTTXobYyiWrDZ9Qp2W5KN1CrXQXiko0zE38Q==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260617.1.tgz",
+      "integrity": "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==",
       "cpu": [
         "x64"
       ],
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260410.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260410.1.tgz",
-      "integrity": "sha512-dPZT4aXxwhGHFhWA9iZhWVfFoO8g9exiLzeaS8y43Dw0Sard6Gb3o5LJjReav3ejHbQLHUfGEiZsRPGW8qmgMg==",
+      "version": "4.20260620.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260620.1.tgz",
+      "integrity": "sha512-WB81w9u1bAS7KcekpC7/nYhLpIXAEtgybso7XgGJV8CQKNkNPYcyjvICLdghOlDBi/9Ivk+f7NRckV2Bkq1bDg==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2743,9 +2743,9 @@
       }
     },
     "node_modules/@speed-highlight/core": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
-      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
       "license": "CC0-1.0"
     },
     "node_modules/@standard-schema/spec": {
@@ -3564,9 +3564,9 @@
       }
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
-      "integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -3587,17 +3587,17 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.57.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.57.1.tgz",
-      "integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
+      "version": "2.66.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.66.0.tgz",
+      "integrity": "sha512-7nN4Ur4+nofZ36DVo83JbRe02m61Vc+I441mML/DYa1pUTZ/x26+lbrdqPen8gjmsUc6flMtHEqAtn0UfmfvAw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.9",
         "@types/cookie": "^0.6.0",
-        "acorn": "^8.14.1",
+        "acorn": "^8.16.0",
         "cookie": "^0.6.0",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.2",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
@@ -3894,44 +3894,30 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/types": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
-      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.16.tgz",
-      "integrity": "sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.16",
-        "ast-v8-to-istanbul": "^0.3.8",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
-        "istanbul-lib-source-maps": "^5.0.6",
         "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.1",
+        "magicast": "^0.5.2",
         "obug": "^2.1.1",
-        "std-env": "^3.10.0",
-        "tinyrainbow": "^3.0.3"
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.16",
-        "vitest": "4.0.16"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -3940,27 +3926,28 @@
       }
     },
     "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
-      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
-      "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4022,13 +4009,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
-      "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.16",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4037,7 +4024,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -4049,9 +4036,9 @@
       }
     },
     "node_modules/@vitest/mocker/node_modules/@vitest/spy": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
-      "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4082,13 +4069,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
-      "integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.16",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4096,40 +4083,42 @@
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
-      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner/node_modules/@vitest/utils": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
-      "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
-      "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4138,13 +4127,28 @@
       }
     },
     "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
-      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4189,9 +4193,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4281,21 +4285,21 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.9.tgz",
-      "integrity": "sha512-dSC6tJeOJxbZrPzPbv5mMd6CMiQ1ugaVXXPRad2fXUSsy1kstFn9XQWemV9VW7Y7kpxgQ/4WMoZfwdH8XSU48w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
-        "js-tokens": "^9.0.1"
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4729,6 +4733,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -4938,9 +4949,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -5121,9 +5132,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6547,21 +6558,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.23",
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -6594,10 +6590,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6833,14 +6839,14 @@
       }
     },
     "node_modules/magicast": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
-      "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
         "source-map-js": "^1.2.1"
       }
     },
@@ -6978,44 +6984,23 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260409.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260409.0.tgz",
-      "integrity": "sha512-ayl6To4av0YuXsSivGgWLj+Ug8xZ0Qz3sGV8+Ok2LhNVl6m8m5ktEBM3LX9iT9MtLZRJwBlJrKcraNs/DlZQfA==",
+      "version": "4.20260617.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260617.1.tgz",
+      "integrity": "sha512-Go3/gzStm99QHptsSgU+q1S+xDfLoRgwjJNY80kaTVi0ENhTyqKq+sc4xZiWBSbM7uUcJwmzm8+QFKtcYLJ9nw==",
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "sharp": "^0.34.5",
-        "undici": "7.24.4",
-        "workerd": "1.20260409.1",
-        "ws": "8.18.0",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260617.1",
+        "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
       "bin": {
         "miniflare": "bootstrap.js"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/miniflare/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "node": ">=22.0.0"
       }
     },
     "node_modules/minimatch": {
@@ -7210,9 +7195,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
+      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
       "funding": [
         {
           "type": "github",
@@ -7543,9 +7528,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -7562,7 +7547,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8314,9 +8299,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8438,23 +8423,23 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.0.tgz",
-      "integrity": "sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw==",
+      "version": "5.56.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.3.tgz",
+      "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.10",
         "@types/estree": "^1.0.5",
         "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.2",
+        "esrap": "^2.2.11",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -9052,13 +9037,20 @@
       }
     },
     "node_modules/svelte/node_modules/esrap": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
-      "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.11.tgz",
+      "integrity": "sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
         "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/svelte2tsx": {
@@ -9192,9 +9184,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9342,9 +9334,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -9466,9 +9458,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -9559,31 +9551,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
-      "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.16",
-        "@vitest/mocker": "4.0.16",
-        "@vitest/pretty-format": "4.0.16",
-        "@vitest/runner": "4.0.16",
-        "@vitest/snapshot": "4.0.16",
-        "@vitest/spy": "4.0.16",
-        "@vitest/utils": "4.0.16",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -9599,12 +9591,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.16",
-        "@vitest/browser-preview": "4.0.16",
-        "@vitest/browser-webdriverio": "4.0.16",
-        "@vitest/ui": "4.0.16",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -9625,6 +9620,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -9633,44 +9634,47 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
     "node_modules/vitest/node_modules/@vitest/expect": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
-      "integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.16",
-        "@vitest/utils": "4.0.16",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest/node_modules/@vitest/pretty-format": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
-      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
-      "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -9678,23 +9682,24 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
-      "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vitest/node_modules/chai": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
-      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9863,9 +9868,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260409.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260409.1.tgz",
-      "integrity": "sha512-kuWP20fAaqaLBqLbvUfY9nCF6c3C78L60G9lS6eVwBf+v8trVFIsAdLB/FtrnKm7vgVvpDzvFAfB80VIiVj95w==",
+      "version": "1.20260617.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260617.1.tgz",
+      "integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
@@ -9875,11 +9880,11 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260409.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260409.1",
-        "@cloudflare/workerd-linux-64": "1.20260409.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260409.1",
-        "@cloudflare/workerd-windows-64": "1.20260409.1"
+        "@cloudflare/workerd-darwin-64": "1.20260617.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260617.1",
+        "@cloudflare/workerd-linux-64": "1.20260617.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260617.1",
+        "@cloudflare/workerd-windows-64": "1.20260617.1"
       }
     },
     "node_modules/worktop": {
@@ -9896,32 +9901,33 @@
       }
     },
     "node_modules/wrangler": {
-      "version": "4.81.1",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.81.1.tgz",
-      "integrity": "sha512-fppPXi+W2KJ5bx1zxdUYe1e7CHj5cWPFVBPXy8hSMZhrHeIojMe3ozAktAOw1voVuQjXzbZJf/GVKyVeSjbF8w==",
+      "version": "4.103.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.103.0.tgz",
+      "integrity": "sha512-3Lv1P5t2xcSEkSTKtG+Lz+3JFryuU7YPLkaCUj7gNe+CJsjZJLtUwqsh1x595QBxkIbCE0GAvDx2DCJUU4+oqw==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.4.2",
-        "@cloudflare/unenv-preset": "2.16.0",
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.27.3",
-        "miniflare": "4.20260409.0",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260617.1",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260409.1"
+        "workerd": "1.20260617.1"
       },
       "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=20.3.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2"
+        "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260409.1"
+        "@cloudflare/workers-types": "^4.20260617.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -9930,9 +9936,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -9946,9 +9952,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -9962,9 +9968,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -9978,9 +9984,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -9994,9 +10000,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -10010,9 +10016,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -10026,9 +10032,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -10042,9 +10048,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -10058,9 +10064,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -10074,9 +10080,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -10090,9 +10096,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -10106,9 +10112,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -10122,9 +10128,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -10138,9 +10144,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -10154,9 +10160,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -10170,9 +10176,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -10186,9 +10192,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -10202,9 +10208,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -10218,9 +10224,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -10234,9 +10240,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -10250,9 +10256,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -10266,9 +10272,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -10282,9 +10288,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -10298,9 +10304,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -10314,9 +10320,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -10330,9 +10336,9 @@
       }
     },
     "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -10346,9 +10352,9 @@
       }
     },
     "node_modules/wrangler/node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -10358,32 +10364,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/wrap-ansi": {
@@ -10425,10 +10431,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,9 +15,7 @@ const baseURL = process.env.URL || "https://www.dev.documentcloud.org";
 // Where the logged-in browser session is persisted by the auth setup project.
 export const STORAGE_STATE = "playwright/.auth/user.json";
 
-// Identify our automated traffic so it can be allowlisted (e.g. in a Cloudflare
-// WAF rule) and told apart from real users. Appended to the real browser UA so
-// the browser still behaves normally. Override with PLAYWRIGHT_USER_AGENT.
+// Identify our automated traffic. Override with PLAYWRIGHT_USER_AGENT.
 const userAgent =
   process.env.PLAYWRIGHT_USER_AGENT ||
   `${devices["Desktop Chrome"].userAgent} DocumentCloud-E2E (+https://github.com/MuckRock/documentcloud-frontend)`;
@@ -37,11 +35,7 @@ export default defineConfig({
   // Retry on CI only.
   retries: process.env.CI ? 2 : 0,
 
-  // Run serially. The authenticated specs upload and (re)process documents
-  // against a shared dev/staging backend whose processing queue can't keep up
-  // with concurrent jobs — running them in parallel slows processing enough to
-  // blow the per-test timeouts. One worker keeps the whole suite reliable; it's
-  // small enough that the lost parallelism doesn't matter.
+  // Run serially to avoid overloading the backend
   workers: 1,
 
   // Rich HTML report; don't auto-open it on CI.
@@ -91,6 +85,6 @@ export default defineConfig({
       testIgnore: /.*\.anon\.spec\.ts/,
     },
 
-    // Add Firefox / WebKit projects here when ready for cross-browser runs.
+    // TODO: Add Firefox / WebKit projects here when ready for cross-browser runs.
   ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,8 +37,12 @@ export default defineConfig({
   // Retry on CI only.
   retries: process.env.CI ? 2 : 0,
 
-  // Limit workers on CI for stability; use the local default otherwise.
-  workers: process.env.CI ? 1 : undefined,
+  // Run serially. The authenticated specs upload and (re)process documents
+  // against a shared dev/staging backend whose processing queue can't keep up
+  // with concurrent jobs — running them in parallel slows processing enough to
+  // blow the per-test timeouts. One worker keeps the whole suite reliable; it's
+  // small enough that the lost parallelism doesn't matter.
+  workers: 1,
 
   // Rich HTML report; don't auto-open it on CI.
   reporter: process.env.CI ? [["html", { open: "never" }], ["list"]] : "html",

--- a/src/lib/components/home/MuckRockLogo.svelte
+++ b/src/lib/components/home/MuckRockLogo.svelte
@@ -36,6 +36,6 @@
 
 <style>
   svg {
-    fill: #0C1E27;
+    fill: #0c1e27;
   }
 </style>

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,6 @@
 # End-to-end tests
 
-[Playwright](https://playwright.dev) tests that run in a headless browser
-against a running version of the site. These are separate from the Vitest unit
-tests under `src/`.
+[Playwright](https://playwright.dev) tests that run in a headless browser against a running version of the site. These are separate from the Vitest unit tests under `src/`.
 
 ## Setup
 
@@ -21,10 +19,7 @@ npm run test:e2e:headed   # watch the browser as tests run
 npm run test:e2e:report   # open the last HTML report
 ```
 
-By default tests run against `https://www.dev.documentcloud.org`. Override the
-target with the `URL` environment variable. In CI this is set automatically to
-the PR's Cloudflare preview deploy
-(`https://preview-<PR_NUMBER>.staging.documentcloud.org`):
+By default tests run against `https://www.dev.documentcloud.org`. Override the target with the `URL` environment variable. In CI this is set automatically to the PR's Cloudflare preview deploy (`https://preview-<PR_NUMBER>.staging.documentcloud.org`):
 
 ```sh
 URL=https://preview-123.staging.documentcloud.org npm run test:e2e
@@ -34,83 +29,48 @@ URL=https://preview-123.staging.documentcloud.org npm run test:e2e
 
 The config (`playwright.config.ts`) defines three projects:
 
-- **`setup`** — runs `auth.setup.ts`, which logs in through Squarelet and saves
-  the authenticated session to `playwright/.auth/user.json`.
+- **`setup`** — runs `auth.setup.ts`, which logs in through Squarelet and saves the authenticated session to `playwright/.auth/user.json`.
 - **`chromium`** — logged-out tests. Name these files `*.anon.spec.ts`.
-- **`authenticated`** — logged-in tests. Any other `*.spec.ts` runs here and
-  reuses the saved session (depends on `setup`).
+- **`authenticated`** — logged-in tests. Any other `*.spec.ts` runs here and reuses the saved session (depends on `setup`).
 
-The suite runs with a **single worker** (`workers: 1`). The authenticated specs
-upload and (re)process documents against a shared dev/staging backend whose
-processing queue can't keep up with concurrent jobs — in parallel, processing
-slows enough to blow the per-test timeouts. The suite is small, so serial
-execution costs little and keeps it reliable.
+The suite runs with a **single worker** (`workers: 1`). The authenticated specs upload and (re)process documents against a shared dev/staging backend whose processing queue can't keep up with concurrent jobs — in parallel, processing slows enough to blow the per-test timeouts. The suite is small, so serial execution costs little and keeps it reliable.
 
 ## Authentication
 
-Authenticated tests need a dedicated test account on the dev/staging
-environment. Set credentials in `.env` (never use a production login):
+Authenticated tests need a dedicated test account on the dev/staging environment. Set credentials in `.env` (never use a production login):
 
 ```sh
 DC_TEST_USERNAME=...
 DC_TEST_PASSWORD=...
 ```
 
-If these are unset, the auth setup is skipped and authenticated tests don't run.
-The Squarelet login selectors in `auth.setup.ts` may need adjusting if
-Squarelet's markup changes.
+If these are unset, the auth setup is skipped and authenticated tests don't run. The Squarelet login selectors in `auth.setup.ts` may need adjusting if Squarelet's markup changes.
 
 ## Fixtures
 
-`fixtures/` holds sample PDFs for use in tests (e.g. file-upload flows). Prefer
-a small file (`Small pdf.pdf`) so processing finishes quickly.
+`fixtures/` holds sample PDFs for use in tests (e.g. file-upload flows). Prefer a small file (`Small pdf.pdf`) so processing finishes quickly.
 
 ## Helpers
 
-`helpers/` holds shared utilities used across specs. Currently
-`helpers/documents.ts`:
+`helpers/` holds shared utilities used across specs. Currently `helpers/documents.ts`:
 
-- `uniqueTitle(prefix)` — a per-run unique title so a spec can find _its_
-  document by name (never "the newest document", which races other runs).
-- `uploadDocument(page, { title, fixture })` — uploads through the UI and
-  returns `{ id, docApiUrl }` once the document is created. Shared by every spec
-  that needs a throwaway document.
-- `waitForProcessed(request, docApiUrl)` — polls the document API until it
-  reaches `success`. Pass `page.request` so the poll shares the authenticated
-  session.
-- `fetchDoc(page, docApiUrl)` — fetches the document detail JSON. Pair with
-  `expect.poll` to assert a field changed (the detail endpoint reflects edits
-  before the viewer header does).
-- `drawBox(page, layer)` — drags a rectangle across a drawing layer (note
-  annotation or redaction), using fractional offsets so it stays in bounds.
-- `openModalForm(trigger, form)` — clicks a trigger and retries until the
-  modal's form appears (works around the hydration race; see below).
-- `deleteDocument(page, docApiUrl, referer)` — deletes a document straight
-  through the API (CSRF from the cookie). Used as a cleanup safety net.
+- `uniqueTitle(prefix)` — a per-run unique title so a spec can find _its_ document by name (never "the newest document", which races other runs).
+- `uploadDocument(page, { title, fixture })` — uploads through the UI and returns `{ id, docApiUrl }` once the document is created. Shared by every spec that needs a throwaway document.
+- `waitForProcessed(request, docApiUrl)` — polls the document API until it reaches `success`. Pass `page.request` so the poll shares the authenticated session.
+- `fetchDoc(page, docApiUrl)` — fetches the document detail JSON. Pair with `expect.poll` to assert a field changed (the detail endpoint reflects edits before the viewer header does).
+- `drawBox(page, layer)` — drags a rectangle across a drawing layer (note annotation or redaction), using fractional offsets so it stays in bounds.
+- `openModalForm(trigger, form)` — clicks a trigger and retries until the modal's form appears (works around the hydration race; see below).
+- `deleteDocument(page, docApiUrl, referer)` — deletes a document straight through the API (CSRF from the cookie). Used as a cleanup safety net.
 
 ## The specs
 
-- **`document-lifecycle.spec.ts`** — the end-to-end backbone: upload → process →
-  confirm the PDF renders → make public → edit metadata → check text and grid
-  modes render → delete. One serial flow because every step shares the new
-  document's id.
-- **`document-management.spec.ts`** — self-contained operations that re-trigger
-  processing: redact a document, and reprocess one. Each uploads its own
-  throwaway doc and deletes it in `finally`.
-- **`note-lifecycle.spec.ts`** — the note lifecycle on the viewer: create a note
-  by drawing on the page (annotating mode), edit it, change its access, delete
-  it. Note CRUD is direct browser→API, so each step is verified via that call's
-  response.
+- **`document-lifecycle.spec.ts`** — the end-to-end backbone: upload → process → confirm the PDF renders → make public → edit metadata → check text and grid modes render → delete. One serial flow because every step shares the new document's id.
+- **`document-management.spec.ts`** — self-contained operations that re-trigger processing: redact a document, and reprocess one. Each uploads its own throwaway doc and deletes it in `finally`.
+- **`note-lifecycle.spec.ts`** — the note lifecycle on the viewer: create a note by drawing on the page (annotating mode), edit it, change its access, delete it. Note CRUD is direct browser→API, so each step is verified via that call's response.
 
 ### Known dev-backend limitation: image-rendering reprocess paths
 
-Redaction and force-OCR reprocessing both rasterize page images, which on the
-dev backend fails (`libpng16.so.16` missing in the processing worker), leaving
-the document `status: error`. This is infra, not a frontend bug. The specs are
-scoped around it: the redaction test asserts the redaction submits and the doc
-re-enters processing (not that it finishes), and the reprocess test uses a
-**plain** reprocess (no force OCR), which completes. See
-`notes/backend-redaction-libpng-error.md` for the debugging runbook.
+Redaction and force-OCR reprocessing both rasterize page images, which on the dev backend fails (`libpng16.so.16` missing in the processing worker), leaving the document `status: error`. This is infra, not a frontend bug. The specs are scoped around it: the redaction test asserts the redaction submits and the doc re-enters processing (not that it finishes), and the reprocess test uses a **plain** reprocess (no force OCR), which completes. See `notes/backend-redaction-libpng-error.md` for the debugging runbook.
 
 ## Writing e2e tests here — lessons learned
 
@@ -118,20 +78,11 @@ These bit us while building the lifecycle spec. Read before adding interactions.
 
 ### Hydration races: the first click after navigation can silently no-op
 
-Interactions that depend on a Svelte `onclick` do **nothing** if they fire
-before the page has hydrated — the element just receives focus (it shows up as
-`[active]` in the failure snapshot) and the handler never runs. The test then
-hangs waiting for a result that never comes. Native form **submit** buttons are
-unaffected (the browser submits regardless).
+Interactions that depend on a Svelte `onclick` do **nothing** if they fire before the page has hydrated — the element just receives focus (it shows up as `[active]` in the failure snapshot) and the handler never runs. The test then hangs waiting for a result that never comes. Native form **submit** buttons are unaffected (the browser submits regardless).
 
-Don't trust the first click after `goto`. Gate on a signal that only flips
-post-hydration, or retry the action:
+Don't trust the first click after `goto`. Gate on a signal that only flips post-hydration, or retry the action:
 
-- Gate on reactive state. The upload page's "Select Files" button is `disabled`
-  until the component mounts and reads the CSRF token, so
-  `await expect(selectFiles).toBeEnabled()` is a reliable "ready" signal. Then
-  drive the **real file chooser** rather than `setInputFiles` on the hidden
-  `<input>`:
+- Gate on reactive state. The upload page's "Select Files" button is `disabled` until the component mounts and reads the CSRF token, so `await expect(selectFiles).toBeEnabled()` is a reliable "ready" signal. Then drive the **real file chooser** rather than `setInputFiles` on the hidden `<input>`:
 
   ```ts
   const fileChooser = page.waitForEvent("filechooser");
@@ -139,8 +90,7 @@ post-hydration, or retry the action:
   await (await fileChooser).setFiles("tests/fixtures/Small pdf.pdf");
   ```
 
-- Retry until the effect appears. For the viewer's "Delete" (which opens a
-  modal), retry the open-click until the modal is visible:
+- Retry until the effect appears. For the viewer's "Delete" (which opens a modal), retry the open-click until the modal is visible:
 
   ```ts
   await expect(async () => {
@@ -151,50 +101,23 @@ post-hydration, or retry the action:
 
 ### Disambiguate accessible names with `exact: true`
 
-The Dropzone wrapper exposes a `role="button"` whose accessible name includes
-its child text, so `getByRole("button", { name: "Select Files" })` and
-`"Begin Upload"` each match **two** elements (strict-mode violation). Use
-`{ name: "…", exact: true }`. When a modal's confirm button shares text with the
-button that opened it (both "Delete"), scope the confirm to its form:
-`page.locator('form[action*="?/delete"]').getByRole("button", { name: "Delete", exact: true })`.
+The Dropzone wrapper exposes a `role="button"` whose accessible name includes its child text, so `getByRole("button", { name: "Select Files" })` and `"Begin Upload"` each match **two** elements (strict-mode violation). Use `{ name: "…", exact: true }`. When a modal's confirm button shares text with the button that opened it (both "Delete"), scope the confirm to its form: `page.locator('form[action*="?/delete"]').getByRole("button", { name: "Delete", exact: true })`.
 
 ### Document status: `nofile` is transient, not a failure
 
-Upload is fully client-side (create → S3 PUT → `process`). Right after create
-the document briefly reports `status: "nofile"` before moving to `pending` →
-`success`. When polling, treat only `error` (and timeout) as a real failure;
-keep waiting through `nofile`/`pending`/`readable`.
+Upload is fully client-side (create → S3 PUT → `process`). Right after create the document briefly reports `status: "nofile"` before moving to `pending` → `success`. When polling, treat only `error` (and timeout) as a real failure; keep waiting through `nofile`/`pending`/`readable`.
 
 ### Viewer modes: switch via the `mode` query param
 
-The viewer's mode switcher renders as tabs at wide widths but collapses to a
-dropdown when the toolbar is narrow, so clicking it is layout-dependent.
-Navigate directly instead: `?mode=text`, `?mode=grid`, etc. Asserting on the
-rendered content also doubles as a processing check — text mode (`.textPages
-pre`) only has content if text was extracted, and grid mode (`.pages
-img[alt*="Page"]`) only shows thumbnails once page images were generated. The
-default ("document") mode draws to `<canvas>`; assert
-`.page-container[data-loaded="true"]` to confirm pdf.js actually rendered.
+The viewer's mode switcher renders as tabs at wide widths but collapses to a dropdown when the toolbar is narrow, so clicking it is layout-dependent. Navigate directly instead: `?mode=text`, `?mode=grid`, etc. Asserting on the rendered content also doubles as a processing check — text mode (`.textPages pre`) only has content if text was extracted, and grid mode (`.pages img[alt*="Page"]`) only shows thumbnails once page images were generated. The default ("document") mode draws to `<canvas>`; assert `.page-container[data-loaded="true"]` to confirm pdf.js actually rendered.
 
 ### Verify backend mutations via the API, not the UI badge
 
-After an edit (e.g. changing access to public), the viewer header can lag
-behind backend indexing — the code even forces the value locally because it's
-"often a step behind". Use the modal closing as the UI-level success signal,
-then confirm the change by polling the document detail endpoint
-(`fetchDoc` + `expect.poll`), which reflects it immediately. For direct
-browser→API actions (notes), intercept the request's response and assert on its
-JSON — that's immediate and authoritative.
+After an edit (e.g. changing access to public), the viewer header can lag behind backend indexing — the code even forces the value locally because it's "often a step behind". Use the modal closing as the UI-level success signal, then confirm the change by polling the document detail endpoint (`fetchDoc` + `expect.poll`), which reflects it immediately. For direct browser→API actions (notes), intercept the request's response and assert on its JSON — that's immediate and authoritative.
 
 ### Reload before editing: a background invalidate can reset the form
 
-Editable forms (metadata, notes) bind their inputs to the document store. After
-any save the app calls `invalidate(...)`, and when that reload lands it
-re-renders the form and **resets your typed-but-unsaved input**. If you edit
-right after another mutation, the in-flight reload can clobber the field
-between `fill` and submit — intermittently submitting the old value. Start the
-edit from a freshly-loaded page (`await page.goto(viewerUrl)`) so no reload is
-pending.
+Editable forms (metadata, notes) bind their inputs to the document store. After any save the app calls `invalidate(...)`, and when that reload lands it re-renders the form and **resets your typed-but-unsaved input**. If you edit right after another mutation, the in-flight reload can clobber the field between `fill` and submit — intermittently submitting the old value. Start the edit from a freshly-loaded page (`await page.goto(viewerUrl)`) so no reload is pending.
 
 ### Capturing the new document id, and the viewer URL
 
@@ -209,16 +132,11 @@ const created = await page.waitForResponse(
 const { id } = await created.json();
 ```
 
-The final `slug` is most reliably read from the status poll. The viewer URL is
-`/documents/{id}-{slug}/` — note it shares the `/documents/` prefix with the
-list, so after a single delete (which navigates to the user's list) wait for
-`url.pathname === "/documents/"`, not a loose `/documents/` match.
+The final `slug` is most reliably read from the status poll. The viewer URL is `/documents/{id}-{slug}/` — note it shares the `/documents/` prefix with the list, so after a single delete (which navigates to the user's list) wait for `url.pathname === "/documents/"`, not a loose `/documents/` match.
 
 ### Direct API calls (status polls, cleanup)
 
-`page.request` shares the browser context's cookies, so it's authenticated for
-reading private documents. For mutating calls (e.g. cleanup DELETE) set the CSRF
-header and a `Referer`:
+`page.request` shares the browser context's cookies, so it's authenticated for reading private documents. For mutating calls (e.g. cleanup DELETE) set the CSRF header and a `Referer`:
 
 ```ts
 const csrf =
@@ -231,17 +149,10 @@ await page.request.delete(docApiUrl, {
 
 ### Always clean up test data
 
-Anything a spec creates should be removed even when assertions fail. Capture the
-id early, do the work in `try`, and delete in `finally` (through the API if the
-UI delete didn't run). The lifecycle spec also asserts the document 404s after
-deletion to prove cleanup worked.
+Anything a spec creates should be removed even when assertions fail. Capture the id early, do the work in `try`, and delete in `finally` (through the API if the UI delete didn't run). The lifecycle spec also asserts the document 404s after deletion to prove cleanup worked.
 
 ## Debugging tips
 
-- A failed run drops a screenshot, video, and (on retry/CI) a trace under
-  `test-results/`. Open a trace with `npx playwright show-trace <path>`.
-- `error-context.md` next to those artifacts contains an aria snapshot of the
-  page at the moment of failure — great for seeing whether a modal actually
-  opened or which elements matched a role/name.
-- `npm run test:e2e:ui` (Playwright UI mode) is the fastest way to step through
-  a flow and inspect selectors live.
+- A failed run drops a screenshot, video, and (on retry/CI) a trace under `test-results/`. Open a trace with `npx playwright show-trace <path>`.
+- `error-context.md` next to those artifacts contains an aria snapshot of the page at the moment of failure — great for seeing whether a modal actually opened or which elements matched a role/name.
+- `npm run test:e2e:ui` (Playwright UI mode) is the fastest way to step through a flow and inspect selectors live.

--- a/tests/README.md
+++ b/tests/README.md
@@ -40,6 +40,12 @@ The config (`playwright.config.ts`) defines three projects:
 - **`authenticated`** — logged-in tests. Any other `*.spec.ts` runs here and
   reuses the saved session (depends on `setup`).
 
+The suite runs with a **single worker** (`workers: 1`). The authenticated specs
+upload and (re)process documents against a shared dev/staging backend whose
+processing queue can't keep up with concurrent jobs — in parallel, processing
+slows enough to blow the per-test timeouts. The suite is small, so serial
+execution costs little and keeps it reliable.
+
 ## Authentication
 
 Authenticated tests need a dedicated test account on the dev/staging
@@ -66,20 +72,45 @@ a small file (`Small pdf.pdf`) so processing finishes quickly.
 
 - `uniqueTitle(prefix)` — a per-run unique title so a spec can find _its_
   document by name (never "the newest document", which races other runs).
+- `uploadDocument(page, { title, fixture })` — uploads through the UI and
+  returns `{ id, docApiUrl }` once the document is created. Shared by every spec
+  that needs a throwaway document.
 - `waitForProcessed(request, docApiUrl)` — polls the document API until it
   reaches `success`. Pass `page.request` so the poll shares the authenticated
   session.
+- `fetchDoc(page, docApiUrl)` — fetches the document detail JSON. Pair with
+  `expect.poll` to assert a field changed (the detail endpoint reflects edits
+  before the viewer header does).
+- `drawBox(page, layer)` — drags a rectangle across a drawing layer (note
+  annotation or redaction), using fractional offsets so it stays in bounds.
+- `openModalForm(trigger, form)` — clicks a trigger and retries until the
+  modal's form appears (works around the hydration race; see below).
 - `deleteDocument(page, docApiUrl, referer)` — deletes a document straight
   through the API (CSRF from the cookie). Used as a cleanup safety net.
 
-## The document-lifecycle spec
+## The specs
 
-`document-lifecycle.spec.ts` is the end-to-end backbone: a logged-in user
-uploads a document, waits for it to process, confirms the PDF renders, makes it
-public, checks that text and grid viewer modes render (which proves processing
-produced text and page images), then deletes it. It's written as one serial
-flow because every step shares the new document's id. New per-document journeys
-(notes, sharing, …) should slot in before the delete.
+- **`document-lifecycle.spec.ts`** — the end-to-end backbone: upload → process →
+  confirm the PDF renders → make public → edit metadata → check text and grid
+  modes render → delete. One serial flow because every step shares the new
+  document's id.
+- **`document-management.spec.ts`** — self-contained operations that re-trigger
+  processing: redact a document, and reprocess one. Each uploads its own
+  throwaway doc and deletes it in `finally`.
+- **`note-lifecycle.spec.ts`** — the note lifecycle on the viewer: create a note
+  by drawing on the page (annotating mode), edit it, change its access, delete
+  it. Note CRUD is direct browser→API, so each step is verified via that call's
+  response.
+
+### Known dev-backend limitation: image-rendering reprocess paths
+
+Redaction and force-OCR reprocessing both rasterize page images, which on the
+dev backend fails (`libpng16.so.16` missing in the processing worker), leaving
+the document `status: error`. This is infra, not a frontend bug. The specs are
+scoped around it: the redaction test asserts the redaction submits and the doc
+re-enters processing (not that it finishes), and the reprocess test uses a
+**plain** reprocess (no force OCR), which completes. See
+`notes/backend-redaction-libpng-error.md` for the debugging runbook.
 
 ## Writing e2e tests here — lessons learned
 
@@ -151,7 +182,19 @@ After an edit (e.g. changing access to public), the viewer header can lag
 behind backend indexing — the code even forces the value locally because it's
 "often a step behind". Use the modal closing as the UI-level success signal,
 then confirm the change by polling the document detail endpoint
-(`expect.poll(... access).toBe("public")`), which reflects it immediately.
+(`fetchDoc` + `expect.poll`), which reflects it immediately. For direct
+browser→API actions (notes), intercept the request's response and assert on its
+JSON — that's immediate and authoritative.
+
+### Reload before editing: a background invalidate can reset the form
+
+Editable forms (metadata, notes) bind their inputs to the document store. After
+any save the app calls `invalidate(...)`, and when that reload lands it
+re-renders the form and **resets your typed-but-unsaved input**. If you edit
+right after another mutation, the in-flight reload can clobber the field
+between `fill` and submit — intermittently submitting the old value. Start the
+edit from a freshly-loaded page (`await page.goto(viewerUrl)`) so no reload is
+pending.
 
 ### Capturing the new document id, and the viewer URL
 

--- a/tests/document-lifecycle.spec.ts
+++ b/tests/document-lifecycle.spec.ts
@@ -12,14 +12,8 @@ import {
 // A small PDF keeps processing fast.
 const FIXTURE = "tests/fixtures/Small pdf.pdf";
 
-// The full document lifecycle, as a logged-in user experiences it: upload a
-// document, wait for it to finish processing, confirm the PDF renders, make it
-// public, check that text and grid modes work (which proves processing
-// produced text and page images), then delete it. Runs in the `authenticated`
-// project (reuses the saved session); skipped automatically when no test
-// credentials are configured.
-//
-// More steps (notes, sharing, …) can slot in before the delete later.
+// The full document lifecycle as a logged-in user: upload, wait for
+// processing, then view → publish → edit metadata → check modes → delete.
 test("upload → process → view → publish → check modes → delete", async ({
   page,
   baseURL,
@@ -49,31 +43,28 @@ test("upload → process → view → publish → check modes → delete", async
     await expect(page.locator("h1.title")).toContainText(title);
 
     // --- VERIFY THE PDF RENDERS -----------------------------------------
-    // The default ("document") mode draws each page to a <canvas> via pdf.js;
-    // a page-container flips `data-loaded` once it has actually rendered.
+    // "document" mode draws each page to a <canvas>; data-loaded flips once
+    // pdf.js has rendered.
     await expect(
       page.locator('.page-container[data-loaded="true"]').first(),
     ).toBeVisible({ timeout: 30_000 });
     await expect(page.locator(".pages canvas").first()).toBeVisible();
 
     // --- MAKE THE DOCUMENT PUBLIC ---------------------------------------
-    // The access badge in the header doubles as the edit-access trigger and
-    // currently reads "Private".
+    // The header access badge (reads "Private") is the edit-access trigger.
     const editAccessForm = page.locator('form[action*="?/edit"]');
     await openModalForm(
       page.getByRole("button", { name: "Private", exact: true }),
       editAccessForm,
     );
 
-    // Pick "Public" (a label wrapping a screen-reader-only radio) and save.
+    // "Public" is a label wrapping a screen-reader-only radio.
     await editAccessForm.locator('label[for="public"]').click();
     await editAccessForm
       .getByRole("button", { name: "Save", exact: true })
       .click();
 
-    // A successful save closes the modal. Verify the change via the API: the
-    // header badge can lag behind backend indexing, but the document detail
-    // endpoint reflects the new access immediately.
+    // Verify via the API — the header badge lags backend indexing.
     await expect(editAccessForm).toBeHidden({ timeout: 15_000 });
     await expect
       .poll(async () => (await fetchDoc(page, docApiUrl!))?.access, {
@@ -82,13 +73,10 @@ test("upload → process → view → publish → check modes → delete", async
       .toBe("public");
 
     // --- EDIT METADATA --------------------------------------------------
-    // Reload first: the publish step's background invalidate would otherwise
-    // land mid-edit and reset the form fields (they're bound to the document
-    // store), clobbering our input. A fresh load means no reload is in flight.
+    // Reload first so the publish step's in-flight invalidate can't reset the
+    // form mid-edit (its fields are bound to the document store).
     await page.goto(viewerUrl);
 
-    // The sidebar's "Edit Document Metadata" opens the full editor. Change the
-    // title and description.
     const editedTitle = `${title} (edited)`;
     const editForm = page.locator('form[action*="?/edit"]');
     await openModalForm(
@@ -109,10 +97,8 @@ test("upload → process → view → publish → check modes → delete", async
       .toBe(editedTitle);
 
     // --- TEXT & GRID MODES ----------------------------------------------
-    // Both modes only have content if processing succeeded: text mode shows
-    // the extracted text, grid mode shows a thumbnail per generated page
-    // image. Switch via the `mode` query param (the toolbar collapses to a
-    // dropdown at narrow widths, so a URL is more robust than clicking tabs).
+    // Only have content if processing produced text + page images. Use the
+    // mode query param (the toolbar tabs collapse to a dropdown when narrow).
     await page.goto(`${viewerUrl}?mode=text`);
     await expect(page.locator(".textPages pre").first()).toContainText(
       /small pdf/i,
@@ -125,34 +111,30 @@ test("upload → process → view → publish → check modes → delete", async
     });
 
     // --- DELETE (through the UI) ----------------------------------------
-    // Open the confirmation from the viewer sidebar.
     const confirmForm = page.locator('form[action*="?/delete"]');
     await openModalForm(
       page.getByRole("button", { name: "Delete", exact: true }),
       confirmForm,
     );
 
-    // Confirm via the submit scoped inside the delete form (the modal's submit
-    // button also reads "Delete").
+    // The modal's submit also reads "Delete"; scope it to the delete form.
     await confirmForm
       .getByRole("button", { name: "Delete", exact: true })
       .click();
 
-    // A single delete navigates to the user's document list (not the viewer).
+    // A single delete navigates to the document list, not the viewer.
     await page.waitForURL((url) => url.pathname === "/documents/", {
       timeout: 30_000,
     });
     deletedViaUi = true;
 
-    // The document should now be gone from the API.
     await expect
       .poll(async () => (await page.request.get(docApiUrl!)).status(), {
         timeout: 15_000,
       })
       .toBe(404);
   } finally {
-    // Safety net: never leave a test document behind, even if the UI flow
-    // failed before the delete step ran.
+    // Safety net: never leave a test document behind.
     if (!deletedViaUi && docApiUrl && baseURL) {
       await deleteDocument(page, docApiUrl, baseURL);
     }

--- a/tests/document-lifecycle.spec.ts
+++ b/tests/document-lifecycle.spec.ts
@@ -2,8 +2,10 @@ import { test, expect } from "@playwright/test";
 
 import {
   deleteDocument,
+  fetchDoc,
   openModalForm,
   uniqueTitle,
+  uploadDocument,
   waitForProcessed,
 } from "./helpers/documents";
 
@@ -34,48 +36,9 @@ test("upload → process → view → publish → check modes → delete", async
 
   try {
     // --- UPLOAD ---------------------------------------------------------
-    await page.goto("/upload/");
-
-    // "Select Files" is disabled until the component has hydrated and read the
-    // CSRF token, so waiting for it to enable also ensures the file-picker
-    // handler is wired up before we open it.
-    const selectFiles = page.getByRole("button", {
-      name: "Select Files",
-      exact: true,
-    });
-    await expect(selectFiles).toBeEnabled();
-
-    // Drive the real file chooser rather than poking the hidden <input>, so the
-    // component's onchange handler actually runs and registers the file.
-    const fileChooser = page.waitForEvent("filechooser");
-    await selectFiles.click();
-    await (await fileChooser).setFiles(FIXTURE);
-
-    // Give our document the unique title so later steps can identify it.
-    const titleInput = page.locator('input[name="title"]');
-    await expect(titleInput).toBeVisible();
-    await titleInput.fill(title);
-
-    // The upload happens client-side, hitting the API directly. Capture the
-    // create call (POST .../api/documents/) to learn the new document's id.
-    const createResponse = page.waitForResponse(
-      (r) =>
-        r.request().method() === "POST" &&
-        /\/documents\/$/.test(new URL(r.url()).pathname),
-    );
-
-    await page
-      .getByRole("button", { name: "Begin Upload", exact: true })
-      .click();
-
-    const created = await createResponse;
-    expect(created.ok()).toBeTruthy();
-    const { id } = await created.json();
-    expect(id, "create response should include a document id").toBeTruthy();
-
-    // Derive the document API URL from the create endpoint so we don't have to
-    // hardcode the API host (it differs between dev / staging / previews).
-    docApiUrl = created.url().replace(/\/documents\/$/, `/documents/${id}/`);
+    const uploaded = await uploadDocument(page, { title, fixture: FIXTURE });
+    const { id } = uploaded;
+    docApiUrl = uploaded.docApiUrl;
 
     // --- PROCESS --------------------------------------------------------
     const processed = await waitForProcessed(page.request, docApiUrl);
@@ -113,14 +76,37 @@ test("upload → process → view → publish → check modes → delete", async
     // endpoint reflects the new access immediately.
     await expect(editAccessForm).toBeHidden({ timeout: 15_000 });
     await expect
-      .poll(
-        async () => {
-          const r = await page.request.get(docApiUrl!);
-          return r.ok() ? (await r.json()).access : undefined;
-        },
-        { timeout: 15_000 },
-      )
+      .poll(async () => (await fetchDoc(page, docApiUrl!))?.access, {
+        timeout: 15_000,
+      })
       .toBe("public");
+
+    // --- EDIT METADATA --------------------------------------------------
+    // Reload first: the publish step's background invalidate would otherwise
+    // land mid-edit and reset the form fields (they're bound to the document
+    // store), clobbering our input. A fresh load means no reload is in flight.
+    await page.goto(viewerUrl);
+
+    // The sidebar's "Edit Document Metadata" opens the full editor. Change the
+    // title and description.
+    const editedTitle = `${title} (edited)`;
+    const editForm = page.locator('form[action*="?/edit"]');
+    await openModalForm(
+      page.getByRole("button", { name: "Edit Document Metadata", exact: true }),
+      editForm,
+    );
+    await editForm.locator('input[name="title"]').fill(editedTitle);
+    await editForm
+      .locator('textarea[name="description"]')
+      .fill("Edited by the lifecycle e2e test.");
+    await editForm.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(editForm).toBeHidden({ timeout: 15_000 });
+    // Verify via the API (the header title lags backend indexing).
+    await expect
+      .poll(async () => (await fetchDoc(page, docApiUrl!))?.title, {
+        timeout: 15_000,
+      })
+      .toBe(editedTitle);
 
     // --- TEXT & GRID MODES ----------------------------------------------
     // Both modes only have content if processing succeeded: text mode shows

--- a/tests/document-management.spec.ts
+++ b/tests/document-management.spec.ts
@@ -1,131 +1,98 @@
-import { test, expect } from "@playwright/test";
-
+import { test, expect } from "./helpers/fixtures";
 import {
-  deleteDocument,
   drawBox,
+  expectPdfRendered,
   fetchDoc,
   openModalForm,
-  uniqueTitle,
-  uploadDocument,
   waitForProcessed,
 } from "./helpers/documents";
 
 // Document operations that re-trigger processing: redacting and reprocessing.
-// Each test is self-contained — it uploads its own throwaway document and
-// deletes it in `finally` — and runs in the `authenticated` project. Skipped
-// automatically when no test credentials are configured.
+// Each test gets a fresh processed document from the `processedDoc` fixture,
+// which also deletes it in teardown. Runs in the `authenticated` project;
+// skipped automatically when no test credentials are configured.
 
-const FIXTURE = "tests/fixtures/Small pdf.pdf";
-
-test("redact a document", async ({ page, baseURL }) => {
+test("redact a document", async ({ page, processedDoc }) => {
   // Redaction reprocesses the document, so budget for two processing waits.
   test.setTimeout(180_000);
   // Accept the "unsaved redactions" leave prompt if it ever fires.
   page.on("dialog", (dialog) => dialog.accept());
 
-  let docApiUrl: string | undefined;
+  const { docApiUrl, viewerUrl } = processedDoc;
 
-  try {
-    const { id, docApiUrl: url } = await uploadDocument(page, {
-      title: uniqueTitle("E2E redact"),
-      fixture: FIXTURE,
+  // Enter redacting mode and wait for the page to render so the redaction
+  // layer is sized.
+  await page.goto(`${viewerUrl}?mode=redacting`);
+  await expectPdfRendered(page);
+
+  // Draw a redaction box. The layer's pointer handlers attach on hydration, so
+  // retry the drag until a redaction box actually registers.
+  const layer = page.locator('.redactions.active[role="application"]').first();
+  await expect(layer).toBeVisible();
+  await expect(async () => {
+    await drawBox(page, layer);
+    await expect(page.locator(".redaction").first()).toBeVisible({
+      timeout: 1_000,
     });
-    docApiUrl = url;
-    const processed = await waitForProcessed(page.request, docApiUrl);
-    const viewerUrl = `/documents/${id}-${processed.slug}/`;
+  }).toPass({ timeout: 20_000 });
 
-    // Enter redacting mode and wait for the page to render so the redaction
-    // layer is sized.
-    await page.goto(`${viewerUrl}?mode=redacting`);
-    await expect(
-      page.locator('.page-container[data-loaded="true"]').first(),
-    ).toBeVisible({ timeout: 30_000 });
+  // The toolbar "Save" opens a confirmation modal whose form posts to
+  // `?/redact`; confirm there.
+  const redactForm = page.locator('form[action*="?/redact"]');
+  await openModalForm(
+    page.getByRole("button", { name: "Save", exact: true }),
+    redactForm,
+  );
+  const redactResponse = page.waitForResponse(
+    (r) => r.url().includes("?/redact") && r.request().method() === "POST",
+  );
+  await redactForm.getByRole("button", { name: "Save", exact: true }).click();
+  const redactResult = await redactResponse;
+  expect(redactResult.ok()).toBeTruthy();
+  // The action echoes the saved redactions back; a success result means the
+  // drawn box serialized and the API accepted it.
+  expect(await redactResult.text()).toContain('"type":"success"');
 
-    // Draw a redaction box. The layer's pointer handlers attach on hydration,
-    // so retry the drag until a redaction box actually registers.
-    const layer = page
-      .locator('.redactions.active[role="application"]')
-      .first();
-    await expect(layer).toBeVisible();
-    await expect(async () => {
-      await drawBox(page, layer);
-      await expect(page.locator(".redaction").first()).toBeVisible({
-        timeout: 1_000,
-      });
-    }).toPass({ timeout: 20_000 });
-
-    // The toolbar "Save" opens a confirmation modal whose form posts to
-    // `?/redact`; confirm there.
-    const redactForm = page.locator('form[action*="?/redact"]');
-    await openModalForm(
-      page.getByRole("button", { name: "Save", exact: true }),
-      redactForm,
-    );
-    const redactResponse = page.waitForResponse(
-      (r) => r.url().includes("?/redact") && r.request().method() === "POST",
-    );
-    await redactForm.getByRole("button", { name: "Save", exact: true }).click();
-    const redactResult = await redactResponse;
-    expect(redactResult.ok()).toBeTruthy();
-    // The action echoes the saved redactions back; a success result means the
-    // drawn box serialized and the API accepted it.
-    expect(await redactResult.text()).toContain('"type":"success"');
-
-    // Redacting sends the document back through the pipeline, so it leaves the
-    // "success" state. We don't wait for it to finish: redaction reprocessing
-    // errors on the dev backend (an infra limitation, not a frontend concern) —
-    // the submitted redaction above is the behavior under test.
-    await expect
-      .poll(async () => (await fetchDoc(page, docApiUrl!))?.status, {
-        timeout: 30_000,
-      })
-      .not.toBe("success");
-  } finally {
-    if (docApiUrl && baseURL) await deleteDocument(page, docApiUrl, baseURL);
-  }
+  // Redacting sends the document back through the pipeline, so it leaves the
+  // "success" state. We don't wait for it to finish: redaction reprocessing
+  // errors on the dev backend (an infra limitation, not a frontend concern) —
+  // the submitted redaction above is the behavior under test.
+  await expect
+    .poll(async () => (await fetchDoc(page, docApiUrl))?.status, {
+      timeout: 30_000,
+    })
+    .not.toBe("success");
 });
 
-test("reprocess a document", async ({ page, baseURL }) => {
+test("reprocess a document", async ({ page, processedDoc }) => {
   test.setTimeout(180_000);
 
-  let docApiUrl: string | undefined;
+  const { docApiUrl, viewerUrl } = processedDoc;
 
-  try {
-    const { id, docApiUrl: url } = await uploadDocument(page, {
-      title: uniqueTitle("E2E reprocess"),
-      fixture: FIXTURE,
-    });
-    docApiUrl = url;
-    const processed = await waitForProcessed(page.request, docApiUrl);
-    const viewerUrl = `/documents/${id}-${processed.slug}/`;
+  await page.goto(viewerUrl);
 
-    await page.goto(viewerUrl);
+  // Open the Reprocess modal from the sidebar. Identify it by the force-OCR
+  // checkbox (the sidebar trigger and the modal's confirm both read
+  // "Reprocess").
+  const reprocessForm = page.locator('form:has(input[name="force_ocr"])');
+  await openModalForm(
+    page.getByRole("button", { name: "Reprocess", exact: true }),
+    reprocessForm,
+  );
 
-    // Open the Reprocess modal from the sidebar. Identify it by the force-OCR
-    // checkbox (the sidebar trigger and the modal's confirm both read
-    // "Reprocess").
-    const reprocessForm = page.locator('form:has(input[name="force_ocr"])');
-    await openModalForm(
-      page.getByRole("button", { name: "Reprocess", exact: true }),
-      reprocessForm,
-    );
+  // Confirm with the default options. (Forcing OCR on this fixture errors on
+  // the dev backend, so a plain reprocess is the reliable path.) This posts
+  // directly to the process API from the browser.
+  const processResponse = page.waitForResponse(
+    (r) =>
+      r.url().includes("/documents/process/") &&
+      r.request().method() === "POST",
+  );
+  await reprocessForm
+    .getByRole("button", { name: "Reprocess", exact: true })
+    .click();
+  expect((await processResponse).ok()).toBeTruthy();
 
-    // Confirm with the default options. (Forcing OCR on this fixture errors on
-    // the dev backend, so a plain reprocess is the reliable path.) This posts
-    // directly to the process API from the browser.
-    const processResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes("/documents/process/") &&
-        r.request().method() === "POST",
-    );
-    await reprocessForm
-      .getByRole("button", { name: "Reprocess", exact: true })
-      .click();
-    expect((await processResponse).ok()).toBeTruthy();
-
-    // Reprocessing cycles the document back through pending to success.
-    await waitForProcessed(page.request, docApiUrl);
-  } finally {
-    if (docApiUrl && baseURL) await deleteDocument(page, docApiUrl, baseURL);
-  }
+  // Reprocessing cycles the document back through pending to success.
+  await waitForProcessed(page.request, docApiUrl);
 });

--- a/tests/document-management.spec.ts
+++ b/tests/document-management.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from "@playwright/test";
+
+import {
+  deleteDocument,
+  drawBox,
+  fetchDoc,
+  openModalForm,
+  uniqueTitle,
+  uploadDocument,
+  waitForProcessed,
+} from "./helpers/documents";
+
+// Document operations that re-trigger processing: redacting and reprocessing.
+// Each test is self-contained — it uploads its own throwaway document and
+// deletes it in `finally` — and runs in the `authenticated` project. Skipped
+// automatically when no test credentials are configured.
+
+const FIXTURE = "tests/fixtures/Small pdf.pdf";
+
+test("redact a document", async ({ page, baseURL }) => {
+  // Redaction reprocesses the document, so budget for two processing waits.
+  test.setTimeout(180_000);
+  // Accept the "unsaved redactions" leave prompt if it ever fires.
+  page.on("dialog", (dialog) => dialog.accept());
+
+  let docApiUrl: string | undefined;
+
+  try {
+    const { id, docApiUrl: url } = await uploadDocument(page, {
+      title: uniqueTitle("E2E redact"),
+      fixture: FIXTURE,
+    });
+    docApiUrl = url;
+    const processed = await waitForProcessed(page.request, docApiUrl);
+    const viewerUrl = `/documents/${id}-${processed.slug}/`;
+
+    // Enter redacting mode and wait for the page to render so the redaction
+    // layer is sized.
+    await page.goto(`${viewerUrl}?mode=redacting`);
+    await expect(
+      page.locator('.page-container[data-loaded="true"]').first(),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Draw a redaction box. The layer's pointer handlers attach on hydration,
+    // so retry the drag until a redaction box actually registers.
+    const layer = page
+      .locator('.redactions.active[role="application"]')
+      .first();
+    await expect(layer).toBeVisible();
+    await expect(async () => {
+      await drawBox(page, layer);
+      await expect(page.locator(".redaction").first()).toBeVisible({
+        timeout: 1_000,
+      });
+    }).toPass({ timeout: 20_000 });
+
+    // The toolbar "Save" opens a confirmation modal whose form posts to
+    // `?/redact`; confirm there.
+    const redactForm = page.locator('form[action*="?/redact"]');
+    await openModalForm(
+      page.getByRole("button", { name: "Save", exact: true }),
+      redactForm,
+    );
+    const redactResponse = page.waitForResponse(
+      (r) => r.url().includes("?/redact") && r.request().method() === "POST",
+    );
+    await redactForm.getByRole("button", { name: "Save", exact: true }).click();
+    const redactResult = await redactResponse;
+    expect(redactResult.ok()).toBeTruthy();
+    // The action echoes the saved redactions back; a success result means the
+    // drawn box serialized and the API accepted it.
+    expect(await redactResult.text()).toContain('"type":"success"');
+
+    // Redacting sends the document back through the pipeline, so it leaves the
+    // "success" state. We don't wait for it to finish: redaction reprocessing
+    // errors on the dev backend (an infra limitation, not a frontend concern) —
+    // the submitted redaction above is the behavior under test.
+    await expect
+      .poll(async () => (await fetchDoc(page, docApiUrl!))?.status, {
+        timeout: 30_000,
+      })
+      .not.toBe("success");
+  } finally {
+    if (docApiUrl && baseURL) await deleteDocument(page, docApiUrl, baseURL);
+  }
+});
+
+test("reprocess a document", async ({ page, baseURL }) => {
+  test.setTimeout(180_000);
+
+  let docApiUrl: string | undefined;
+
+  try {
+    const { id, docApiUrl: url } = await uploadDocument(page, {
+      title: uniqueTitle("E2E reprocess"),
+      fixture: FIXTURE,
+    });
+    docApiUrl = url;
+    const processed = await waitForProcessed(page.request, docApiUrl);
+    const viewerUrl = `/documents/${id}-${processed.slug}/`;
+
+    await page.goto(viewerUrl);
+
+    // Open the Reprocess modal from the sidebar. Identify it by the force-OCR
+    // checkbox (the sidebar trigger and the modal's confirm both read
+    // "Reprocess").
+    const reprocessForm = page.locator('form:has(input[name="force_ocr"])');
+    await openModalForm(
+      page.getByRole("button", { name: "Reprocess", exact: true }),
+      reprocessForm,
+    );
+
+    // Confirm with the default options. (Forcing OCR on this fixture errors on
+    // the dev backend, so a plain reprocess is the reliable path.) This posts
+    // directly to the process API from the browser.
+    const processResponse = page.waitForResponse(
+      (r) =>
+        r.url().includes("/documents/process/") &&
+        r.request().method() === "POST",
+    );
+    await reprocessForm
+      .getByRole("button", { name: "Reprocess", exact: true })
+      .click();
+    expect((await processResponse).ok()).toBeTruthy();
+
+    // Reprocessing cycles the document back through pending to success.
+    await waitForProcessed(page.request, docApiUrl);
+  } finally {
+    if (docApiUrl && baseURL) await deleteDocument(page, docApiUrl, baseURL);
+  }
+});

--- a/tests/document-management.spec.ts
+++ b/tests/document-management.spec.ts
@@ -8,9 +8,8 @@ import {
 } from "./helpers/documents";
 
 // Document operations that re-trigger processing: redacting and reprocessing.
-// Each test gets a fresh processed document from the `processedDoc` fixture,
-// which also deletes it in teardown. Runs in the `authenticated` project;
-// skipped automatically when no test credentials are configured.
+// Each test gets a fresh document from the `processedDoc` fixture, which also
+// deletes it in teardown.
 
 test("redact a document", async ({ page, processedDoc }) => {
   // Redaction reprocesses the document, so budget for two processing waits.
@@ -20,13 +19,12 @@ test("redact a document", async ({ page, processedDoc }) => {
 
   const { docApiUrl, viewerUrl } = processedDoc;
 
-  // Enter redacting mode and wait for the page to render so the redaction
-  // layer is sized.
+  // Render first so the redaction layer is sized.
   await page.goto(`${viewerUrl}?mode=redacting`);
   await expectPdfRendered(page);
 
-  // Draw a redaction box. The layer's pointer handlers attach on hydration, so
-  // retry the drag until a redaction box actually registers.
+  // The layer's pointer handlers attach on hydration, so retry the drag until a
+  // redaction box actually registers.
   const layer = page.locator('.redactions.active[role="application"]').first();
   await expect(layer).toBeVisible();
   await expect(async () => {
@@ -49,14 +47,13 @@ test("redact a document", async ({ page, processedDoc }) => {
   await redactForm.getByRole("button", { name: "Save", exact: true }).click();
   const redactResult = await redactResponse;
   expect(redactResult.ok()).toBeTruthy();
-  // The action echoes the saved redactions back; a success result means the
-  // drawn box serialized and the API accepted it.
+  // A success result means the drawn box serialized and the API accepted it.
   expect(await redactResult.text()).toContain('"type":"success"');
 
-  // Redacting sends the document back through the pipeline, so it leaves the
-  // "success" state. We don't wait for it to finish: redaction reprocessing
-  // errors on the dev backend (an infra limitation, not a frontend concern) —
-  // the submitted redaction above is the behavior under test.
+  // Redacting kicks the document back into processing, so it leaves "success".
+  // We don't wait for it to finish: redaction reprocessing errors on the dev
+  // backend (infra, not a frontend concern) — submitting the redaction is what's
+  // under test.
   await expect
     .poll(async () => (await fetchDoc(page, docApiUrl))?.status, {
       timeout: 30_000,
@@ -80,9 +77,8 @@ test("reprocess a document", async ({ page, processedDoc }) => {
     reprocessForm,
   );
 
-  // Confirm with the default options. (Forcing OCR on this fixture errors on
-  // the dev backend, so a plain reprocess is the reliable path.) This posts
-  // directly to the process API from the browser.
+  // Confirm with defaults — a plain reprocess (forcing OCR errors on the dev
+  // backend). This posts directly to the process API from the browser.
   const processResponse = page.waitForResponse(
     (r) =>
       r.url().includes("/documents/process/") &&

--- a/tests/helpers/documents.ts
+++ b/tests/helpers/documents.ts
@@ -1,21 +1,14 @@
 import type { APIRequestContext, Locator, Page } from "@playwright/test";
+import type { Document } from "$lib/api/types";
 
 import { expect } from "@playwright/test";
 
-// Mirrors the document `Status` union in src/lib/api/types.d.ts.
-type DocStatus = "success" | "readable" | "pending" | "error" | "nofile";
-
-export interface DocSummary {
-  id: number;
-  slug: string;
-  title: string;
-  status: DocStatus;
-}
-
-export interface DocDetail extends DocSummary {
-  access: "public" | "private" | "organization";
-  description: string;
-}
+// The fields these helpers read off the document JSON. Derived from the app's
+// `Document` type so the status union etc. stay in sync.
+export type DocDetail = Pick<
+  Document,
+  "id" | "slug" | "title" | "status" | "access" | "description"
+>;
 
 /**
  * Fetch the document detail JSON via the authenticated request context, or
@@ -163,14 +156,14 @@ export async function waitForProcessed(
   request: APIRequestContext,
   docApiUrl: string,
   { timeout = 120_000, interval = 2_000 } = {},
-): Promise<DocSummary> {
+): Promise<DocDetail> {
   const deadline = Date.now() + timeout;
-  let last: DocSummary | undefined;
+  let last: DocDetail | undefined;
 
   while (Date.now() < deadline) {
     const resp = await request.get(docApiUrl);
     if (resp.ok()) {
-      last = (await resp.json()) as DocSummary;
+      last = (await resp.json()) as DocDetail;
       if (last.status === "success") return last;
       if (last.status === "error") {
         throw new Error(

--- a/tests/helpers/documents.ts
+++ b/tests/helpers/documents.ts
@@ -1,9 +1,6 @@
-import {
-  expect,
-  type APIRequestContext,
-  type Locator,
-  type Page,
-} from "@playwright/test";
+import type { APIRequestContext, Locator, Page } from "@playwright/test";
+
+import { expect } from "@playwright/test";
 
 // Mirrors the document `Status` union in src/lib/api/types.d.ts.
 type DocStatus = "success" | "readable" | "pending" | "error" | "nofile";
@@ -50,6 +47,18 @@ export async function openModalForm(
     await trigger.click();
     await expect(form).toBeVisible({ timeout: 2_000 });
   }).toPass({ timeout });
+}
+
+/**
+ * Wait until the first PDF page has actually rendered. The viewer draws each
+ * page to a `<canvas>` via pdf.js and flips `data-loaded` once it has; this is
+ * both a "PDF renders" assertion and a precondition for the page being sized
+ * (e.g. before drawing a note/redaction box on it).
+ */
+export async function expectPdfRendered(page: Page, { timeout = 30_000 } = {}) {
+  await expect(
+    page.locator('.page-container[data-loaded="true"]').first(),
+  ).toBeVisible({ timeout });
 }
 
 /**

--- a/tests/helpers/documents.ts
+++ b/tests/helpers/documents.ts
@@ -15,6 +15,26 @@ export interface DocSummary {
   status: DocStatus;
 }
 
+export interface DocDetail extends DocSummary {
+  access: "public" | "private" | "organization";
+  description: string;
+}
+
+/**
+ * Fetch the document detail JSON via the authenticated request context, or
+ * `undefined` if the request failed. The detail endpoint reflects edits
+ * immediately (unlike the viewer header, which can lag backend indexing), so
+ * it's the reliable place to assert a field changed — pair it with
+ * `expect.poll`.
+ */
+export async function fetchDoc(
+  page: Page,
+  docApiUrl: string,
+): Promise<DocDetail | undefined> {
+  const r = await page.request.get(docApiUrl);
+  return r.ok() ? ((await r.json()) as DocDetail) : undefined;
+}
+
 /**
  * Open a modal by clicking its trigger, retrying until the modal's form is
  * visible. A trigger's onclick only fires once the view has hydrated, so an
@@ -33,6 +53,26 @@ export async function openModalForm(
 }
 
 /**
+ * Drag a rectangle across a drawing layer (a note annotation layer or a
+ * redaction layer). Uses fractional offsets so the box stays within the layer
+ * whatever its rendered size.
+ */
+export async function drawBox(
+  page: Page,
+  layer: Locator,
+  { fromX = 0.15, fromY = 0.08, toX = 0.6, toY = 0.22 } = {},
+): Promise<void> {
+  const box = await layer.boundingBox();
+  if (!box) throw new Error("drawBox: layer has no bounding box");
+  await page.mouse.move(box.x + box.width * fromX, box.y + box.height * fromY);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width * toX, box.y + box.height * toY, {
+    steps: 12,
+  });
+  await page.mouse.up();
+}
+
+/**
  * A title unique to this run so every lifecycle step can find *our* document
  * by name — never "the newest document", which races other runs and test data.
  */
@@ -40,6 +80,63 @@ export function uniqueTitle(prefix = "E2E"): string {
   const stamp = new Date().toISOString().replace(/[:.]/g, "-");
   const rand = Math.random().toString(36).slice(2, 8);
   return `${prefix} ${stamp} ${rand}`;
+}
+
+export interface UploadedDoc {
+  id: number;
+  /** Document detail API URL, derived from the create response. */
+  docApiUrl: string;
+}
+
+/**
+ * Upload a single document through the UI and return its id and API URL. Stops
+ * once the document is created; callers wait for processing separately (via
+ * `waitForProcessed`). Shared by every spec that needs a throwaway document.
+ */
+export async function uploadDocument(
+  page: Page,
+  { title, fixture }: { title: string; fixture: string },
+): Promise<UploadedDoc> {
+  await page.goto("/upload/");
+
+  // "Select Files" is disabled until the component hydrates and reads the CSRF
+  // token, so waiting for it to enable also ensures the picker handler is wired.
+  const selectFiles = page.getByRole("button", {
+    name: "Select Files",
+    exact: true,
+  });
+  await expect(selectFiles).toBeEnabled();
+
+  // Drive the real file chooser rather than poking the hidden <input>, so the
+  // component's onchange handler actually runs and registers the file.
+  const fileChooser = page.waitForEvent("filechooser");
+  await selectFiles.click();
+  await (await fileChooser).setFiles(fixture);
+
+  const titleInput = page.locator('input[name="title"]');
+  await expect(titleInput).toBeVisible();
+  await titleInput.fill(title);
+
+  // The upload happens client-side, hitting the API directly. Capture the
+  // create call (POST .../api/documents/) to learn the new document's id.
+  const createResponse = page.waitForResponse(
+    (r) =>
+      r.request().method() === "POST" &&
+      /\/documents\/$/.test(new URL(r.url()).pathname),
+  );
+  await page.getByRole("button", { name: "Begin Upload", exact: true }).click();
+
+  const created = await createResponse;
+  expect(created.ok()).toBeTruthy();
+  const { id } = await created.json();
+  expect(id, "create response should include a document id").toBeTruthy();
+
+  // Derive the document API URL from the create endpoint so we don't hardcode
+  // the API host (it differs between dev / staging / previews).
+  const docApiUrl = created
+    .url()
+    .replace(/\/documents\/$/, `/documents/${id}/`);
+  return { id, docApiUrl };
 }
 
 /**

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -17,11 +17,9 @@ export interface ProcessedDoc {
 
 interface Fixtures {
   /**
-   * A freshly uploaded, fully processed throwaway document. Deleted in teardown
-   * (via the API) so tests never leave one behind — Playwright runs teardown
-   * even when the test fails. Use for any test that just needs a document to
-   * operate on; tests that assert on the title should upload their own so they
-   * control it.
+   * A freshly uploaded, fully processed throwaway document, deleted in teardown
+   * (which Playwright runs even on failure). Tests that assert on the title
+   * should upload their own instead, to control it.
    */
   processedDoc: ProcessedDoc;
 }

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,0 +1,46 @@
+import { test as base } from "@playwright/test";
+
+import {
+  deleteDocument,
+  uniqueTitle,
+  uploadDocument,
+  waitForProcessed,
+} from "./documents";
+
+export interface ProcessedDoc {
+  id: number;
+  /** Document detail API URL, e.g. `…/api/documents/123/`. */
+  docApiUrl: string;
+  /** Viewer route, e.g. `/documents/123-slug/`. */
+  viewerUrl: string;
+}
+
+interface Fixtures {
+  /**
+   * A freshly uploaded, fully processed throwaway document. Deleted in teardown
+   * (via the API) so tests never leave one behind — Playwright runs teardown
+   * even when the test fails. Use for any test that just needs a document to
+   * operate on; tests that assert on the title should upload their own so they
+   * control it.
+   */
+  processedDoc: ProcessedDoc;
+}
+
+const FIXTURE = "tests/fixtures/Small pdf.pdf";
+
+export const test = base.extend<Fixtures>({
+  processedDoc: async ({ page, baseURL }, use) => {
+    const { id, docApiUrl } = await uploadDocument(page, {
+      title: uniqueTitle("E2E"),
+      fixture: FIXTURE,
+    });
+    const processed = await waitForProcessed(page.request, docApiUrl);
+    const viewerUrl = `/documents/${id}-${processed.slug}/`;
+
+    await use({ id, docApiUrl, viewerUrl });
+
+    if (baseURL) await deleteDocument(page, docApiUrl, baseURL);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/tests/note-lifecycle.spec.ts
+++ b/tests/note-lifecycle.spec.ts
@@ -1,20 +1,14 @@
-import { test, expect, type Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
-import {
-  deleteDocument,
-  drawBox,
-  uniqueTitle,
-  uploadDocument,
-  waitForProcessed,
-} from "./helpers/documents";
+import { test, expect } from "./helpers/fixtures";
+import { drawBox, expectPdfRendered, uniqueTitle } from "./helpers/documents";
 
 // The note lifecycle, as a logged-in user experiences it on the document
 // viewer: create a note by drawing on the page, edit it, change its access,
 // then delete it. Notes are created/updated/deleted by direct API calls from
-// the browser, so each step is verified through that call's response. Runs in
-// the `authenticated` project; skipped when no test credentials are configured.
-
-const FIXTURE = "tests/fixtures/Small pdf.pdf";
+// the browser, so each step is verified through that call's response. The
+// `processedDoc` fixture supplies (and later deletes) the document. Runs in the
+// `authenticated` project; skipped when no test credentials are configured.
 
 /**
  * Open the (single) existing note for editing in annotating mode by clicking
@@ -34,108 +28,94 @@ async function openNoteForEditing(page: Page) {
 
 test("create → edit → change access → delete a note", async ({
   page,
-  baseURL,
+  processedDoc,
 }) => {
   test.setTimeout(180_000);
 
+  const { docApiUrl, viewerUrl } = processedDoc;
+  const notesUrl = `${docApiUrl}notes/`;
   const noteTitle = uniqueTitle("E2E note");
   const editedNoteTitle = `${noteTitle} (edited)`;
-  let docApiUrl: string | undefined;
 
-  try {
-    const { id, docApiUrl: url } = await uploadDocument(page, {
-      title: uniqueTitle("E2E note doc"),
-      fixture: FIXTURE,
+  // --- CREATE -----------------------------------------------------------
+  await page.goto(`${viewerUrl}?mode=annotating`);
+  await expectPdfRendered(page);
+
+  // Drag a region on the first page to open the new-note form. The layer's
+  // pointer handlers attach on hydration, so retry until the form appears.
+  const noteForm = page.locator(".note.card form");
+  const layer = page.locator('.notes[role="application"]').first();
+  await expect(async () => {
+    await drawBox(page, layer);
+    await expect(noteForm.locator('input[name="title"]')).toBeVisible({
+      timeout: 2_000,
     });
-    docApiUrl = url;
-    const processed = await waitForProcessed(page.request, docApiUrl);
-    const viewerUrl = `/documents/${id}-${processed.slug}/`;
-    const notesUrl = `${docApiUrl}notes/`;
+  }).toPass({ timeout: 20_000 });
 
-    // --- CREATE ---------------------------------------------------------
-    await page.goto(`${viewerUrl}?mode=annotating`);
-    await expect(
-      page.locator('.page-container[data-loaded="true"]').first(),
-    ).toBeVisible({ timeout: 30_000 });
+  await noteForm.locator('input[name="title"]').fill(noteTitle);
+  await noteForm
+    .locator('textarea[name="content"]')
+    .fill("Created by the note e2e test.");
 
-    // Drag a region on the first page to open the new-note form. The layer's
-    // pointer handlers attach on hydration, so retry until the form appears.
-    const noteForm = page.locator(".note.card form");
-    const layer = page.locator('.notes[role="application"]').first();
-    await expect(async () => {
-      await drawBox(page, layer);
-      await expect(noteForm.locator('input[name="title"]')).toBeVisible({
-        timeout: 2_000,
-      });
-    }).toPass({ timeout: 20_000 });
+  const createResponse = page.waitForResponse(
+    (r) => r.url().endsWith("/notes/") && r.request().method() === "POST",
+  );
+  await noteForm.getByRole("button", { name: "Save", exact: true }).click();
+  const created = await createResponse;
+  expect(created.ok()).toBeTruthy();
+  const note = await created.json();
+  expect(note.id, "create response should include a note id").toBeTruthy();
 
-    await noteForm.locator('input[name="title"]').fill(noteTitle);
-    await noteForm
-      .locator('textarea[name="content"]')
-      .fill("Created by the note e2e test.");
+  // It renders in notes mode.
+  await page.goto(`${viewerUrl}?mode=notes`);
+  await expect(page.getByText(noteTitle).first()).toBeVisible({
+    timeout: 15_000,
+  });
 
-    const createResponse = page.waitForResponse(
-      (r) => r.url().endsWith("/notes/") && r.request().method() === "POST",
-    );
-    await noteForm.getByRole("button", { name: "Save", exact: true }).click();
-    const created = await createResponse;
-    expect(created.ok()).toBeTruthy();
-    const note = await created.json();
-    expect(note.id, "create response should include a note id").toBeTruthy();
+  // --- EDIT -------------------------------------------------------------
+  // Reload annotating mode fresh so no pending invalidation resets the form.
+  await page.goto(`${viewerUrl}?mode=annotating`);
+  let form = await openNoteForEditing(page);
+  await form.locator('input[name="title"]').fill(editedNoteTitle);
+  const editResponse = page.waitForResponse(
+    (r) =>
+      r.url().includes(`/notes/${note.id}/`) &&
+      r.request().method() === "PATCH",
+  );
+  await form.getByRole("button", { name: "Save", exact: true }).click();
+  expect((await (await editResponse).json()).title).toBe(editedNoteTitle);
 
-    // It renders in notes mode.
-    await page.goto(`${viewerUrl}?mode=notes`);
-    await expect(page.getByText(noteTitle).first()).toBeVisible({
-      timeout: 15_000,
-    });
+  // --- CHANGE ACCESS ----------------------------------------------------
+  await page.goto(`${viewerUrl}?mode=annotating`);
+  form = await openNoteForEditing(page);
+  await form.locator('label[for="public"]').click();
+  const accessResponse = page.waitForResponse(
+    (r) =>
+      r.url().includes(`/notes/${note.id}/`) &&
+      r.request().method() === "PATCH",
+  );
+  await form.getByRole("button", { name: "Save", exact: true }).click();
+  expect((await (await accessResponse).json()).access).toBe("public");
 
-    // --- EDIT -----------------------------------------------------------
-    // Reload annotating mode fresh so no pending invalidation resets the form.
-    await page.goto(`${viewerUrl}?mode=annotating`);
-    let form = await openNoteForEditing(page);
-    await form.locator('input[name="title"]').fill(editedNoteTitle);
-    const editResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes(`/notes/${note.id}/`) &&
-        r.request().method() === "PATCH",
-    );
-    await form.getByRole("button", { name: "Save", exact: true }).click();
-    expect((await (await editResponse).json()).title).toBe(editedNoteTitle);
+  // --- DELETE -----------------------------------------------------------
+  await page.goto(`${viewerUrl}?mode=annotating`);
+  form = await openNoteForEditing(page);
+  const deleteResponse = page.waitForResponse(
+    (r) =>
+      r.url().includes(`/notes/${note.id}/`) &&
+      r.request().method() === "DELETE",
+  );
+  await form.getByRole("button", { name: "Delete", exact: true }).click();
+  expect((await deleteResponse).ok()).toBeTruthy();
 
-    // --- CHANGE ACCESS --------------------------------------------------
-    await page.goto(`${viewerUrl}?mode=annotating`);
-    form = await openNoteForEditing(page);
-    await form.locator('label[for="public"]').click();
-    const accessResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes(`/notes/${note.id}/`) &&
-        r.request().method() === "PATCH",
-    );
-    await form.getByRole("button", { name: "Save", exact: true }).click();
-    expect((await (await accessResponse).json()).access).toBe("public");
-
-    // --- DELETE ---------------------------------------------------------
-    await page.goto(`${viewerUrl}?mode=annotating`);
-    form = await openNoteForEditing(page);
-    const deleteResponse = page.waitForResponse(
-      (r) =>
-        r.url().includes(`/notes/${note.id}/`) &&
-        r.request().method() === "DELETE",
-    );
-    await form.getByRole("button", { name: "Delete", exact: true }).click();
-    expect((await deleteResponse).ok()).toBeTruthy();
-
-    // The note list is now empty.
-    await expect
-      .poll(
-        async () => {
-          const r = await page.request.get(notesUrl);
-          return r.ok() ? (await r.json()).results.length : -1;
-        },
-        { timeout: 15_000 },
-      )
-      .toBe(0);
-  } finally {
-    if (docApiUrl && baseURL) await deleteDocument(page, docApiUrl, baseURL);
-  }
+  // The note list is now empty.
+  await expect
+    .poll(
+      async () => {
+        const r = await page.request.get(notesUrl);
+        return r.ok() ? (await r.json()).results.length : -1;
+      },
+      { timeout: 15_000 },
+    )
+    .toBe(0);
 });

--- a/tests/note-lifecycle.spec.ts
+++ b/tests/note-lifecycle.spec.ts
@@ -3,12 +3,10 @@ import type { Page } from "@playwright/test";
 import { test, expect } from "./helpers/fixtures";
 import { drawBox, expectPdfRendered, uniqueTitle } from "./helpers/documents";
 
-// The note lifecycle, as a logged-in user experiences it on the document
-// viewer: create a note by drawing on the page, edit it, change its access,
-// then delete it. Notes are created/updated/deleted by direct API calls from
-// the browser, so each step is verified through that call's response. The
-// `processedDoc` fixture supplies (and later deletes) the document. Runs in the
-// `authenticated` project; skipped when no test credentials are configured.
+// The note lifecycle on the document viewer: create a note by drawing on the
+// page, edit it, change its access, then delete it. Note CRUD happens via
+// direct browser→API calls, so each step is verified from that call's response.
+// The `processedDoc` fixture supplies and deletes the document.
 
 /**
  * Open the (single) existing note for editing in annotating mode by clicking

--- a/tests/note-lifecycle.spec.ts
+++ b/tests/note-lifecycle.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, type Page } from "@playwright/test";
+
+import {
+  deleteDocument,
+  drawBox,
+  uniqueTitle,
+  uploadDocument,
+  waitForProcessed,
+} from "./helpers/documents";
+
+// The note lifecycle, as a logged-in user experiences it on the document
+// viewer: create a note by drawing on the page, edit it, change its access,
+// then delete it. Notes are created/updated/deleted by direct API calls from
+// the browser, so each step is verified through that call's response. Runs in
+// the `authenticated` project; skipped when no test credentials are configured.
+
+const FIXTURE = "tests/fixtures/Small pdf.pdf";
+
+/**
+ * Open the (single) existing note for editing in annotating mode by clicking
+ * its margin tab, retrying until the edit form appears (the tab's handler only
+ * fires once the viewer has hydrated). Returns the note form locator.
+ */
+async function openNoteForEditing(page: Page) {
+  const noteForm = page.locator(".note.card form");
+  await expect(async () => {
+    await page.locator("a.note-tab").first().click();
+    await expect(noteForm.locator('input[name="title"]')).toBeVisible({
+      timeout: 2_000,
+    });
+  }).toPass({ timeout: 20_000 });
+  return noteForm;
+}
+
+test("create → edit → change access → delete a note", async ({
+  page,
+  baseURL,
+}) => {
+  test.setTimeout(180_000);
+
+  const noteTitle = uniqueTitle("E2E note");
+  const editedNoteTitle = `${noteTitle} (edited)`;
+  let docApiUrl: string | undefined;
+
+  try {
+    const { id, docApiUrl: url } = await uploadDocument(page, {
+      title: uniqueTitle("E2E note doc"),
+      fixture: FIXTURE,
+    });
+    docApiUrl = url;
+    const processed = await waitForProcessed(page.request, docApiUrl);
+    const viewerUrl = `/documents/${id}-${processed.slug}/`;
+    const notesUrl = `${docApiUrl}notes/`;
+
+    // --- CREATE ---------------------------------------------------------
+    await page.goto(`${viewerUrl}?mode=annotating`);
+    await expect(
+      page.locator('.page-container[data-loaded="true"]').first(),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Drag a region on the first page to open the new-note form. The layer's
+    // pointer handlers attach on hydration, so retry until the form appears.
+    const noteForm = page.locator(".note.card form");
+    const layer = page.locator('.notes[role="application"]').first();
+    await expect(async () => {
+      await drawBox(page, layer);
+      await expect(noteForm.locator('input[name="title"]')).toBeVisible({
+        timeout: 2_000,
+      });
+    }).toPass({ timeout: 20_000 });
+
+    await noteForm.locator('input[name="title"]').fill(noteTitle);
+    await noteForm
+      .locator('textarea[name="content"]')
+      .fill("Created by the note e2e test.");
+
+    const createResponse = page.waitForResponse(
+      (r) => r.url().endsWith("/notes/") && r.request().method() === "POST",
+    );
+    await noteForm.getByRole("button", { name: "Save", exact: true }).click();
+    const created = await createResponse;
+    expect(created.ok()).toBeTruthy();
+    const note = await created.json();
+    expect(note.id, "create response should include a note id").toBeTruthy();
+
+    // It renders in notes mode.
+    await page.goto(`${viewerUrl}?mode=notes`);
+    await expect(page.getByText(noteTitle).first()).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // --- EDIT -----------------------------------------------------------
+    // Reload annotating mode fresh so no pending invalidation resets the form.
+    await page.goto(`${viewerUrl}?mode=annotating`);
+    let form = await openNoteForEditing(page);
+    await form.locator('input[name="title"]').fill(editedNoteTitle);
+    const editResponse = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/notes/${note.id}/`) &&
+        r.request().method() === "PATCH",
+    );
+    await form.getByRole("button", { name: "Save", exact: true }).click();
+    expect((await (await editResponse).json()).title).toBe(editedNoteTitle);
+
+    // --- CHANGE ACCESS --------------------------------------------------
+    await page.goto(`${viewerUrl}?mode=annotating`);
+    form = await openNoteForEditing(page);
+    await form.locator('label[for="public"]').click();
+    const accessResponse = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/notes/${note.id}/`) &&
+        r.request().method() === "PATCH",
+    );
+    await form.getByRole("button", { name: "Save", exact: true }).click();
+    expect((await (await accessResponse).json()).access).toBe("public");
+
+    // --- DELETE ---------------------------------------------------------
+    await page.goto(`${viewerUrl}?mode=annotating`);
+    form = await openNoteForEditing(page);
+    const deleteResponse = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/notes/${note.id}/`) &&
+        r.request().method() === "DELETE",
+    );
+    await form.getByRole("button", { name: "Delete", exact: true }).click();
+    expect((await deleteResponse).ok()).toBeTruthy();
+
+    // The note list is now empty.
+    await expect
+      .poll(
+        async () => {
+          const r = await page.request.get(notesUrl);
+          return r.ok() ? (await r.json()).results.length : -1;
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(0);
+  } finally {
+    if (docApiUrl && baseURL) await deleteDocument(page, docApiUrl, baseURL);
+  }
+});


### PR DESCRIPTION
Closes #1351

## What

Extends the Playwright e2e suite to cover the full document lifecycle and adds a separate note lifecycle, building on the upload→process→view→delete backbone.

### Specs
- **`document-lifecycle.spec.ts`** — now also **edits metadata** (title + description) between publish and the mode checks.
- **`document-management.spec.ts`** (new) — **redact** a document and **reprocess** one. Self-contained via a fixture; each cleans up after itself.
- **`note-lifecycle.spec.ts`** (new) — **create** a note by drawing on the page (annotating mode), **edit** it, **change its access**, and **delete** it. Note CRUD is browser→API, so each step is verified from that call's response.

### Test infrastructure (`tests/helpers/`)
- `processedDoc` **fixture** — uploads + processes a throwaway document and deletes it in teardown (guaranteed cleanup, even on failure).
- Shared helpers: `uploadDocument`, `waitForProcessed`, `fetchDoc`, `drawBox`, `expectPdfRendered`, `openModalForm`, `deleteDocument`.
- The suite runs **serially** (`workers: 1`): the authenticated specs upload/(re)process against a shared dev backend that can't keep up with concurrent jobs — in parallel, processing slows enough to blow timeouts.
- `tests/README.md` documents the specs, helpers, and the hard-won gotchas (hydration races, reload-before-editing, verifying mutations via the API).

## Testing
Full suite green serially against `https://www.dev.documentcloud.org` (11/11, ~3 min). Skips cleanly when no `DC_TEST_*` credentials are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
