### PR TITLE
Gate process loading on auth check

### DIFF
--- a/src/lib/components/processing/ProcessContext.svelte
+++ b/src/lib/components/processing/ProcessContext.svelte
@@ -22,6 +22,7 @@ This makes the state of those processes available via context.
 
   import { history } from "$lib/api/addons";
   import { pending } from "$lib/api/documents";
+  import { getCurrentUser, isSignedIn } from "$lib/utils/permissions";
   import { POLL_INTERVAL } from "@/config/config";
 
   interface ProcessContext {
@@ -94,6 +95,11 @@ This makes the state of those processes available via context.
   }
 
   let { children }: Props = $props();
+
+  // Only signed-in users have pending documents or add-on runs to poll for.
+  // Gating on auth keeps anonymous visitors from burning their API quota.
+  const me = getCurrentUser();
+
   // keep track of processed documents
   let started: Set<number> = new Set();
 
@@ -111,7 +117,9 @@ This makes the state of those processes available via context.
   });
 
   onMount(() => {
-    load();
+    if (isSignedIn($me)) {
+      load();
+    }
     // started grows indefinitely, so we need to manage it here
     return documents.subscribe((docs) => {
       started = new Set([...started, ...docs.map((d) => d.doc_id)]);
@@ -119,7 +127,7 @@ This makes the state of those processes available via context.
   });
 
   $effect(() => {
-    if ($documents.length > 0 || $addons.length > 0) {
+    if (isSignedIn($me) && ($documents.length > 0 || $addons.length > 0)) {
       load();
     }
 

--- a/src/lib/components/processing/tests/ProcessContext.demo.svelte
+++ b/src/lib/components/processing/tests/ProcessContext.demo.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { User } from "$lib/api/types";
+  import { setContext, untrack } from "svelte";
+  import { writable } from "svelte/store";
+
+  import ProcessContext from "../ProcessContext.svelte";
+
+  interface Props {
+    user?: User | null;
+  }
+
+  const props: Props = $props();
+
+  untrack(() => {
+    setContext("me", writable(props.user));
+  });
+</script>
+
+<ProcessContext />

--- a/src/lib/components/processing/tests/ProcessContext.test.ts
+++ b/src/lib/components/processing/tests/ProcessContext.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/svelte";
+
+import ProcessContextDemo from "./ProcessContext.demo.svelte";
+import { me } from "@/test/fixtures/accounts";
+
+// ProcessContext calls invalidate() from $app/navigation in its $effect
+vi.mock("$app/navigation", () => ({
+  invalidate: vi.fn(),
+}));
+
+// Mock the polling endpoints so we can assert whether they get hit
+vi.mock("$lib/api/documents", () => ({
+  pending: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("$lib/api/addons", () => ({
+  history: vi.fn().mockResolvedValue({ data: { results: [] }, error: null }),
+}));
+
+import { pending } from "$lib/api/documents";
+import { history } from "$lib/api/addons";
+
+const mockPending = vi.mocked(pending);
+const mockHistory = vi.mocked(history);
+
+describe("ProcessContext — auth-gated polling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPending.mockResolvedValue([]);
+    mockHistory.mockResolvedValue({
+      data: { results: [] },
+      error: null,
+    } as any);
+  });
+
+  it("polls pending documents and addon runs when signed in", async () => {
+    render(ProcessContextDemo, { props: { user: me } });
+
+    await vi.waitFor(() => {
+      expect(mockPending).toHaveBeenCalled();
+      expect(mockHistory).toHaveBeenCalled();
+    });
+  });
+
+  it("does not poll when signed out", async () => {
+    render(ProcessContextDemo, { props: { user: null } });
+
+    // give onMount and any effects a chance to run
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(mockPending).not.toHaveBeenCalled();
+    expect(mockHistory).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/sidebar/Documents.svelte
+++ b/src/lib/components/sidebar/Documents.svelte
@@ -27,7 +27,7 @@
   import SavedSearchForm from "$lib/components/sidebar/SavedSearchForm.svelte";
 
   import { userDocs, searchUrl } from "$lib/utils/search";
-  import { getCurrentUser } from "$lib/utils/permissions";
+  import { getCurrentUser, isSignedIn } from "$lib/utils/permissions";
   import { listAll } from "$lib/api/saved-searches";
 
   const me = getCurrentUser();
@@ -70,6 +70,13 @@
   );
 
   onMount(async () => {
+    // The saved searches UI is only shown to signed-in users (see <SignedIn>),
+    // so skip the request for anonymous visitors to save their API quota.
+    if (!isSignedIn($me)) {
+      loadingSavedSearches = false;
+      return;
+    }
+
     try {
       savedSearches = await listAll();
     } finally {

--- a/src/lib/components/sidebar/tests/Documents.test.ts
+++ b/src/lib/components/sidebar/tests/Documents.test.ts
@@ -207,4 +207,15 @@ describe("Documents sidebar — saved search detection", () => {
       expect(screen.getByText("FOIA requests")).toBeInTheDocument();
     });
   });
+
+  it("does not load saved searches when signed out", async () => {
+    render(DocumentsDemo, {
+      props: { user: null },
+    });
+
+    // give onMount a chance to run
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(mockGetAll).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Closes #1334 

Mostly short-circuits loading calls in `onMount` or `$effect` by checking `isSignedIn($me)`. Other places we call `load()` directly are already behind an auth check.