### PR TITLE
Await promises in layout load to preserve HTTP status codes

### DIFF
--- a/src/lib/components/layouts/Navigation.svelte
+++ b/src/lib/components/layouts/Navigation.svelte
@@ -31,8 +31,8 @@
   const me = getCurrentUser();
   const org = getContext<Writable<Org>>("org");
   const tipOfDay = getContext<Flatpage>("tipOfDay");
-  const user_orgs = getContext<Writable<Promise<Org[]>>>("user_orgs");
-  const org_users = getContext<Writable<Promise<User[]>>>("org_users");
+  const user_orgs = getContext<Writable<Org[]>>("user_orgs");
+  const org_users = getContext<Writable<User[]>>("org_users");
 
   let feedbackOpen = false;
   let width: number;

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -57,14 +57,27 @@ export async function load({ fetch, cookies }) {
     });
   }
 
+  // Await this data instead of returning the promises directly. Returning
+  // unresolved promises from a layout `load` makes SvelteKit stream the
+  // response, and once streaming begins the HTTP status is locked at 200 —
+  // even when a child page's `load` throws (e.g. a 404 for a missing
+  // document). Awaiting keeps the sidebar requests running in parallel while
+  // letting error statuses propagate. See sveltejs/kit#12533 and #12987.
+  const [
+    resolvedUserOrgs,
+    resolvedOrgUsers,
+    resolvedPinnedAddons,
+    resolvedPinnedProjects,
+  ] = await Promise.all([user_orgs, org_users, pinnedAddons, pinnedProjects]);
+
   return {
     me,
     org,
     tipOfDay,
     breadcrumbs: [],
-    user_orgs,
-    org_users,
-    pinnedAddons,
-    pinnedProjects,
+    user_orgs: resolvedUserOrgs,
+    org_users: resolvedOrgUsers,
+    pinnedAddons: resolvedPinnedAddons,
+    pinnedProjects: resolvedPinnedProjects,
   };
 }

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -57,12 +57,7 @@ export async function load({ fetch, cookies }) {
     });
   }
 
-  // Await this data instead of returning the promises directly. Returning
-  // unresolved promises from a layout `load` makes SvelteKit stream the
-  // response, and once streaming begins the HTTP status is locked at 200 —
-  // even when a child page's `load` throws (e.g. a 404 for a missing
-  // document). Awaiting keeps the sidebar requests running in parallel while
-  // letting error statuses propagate. See sveltejs/kit#12533 and #12987.
+  // Await (don't stream) this data so child-page error statuses aren't locked to 200. See sveltejs/kit#12533.
   const [
     resolvedUserOrgs,
     resolvedOrgUsers,

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -11,8 +11,8 @@
 
   const me: Writable<Maybe<User>> = writable(props.data.me);
   const org: Writable<Maybe<Org>> = writable(props.data.org);
-  const user_orgs: Writable<Promise<Org[]>> = writable(props.data.user_orgs);
-  const org_users: Writable<Promise<User[]>> = writable(props.data.org_users);
+  const user_orgs: Writable<Org[]> = writable(props.data.user_orgs);
+  const org_users: Writable<User[]> = writable(props.data.org_users);
 
   // update context so other components can access and update
   setContext("me", me);


### PR DESCRIPTION
Closes #1365 

## Summary
This change fixes an issue where HTTP error status codes (like 404) from child pages were being overridden to 200 when the layout's `load` function returned unresolved promises. By awaiting the promises before returning them, we allow error statuses to propagate correctly while maintaining parallel request execution.

## Key Changes
- **src/routes/(app)/+layout.server.ts**: Modified the `load` function to await all sidebar data requests (`user_orgs`, `org_users`, `pinnedAddons`, `pinnedProjects`) using `Promise.all()` before returning them, rather than returning the promises directly
- **src/routes/(app)/+layout.svelte**: Updated type annotations to reflect that `user_orgs` and `org_users` are now resolved arrays instead of promises
- **src/lib/components/layouts/Navigation.svelte**: Updated context type annotations to match the resolved data types

## Implementation Details
The root cause was that returning unresolved promises from a layout's `load` function triggers SvelteKit's response streaming, which locks the HTTP status at 200 once streaming begins. By awaiting the promises with `Promise.all()`, the requests continue running in parallel (no performance regression) while allowing the HTTP status to be determined by child page `load` functions that may throw errors.

This resolves issues referenced in sveltejs/kit#12533 and #12987.

https://claude.ai/code/session_01Bhxx2X2kR1eG3EVmxpJqw1