### PR TITLE
Remove unused config constants

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -104,10 +104,6 @@ export const IMAGE_WIDTHS_ENTRIES = [
   ["thumbnail", 60],
 ];
 
-export const IMAGE_WIDTHS = IMAGE_WIDTHS_ENTRIES.sort(
-  (a, b) => a[1] - b[1],
-).map(([k, v]) => [v, k]);
-
 export const IMAGE_WIDTHS_MAP = new Map(IMAGE_WIDTHS_ENTRIES);
 
 export const DEFAULT_PER_PAGE = 25;
@@ -117,33 +113,12 @@ export const MAX_PER_PAGE = 100;
 export const MAX_EDIT_BATCH = 25;
 
 export const PDF_SIZE_LIMIT = 525336576;
-export const PDF_SIZE_LIMIT_READABLE = "500 MB";
 
 export const DOCUMENT_SIZE_LIMIT = 27262976;
-export const DOCUMENT_SIZE_LIMIT_READABLE = "25 MB";
 
 export const TOAST_LENGTH = 3000;
-export const TOAST_FADE = 800;
-
-export const LEGACY_CUT_OFF = 20000000;
-
-export const HIGHLIGHT_START = "<em>";
-export const HIGHLIGHT_END = "</em>";
-
-export const UPLOAD_LIMIT = 1000;
-export const UPLOAD_BATCH = 25;
-export const UPLOAD_BATCH_DELAY = 1000;
-export const GET_BATCH = 25;
-export const GET_BATCH_DELAY = 1000;
 
 export const TAG_KEY = "_tag";
-
-export const SPECIAL_VERSION = "Thanks for using DocumentCloud!";
-export const SPECIAL_CONTACT =
-  "mailto:info@documentcloud.org?subject=DocumentCloud Feedback";
-export const TIP_OF_THE_DAY = "tipofday/";
-export const LOGIN_ERROR =
-  "DocumentCloud is only available to users we have explicitly granted permission.";
 
 export const LANGUAGE_CODES =
   "afr|amh|ara|asm|aze|aze_cyrl|bel|ben|bod|bos|bul|cat|ceb|ces|zho|tra|chr|cym|dan|deu|dzo|ell|eng|enm|epo|est|eus|fas|fin|fra|frk|frm|gle|glg|grc|guj|hat|heb|hin|hrv|hun|iku|ind|isl|ita|ita_old|jav|jpn|kan|kat|kat_old|kaz|khm|kir|kor|kur|lao|lat|lav|lit|mal|mar|mkd|mlt|msa|mya|nep|nld|nor|ori|pan|pol|por|pus|ron|rus|san|sin|slk|slv|spa|spa_old|sqi|srp|srp_latn|swa|swe|syr|tam|tel|tgk|tgl|tha|tir|tur|uig|ukr|urd|uzb|uzb_cyrl|vie|yid".split(
@@ -164,26 +139,6 @@ export const DOCUMENT_TYPES =
   "123,602,abw,agd,bmp,cdr,cgm,cmx,csv,cwk,dbf,dif,doc,docx,dot,emf,eps,fb2,fhd,fodg,fodp,fods,fodt,gif,gnm,gnumeric,htm,html,hwp,jpeg,jpg,jtd,jtt,key,kth,mml,numbers,odb,odf,odg,odp,ods,odt,p65,pages,pbm,pcd,pct,pcx,pdf,pgm,plt,pm3,pm4,pm5,pm6,pmd,png,pot,ppm,pps,ppt,pptx,psd,pub,qxp,ras,rlf,rtf,sda,sdc,sdd,sdp,sdw,sgf,sgl,sgv,slk,stc,std,sti,stw,svg,svm,sxc,sxd,sxi,sxm,sxw,tga,tif,tiff,txt,uof,uop,uos,uot,vor,vsd,wb2,wdb,wk1,wk3,wk4,wks,wpd,wps,wq1,wq2,wri,xbm,xls,xlsx,xlt,xlw,xml,xpm,zabw,zmf".split(
     ",",
   );
-
-export const DOCUMENT_TITLE_CHAR_LIMIT = 1000;
-export const DOCUMENT_DESCRIPTION_CHAR_LIMIT = 4000;
-export const DOCUMENT_SOURCE_CHAR_LIMIT = 1000;
-export const RELATED_ARTICLE_URL_CHAR_LIMIT = 1024;
-export const PUBLISHED_URL_CHAR_LIMIT = 1024;
-
-export const PROJECT_DESCRIPTION_CHAR_LIMIT = 1000;
-export const PROJECT_TITLE_CHAR_LIMIT = 255;
-
-export const NOTE_TITLE_CHAR_LIMIT = 500;
-export const NOTE_CONTENT_CHAR_LIMIT = 2000;
-export const SECTION_TITLE_CHAR_LIMIT = 200;
-
-export const PROJECT_REDIRECT_HASH_URL =
-  "https://s3.amazonaws.com/s3.documentcloud.org/legacy/project_redirects.bin";
-export const ORG_REDIRECT_HASH_URL =
-  "https://s3.amazonaws.com/s3.documentcloud.org/legacy/org_redirects.bin";
-
-export const DEFAULT_ORDERING = "-created_at";
 
 export const USER_EXPAND = "user";
 export const ORG_EXPAND = "organization";


### PR DESCRIPTION
Closes #1041 

Removed 29 exported constants from `src/config/config.js` that had no references anywhere else in the codebase:

- `IMAGE_WIDTHS`
- `PDF_SIZE_LIMIT_READABLE`
- `DOCUMENT_SIZE_LIMIT_READABLE`
- `TOAST_FADE`
- `LEGACY_CUT_OFF`
- `HIGHLIGHT_START`
- `HIGHLIGHT_END`
- `UPLOAD_LIMIT`
- `UPLOAD_BATCH`
- `UPLOAD_BATCH_DELAY`
- `GET_BATCH`
- `GET_BATCH_DELAY`
- `SPECIAL_VERSION`
- `SPECIAL_CONTACT`
- `TIP_OF_THE_DAY`
- `LOGIN_ERROR`
- `DOCUMENT_TITLE_CHAR_LIMIT`
- `DOCUMENT_DESCRIPTION_CHAR_LIMIT`
- `DOCUMENT_SOURCE_CHAR_LIMIT`
- `RELATED_ARTICLE_URL_CHAR_LIMIT`
- `PUBLISHED_URL_CHAR_LIMIT`
- `PROJECT_DESCRIPTION_CHAR_LIMIT`
- `PROJECT_TITLE_CHAR_LIMIT`
- `NOTE_TITLE_CHAR_LIMIT`
- `NOTE_CONTENT_CHAR_LIMIT`
- `SECTION_TITLE_CHAR_LIMIT`
- `PROJECT_REDIRECT_HASH_URL`
- `ORG_REDIRECT_HASH_URL`
- `DEFAULT_ORDERING`
