### PR TITLE
Render Markdown in more places

### DIFF
--- a/src/lib/components/common/TipOfDay.svelte
+++ b/src/lib/components/common/TipOfDay.svelte
@@ -2,7 +2,7 @@
   import { writable } from "svelte/store";
 
   import { StorageManager } from "$lib/utils/storage";
-  import { clean } from "$lib/utils/markup";
+  import { renderMarkdown } from "$lib/utils/markup";
 
   let show = writable(false);
 
@@ -39,7 +39,7 @@
 {#if $show}
   <div class="container">
     <div class="message">
-      {@html clean(message ?? "")}
+      {@html renderMarkdown(message)}
     </div>
     <button class="close" title="Hide Tip" onclick={() => hideTip(message)}>
       <X12 />

--- a/src/lib/components/projects/ProjectHeader.svelte
+++ b/src/lib/components/projects/ProjectHeader.svelte
@@ -7,6 +7,7 @@
   import Flex from "$lib/components/common/Flex.svelte";
   import ProjectPin from "./ProjectPin.svelte";
   import { remToPx } from "$lib/utils/layout";
+  import { renderMarkdown } from "$lib/utils/markup";
 
   interface Props {
     project: Project;
@@ -46,7 +47,7 @@
     {/if}
   </Flex>
   {#if project.description}
-    <p class="description">{project.description}</p>
+    <div class="description">{@html renderMarkdown(project.description)}</div>
   {/if}
 </div>
 

--- a/src/lib/components/projects/ProjectListItem.svelte
+++ b/src/lib/components/projects/ProjectListItem.svelte
@@ -7,7 +7,7 @@
   import ProjectPin from "./ProjectPin.svelte";
 
   import { canonicalUrl } from "$lib/api/projects";
-  import { clean } from "$lib/utils/markup";
+  import { renderMarkdown } from "$lib/utils/markup";
 
   interface Props {
     project: Project;
@@ -18,30 +18,32 @@
   let href = $derived(canonicalUrl(project).href);
 </script>
 
-<a {href} id={project.id.toString()}>
-  <div class="container">
-    <div class="row margin">
-      <div class="center-self">
-        <ProjectPin {project} />
-      </div>
-      <div class="stretch row gap-lg">
-        <h3 class="project-title">{project.title}</h3>
-      </div>
-      {#if project.private}
-        <span class="small center center-self" title={$_("projects.private")}>
-          <Lock16 />
-        </span>
-      {:else}
-        <span class="small center center-self" title={$_("projects.public")}>
-          <Globe16 />
-        </span>
-      {/if}
+<div class="container">
+  <div class="row margin">
+    <div class="center-self">
+      <ProjectPin {project} />
     </div>
-    {#if project.description}
-      <div class="description">{@html clean(project.description ?? "")}</div>
+    <div class="stretch row gap-lg">
+      <h3 class="project-title">
+        <a {href} id={project.id.toString()}>
+          {project.title}
+        </a>
+      </h3>
+    </div>
+    {#if project.private}
+      <span class="small center center-self" title={$_("projects.private")}>
+        <Lock16 />
+      </span>
+    {:else}
+      <span class="small center center-self" title={$_("projects.public")}>
+        <Globe16 />
+      </span>
     {/if}
   </div>
-</a>
+  {#if project.description}
+    <div class="description">{@html renderMarkdown(project.description)}</div>
+  {/if}
+</div>
 
 <style>
   a {
@@ -49,8 +51,8 @@
     text-decoration: none;
   }
 
-  a:hover .container,
-  a:target .container {
+  .container a:hover,
+  .container a:target {
     background-color: var(--blue-1);
   }
 

--- a/src/lib/utils/markup.ts
+++ b/src/lib/utils/markup.ts
@@ -10,6 +10,21 @@ export function renderMarkdown(content: string, options: IOptions = {}) {
   return clean(marked.parse(content), options);
 }
 
+/**
+ * Render Markdown/HTML down to plain text, stripping all tags.
+ * Useful for plain-text contexts like <meta> descriptions.
+ */
+export function renderText(content: string): string {
+  if (!content || typeof content !== "string") return "";
+
+  return clean(marked.parse(content), {
+    allowedTags: [],
+    allowedAttributes: {},
+  })
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 export function clean(html: string, options: IOptions = {}): string {
   if (!html || typeof html !== "string") return "";
 

--- a/src/lib/utils/tests/markup.test.ts
+++ b/src/lib/utils/tests/markup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { clean, renderMarkdown } from "../markup";
+import { clean, renderMarkdown, renderText } from "../markup";
 
 describe("clean() security tests", () => {
   // Test allowed tags work correctly
@@ -330,5 +330,46 @@ describe("renderMarkdown() security tests", () => {
     const result = renderMarkdown(input);
     // Images aren't in the allowed tags, so they should be removed
     expect(result).not.toContain("<img");
+  });
+});
+
+describe("renderText()", () => {
+  test("strips markdown formatting to plain text", () => {
+    const input = "**bold** and *italic* and `code`";
+    const result = renderText(input);
+    expect(result).toBe("bold and italic and code");
+  });
+
+  test("keeps link text but drops the URL and markup", () => {
+    const input = "See [the report](https://example.com) for details";
+    const result = renderText(input);
+    expect(result).toBe("See the report for details");
+  });
+
+  test("removes all HTML tags", () => {
+    const input = "<p>Hello <strong>world</strong></p>";
+    const result = renderText(input);
+    expect(result).toBe("Hello world");
+  });
+
+  test("collapses whitespace across block elements", () => {
+    const input = "# Heading\n\nFirst paragraph.\n\nSecond paragraph.";
+    const result = renderText(input);
+    expect(result).toBe("Heading First paragraph. Second paragraph.");
+  });
+
+  test("strips embedded scripts", () => {
+    const input = "Hi <script>alert('XSS')</script>";
+    const result = renderText(input);
+    expect(result).not.toContain("<script");
+    expect(result).not.toContain("alert");
+  });
+
+  test("handles empty and non-string inputs gracefully", () => {
+    expect(renderText("")).toBe("");
+    // @ts-expect-error - testing runtime behavior with invalid input
+    expect(renderText(null)).toBe("");
+    // @ts-expect-error - testing runtime behavior with invalid input
+    expect(renderText(undefined)).toBe("");
   });
 });

--- a/src/routes/(app)/projects/[id]-[slug]/+page.svelte
+++ b/src/routes/(app)/projects/[id]-[slug]/+page.svelte
@@ -6,6 +6,7 @@
 
   import * as projects from "$lib/api/projects";
   import { embedUrl } from "$lib/api/embed";
+  import { renderText } from "$lib/utils/markup";
   import {
     SearchResultsState,
     setSearchResults,
@@ -54,8 +55,8 @@
     title={project.title}
   />
   {#if project.description?.trim().length > 0}
-    <meta name="description" content={project.description} />
-    <meta property="og:description" content={project.description} />
+    <meta name="description" content={renderText(project.description)} />
+    <meta property="og:description" content={renderText(project.description)} />
   {/if}
 </svelte:head>
 

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -67,12 +67,20 @@ setup("authenticate", async ({ page }) => {
   );
 
   // Optional one-time MFA opt-in interstitial — only shows for some accounts,
-  // so this branch is intentionally conditional, not dead code. `force` is
-  // needed because the dev Django Debug Toolbar overlay can intercept the click.
+  // so this branch is intentionally conditional, not dead code.
   if (page.url().includes("/accounts/onboard")) {
-    await page
-      .getByRole("button", { name: "Skip", exact: true })
-      .click({ force: true });
+    // The dev Django Debug Toolbar renders a panel list fixed to the right edge
+    // that overlaps the onboarding buttons. Collapse it via its own "Hide"
+    // control so the click reaches the real "Skip" submit button. (Clicking with
+    // `force: true` instead just delivered the click to the toolbar panel — the
+    // form never submitted and the flow hung on the onboarding page.) The
+    // toolbar is only present on environments with DEBUG on, so tolerate its
+    // absence.
+    const hideToolbar = page.locator("#djHideToolBarButton");
+    if (await hideToolbar.isVisible().catch(() => false)) {
+      await hideToolbar.click();
+    }
+    await page.getByRole("button", { name: "Skip", exact: true }).click();
   }
 
   // We should land back on the frontend host, logged in. Matching the exact


### PR DESCRIPTION
When introducing Elizabeth to the "Tip of the Day," I realized it supports HTML but not Markdown. We had another outstanding ticket for Markdown support for projects, so I handled them both together.

- Render Markdown in `TipOfDay`
- Render Markdown in Project descriptions in `ProjectHeader` and `ProjectListItem`
- Render stripped down, plain-text in Project "description" `meta` tag