### PR TITLE
Migrate viewer components to Svelte 5

### DIFF
--- a/src/lib/components/common/MenuItem.svelte
+++ b/src/lib/components/common/MenuItem.svelte
@@ -72,7 +72,7 @@
     class:disabled
     class:indent
     class:special
-    onclick={onclick?.()}
+    onclick={() => onclick?.()}
     role="menuitem"
     tabindex="0"
   >

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -32,8 +32,12 @@ Assumes it's a child of a ViewerContext
   import { getNotes, getViewerHref } from "$lib/utils/viewer";
   import Tooltip from "../common/Tooltip.svelte";
 
-  export let scale = 1.5;
-  export let page_number: number; // zero-indexed
+  interface Props {
+    scale?: number;
+    page_number: number; // zero-indexed
+  }
+
+  let { scale = 1.5, page_number }: Props = $props();
 
   const documentStore = getDocument();
   const embed = isEmbedded();
@@ -42,13 +46,16 @@ Assumes it's a child of a ViewerContext
   const newNote = getNewNote();
 
   let drawStart: Nullable<[x: number, y: number]> = null;
-  let drawing = false;
+  let drawing = $state(false);
 
-  $: document = $documentStore;
-  $: notes =
-    getNotes(document)[page_number]?.filter((note) => !isPageLevel(note)) ?? [];
-  $: writing = $mode === "annotating";
-  $: activeNote = Boolean($currentNote) || (Boolean($newNote) && !drawing);
+  let document = $derived($documentStore);
+  let notes = $derived(
+    getNotes(document)[page_number]?.filter((note) => !isPageLevel(note)) ?? [],
+  );
+  let writing = $derived($mode === "annotating");
+  let activeNote = $derived(
+    Boolean($currentNote) || (Boolean($newNote) && !drawing),
+  );
 
   function getNoteId(note: NoteType) {
     return noteHashUrl(note).split("#")[1];
@@ -64,6 +71,7 @@ Assumes it's a child of a ViewerContext
   }
 
   function startDrawingBox(e: PointerEvent) {
+    if (e.target !== e.currentTarget) return;
     closeNote();
 
     drawing = true;
@@ -82,6 +90,7 @@ Assumes it's a child of a ViewerContext
   }
 
   function continueDrawingBox(e: PointerEvent) {
+    if (e.target !== e.currentTarget) return;
     if (!drawing || !newNote || !drawStart || !$newNote) return;
 
     const [x, y] = getLayerPosition(e);
@@ -105,6 +114,7 @@ Assumes it's a child of a ViewerContext
   }
 
   function finishDrawingBox(e: PointerEvent) {
+    if (e.target !== e.currentTarget) return;
     if (!newNote || !drawing || !$newNote) return;
 
     $newNote = {
@@ -174,7 +184,7 @@ Assumes it's a child of a ViewerContext
   }
 </script>
 
-<svelte:window on:keydown={onkeypress} />
+<svelte:window onkeydown={onkeypress} />
 
 <div
   class="notes"
@@ -182,9 +192,9 @@ Assumes it's a child of a ViewerContext
   class:drawing
   class:activeNote
   role="application"
-  on:pointerdown|self={startDrawingBox}
-  on:pointermove|self={continueDrawingBox}
-  on:pointerup|self={finishDrawingBox}
+  onpointerdown={startDrawingBox}
+  onpointermove={continueDrawingBox}
+  onpointerup={finishDrawingBox}
 >
   {#each notes as note (note.id)}
     <a
@@ -193,7 +203,7 @@ Assumes it's a child of a ViewerContext
       href={getViewerHref({ document, note, mode: $mode, embed })}
       title={note.title}
       style:top="calc({note.y1} * 100%)"
-      on:click={(e) => openNote(e, note)}
+      onclick={(e) => openNote(e, note)}
     >
       <Tooltip caption={note.title}><NoteTab access={note.access} /></Tooltip>
     </a>
@@ -206,7 +216,7 @@ Assumes it's a child of a ViewerContext
       style:left="{note.x1 * 100}%"
       style:width="{width(note) * 100}%"
       style:height="{height(note) * 100}%"
-      on:click={(e) => openNote(e, note)}
+      onclick={(e) => openNote(e, note)}
     >
       {note.title}
     </a>

--- a/src/lib/components/viewer/Grid.svelte
+++ b/src/lib/components/viewer/Grid.svelte
@@ -24,7 +24,11 @@
   } from "$lib/components/viewer/ViewerContext.svelte";
   import { zoomToSize } from "$lib/utils/viewer";
 
-  export let size: Sizes = "thumbnail";
+  interface Props {
+    size?: Sizes;
+  }
+
+  let { size = "thumbnail" }: Props = $props();
 
   const documentStore = getDocument();
   const zoom = getZoom();
@@ -36,11 +40,13 @@
     large: 3,
   };
 
-  $: document = $documentStore;
-  $: size = zoomToSize($zoom);
-  $: sizes = pageSizesFromSpec(document.page_spec);
-  $: scale = SCALE[size] ?? 1;
-  $: width = (IMAGE_WIDTHS_MAP.get(size) ?? 180) / scale;
+  let document = $derived($documentStore);
+  $effect(() => {
+    size = zoomToSize($zoom);
+  });
+  let sizes = $derived(pageSizesFromSpec(document.page_spec));
+  let scale = $derived(SCALE[size] ?? 1);
+  let width = $derived((IMAGE_WIDTHS_MAP.get(size) ?? 180) / scale);
 </script>
 
 <div class="pages" style:--image-width="{width}px">
@@ -49,17 +55,19 @@
       {@const page_number = n + 1}
       {@const height = width * aspect}
       {@const src = pageImageUrl(document, page_number, size).href}
-      <Page {page_number} let:documentHref>
-        <a href={documentHref}>
-          <img
-            {src}
-            alt="Page {page_number}, {document.title}"
-            title="Page {page_number}, {document.title}"
-            width="{width}px"
-            height="{height}px"
-            loading="lazy"
-          />
-        </a>
+      <Page {page_number}>
+        {#snippet children({ documentHref })}
+          <a href={documentHref}>
+            <img
+              {src}
+              alt="Page {page_number}, {document.title}"
+              title="Page {page_number}, {document.title}"
+              width="{width}px"
+              height="{height}px"
+              loading="lazy"
+            />
+          </a>
+        {/snippet}
       </Page>
     {/each}
   {/if}

--- a/src/lib/components/viewer/NoteTab.svelte
+++ b/src/lib/components/viewer/NoteTab.svelte
@@ -7,9 +7,12 @@
 <script lang="ts">
   import type { Access } from "$lib/api/types";
 
-  export let access: Access | "" = "";
-  export let size: "small" | "normal" = "normal";
-  // export let title: string | undefined = undefined;
+  interface Props {
+    access?: Access | "";
+    size?: "small" | "normal";
+  }
+
+  let { access = "", size = "normal" }: Props = $props();
 </script>
 
 <div class="tab {access} {size}"></div>

--- a/src/lib/components/viewer/Notes.svelte
+++ b/src/lib/components/viewer/Notes.svelte
@@ -14,9 +14,9 @@ Assumes it's a child of a ViewerContext
 
   const documentStore = getDocument();
 
-  $: document = $documentStore;
-  $: notes = document.notes ?? [];
-  $: annotate = getViewerHref({ document, mode: "annotating" });
+  let document = $derived($documentStore);
+  let notes = $derived(document.notes ?? []);
+  let annotate = $derived(getViewerHref({ document, mode: "annotating" }));
 </script>
 
 <div class="pages">

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -30,25 +30,27 @@
   const pdf = getPDF();
   const zoom = getZoom();
 
-  let width: number;
+  let width: number = $state(800);
 
-  $: document = $documentStore;
-  $: scale = zoomToScale($zoom);
-  $: sizes = document.page_spec ? pageSizes(document.page_spec) : [];
-  $: sections = getSections(document);
-  $: errors = getErrors();
+  let document = $derived($documentStore);
+  let scale = $derived(zoomToScale($zoom));
+  let sizes = $derived(document.page_spec ? pageSizes(document.page_spec) : []);
+  let sections = $derived(getSections(document));
+  let errors = $derived(getErrors());
 
   // handle missing page_spec
-  $: $pdf
-    .then((p) => {
-      if (sizes.length === 0) {
-        sizes = Array(p.numPages).fill([0, 0]);
-      }
-    })
-    .catch((e) => {
-      console.warn(e);
-      errors.update((errs) => [...errs, e]);
-    });
+  $effect(() => {
+    $pdf
+      .then((p) => {
+        if (sizes.length === 0) {
+          sizes = Array(p.numPages).fill([0, 0]);
+        }
+      })
+      .catch((e) => {
+        console.warn(e);
+        errors.update((errs) => [...errs, e]);
+      });
+  });
 
   onMount(() => {
     $pdf

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -10,7 +10,7 @@ Selectable text can be rendered in one of two ways:
 - Passed in as a server-fetched JSON object
 -->
 <script lang="ts">
-  import type { TextPosition } from "$lib/api/types";
+  import type { Maybe, TextPosition } from "$lib/api/types";
 
   import { page as pageStore } from "$app/stores";
 
@@ -34,75 +34,48 @@ Selectable text can be rendered in one of two ways:
   import { getQuery } from "$lib/utils/search";
   import { fitPage, getNotes } from "$lib/utils/viewer";
 
-  export let page_number: number; // 1-indexed
-
-  export let scale: number | "width" | "height";
-  export let width: number;
-  export let height: number;
-  export let text: TextPosition[] = [];
-  export let query: string = getQuery($pageStore.url, "q");
-
   const documentStore = getDocument();
   const mode = getCurrentMode();
   const pdf = getPDF();
 
-  // make hidden things visible, for debugging
-  export let debug = false;
+  interface Props {
+    page_number: number; // 1-indexed
+    scale: number | "width" | "height";
+    width: number;
+    height: number;
+    text?: TextPosition[];
+    query?: string;
+    // make hidden things visible, for debugging
+    debug?: boolean;
+  }
 
-  let canvas: HTMLCanvasElement;
-  let container: HTMLElement;
-  let textContainer: HTMLElement;
+  let {
+    page_number,
+    scale,
+    width = $bindable(),
+    height = $bindable(),
+    text = [],
+    query = $bindable(getQuery($pageStore.url, "q")),
+    debug = false,
+  }: Props = $props();
+
+  let canvas: Maybe<HTMLCanvasElement> = $state();
+  let container: Maybe<HTMLElement> = $state();
+  let textContainer: Maybe<HTMLElement> = $state();
 
   // keep track of this to avoid overlapping renders
   let renderTask;
-  let textPromise: Promise<void>; // resolves when text is rendered
-  let loaded = false;
+  let textPromise: Maybe<Promise<void>> = $state(); // resolves when text is rendered
+  let loaded = $state(false);
   let textLayer: pdfjs.TextLayer; // TextLayer
 
   // visibility, for loading optimization
-  let visible: boolean = false;
-
-  $: query = getQuery($pageStore.url, "q");
-  $: document = $documentStore;
-  $: aspect = height / width;
-  $: orientation = height > width ? "vertical" : "horizontal";
-  $: numericScale = fitPage(width, height, container, scale);
-
-  // render when anything changes
-  $: page =
-    visible && Promise.resolve($pdf).then((pdf) => pdf?.getPage(page_number));
-
-  // we need to wait on both promises to render on initial load
-  $: Promise.all([$pdf, page]).then(([pdf, page]) => {
-    render(page, canvas, container, scale);
-    textPromise = renderTextLayer(page, textContainer, container, scale);
-  });
-
-  $: textPromise?.then(() => {
-    markHighlights(textContainer, query);
-  });
-
-  // handle 0 sizing when page_spec is unavailable
-  $: if (page && width === 0 && height === 0) {
-    page.then((p) => {
-      // It's safe to assume that PDFPageProxy.view is 4 elements long
-      width = p.view[2]!;
-      height = p.view[3]!;
-    });
-  }
-
-  $: redactions_for_page = [
-    ...($pending[document.id] ?? []),
-    ...($redactions[document.id] ?? []),
-  ].filter((r) => r.page_number === page_number - 1);
-
-  $: page_level_notes =
-    getNotes(document)[page_number - 1]?.filter((n) => isPageLevel(n)) ?? [];
+  let visible: boolean = $state(false);
 
   async function render(
     page, // pdf.getPage
-    canvas: HTMLCanvasElement,
-    container: HTMLElement,
+    canvas: Maybe<HTMLCanvasElement>,
+    container: Maybe<HTMLElement>,
     scale: number | "width" | "height",
   ) {
     // only one render task at a time;
@@ -111,7 +84,7 @@ Selectable text can be rendered in one of two ways:
     }
 
     // check that we have things
-    if (![canvas, container, scale, page].every(Boolean)) return;
+    if (!canvas || !container || !scale || !page) return;
 
     const numericScale = fitPage(width, height, container, scale);
     const context = canvas.getContext("2d");
@@ -141,8 +114,8 @@ Selectable text can be rendered in one of two ways:
 
   async function renderTextLayer(
     page, // PdfPageProxy
-    textContainer: HTMLElement,
-    pageContainer: HTMLElement,
+    textContainer: Maybe<HTMLElement>,
+    pageContainer: Maybe<HTMLElement>,
     scale: number | "width" | "height",
   ) {
     if (text.length > 0) return;
@@ -155,7 +128,7 @@ Selectable text can be rendered in one of two ways:
     const content = await page.getTextContent();
 
     // svelte's reactivity ends up a step behind, so do this here
-    container.style.setProperty("--scale-factor", numericScale.toFixed(2));
+    container?.style.setProperty("--scale-factor", numericScale.toFixed(2));
 
     textLayer = new pdfjs.TextLayer({
       textContentSource: content,
@@ -166,8 +139,8 @@ Selectable text can be rendered in one of two ways:
     return textLayer.render();
   }
 
-  function markHighlights(textContainer: HTMLElement, query: string) {
-    if (!query || !textContainer) return;
+  function markHighlights(textContainer: Maybe<HTMLElement>, query: string) {
+    if (!query || !textContainer || !container) return;
     container.querySelectorAll("span").forEach((span) => {
       if (span.textContent) {
         span.innerHTML = highlight(span.textContent, query);
@@ -182,6 +155,7 @@ Selectable text can be rendered in one of two ways:
     // they overlap its bounds — otherwise clicking inside an open EditNote form
     // reopens the note beneath it and editing becomes impossible.
     if ((click.target as HTMLElement)?.closest(".note.card, .note-tab")) return;
+    if (!container) return;
 
     const clickX = click.clientX;
     const clickY = click.clientY;
@@ -208,83 +182,149 @@ Selectable text can be rendered in one of two ways:
   }
 
   function onVisibilityChange() {
-    if (window.document.visibilityState === "visible" && !canvas.hidden) {
+    if (
+      window.document.visibilityState === "visible" &&
+      canvas &&
+      !canvas.hidden
+    ) {
       Promise.all([$pdf, page]).then(([pdf, page]) => {
         render(page, canvas, container, scale);
       });
     }
   }
 
-  let pageWidth: number;
+  let pageWidth: Maybe<number> = $state();
+  $effect(() => {
+    query = getQuery($pageStore.url, "q");
+  });
+  let document = $derived($documentStore);
+  // render when anything changes
+  let page = $derived(
+    visible
+      ? Promise.resolve($pdf).then((pdf) => pdf?.getPage(page_number))
+      : undefined,
+  );
+  // handle 0 sizing when page_spec is unavailable
+  $effect(() => {
+    // Capture the derived value in a local so TS can narrow it; reading the
+    // `page` accessor twice (guard + `.then`) would not narrow.
+    const pagePromise = page;
+    if (pagePromise && width === 0 && height === 0) {
+      pagePromise.then((p) => {
+        // It's safe to assume that PDFPageProxy.view is 4 elements long
+        width = p.view[2]!;
+        height = p.view[3]!;
+      });
+    }
+  });
+  let aspect = $derived(height / width);
+  let orientation = $derived(height > width ? "vertical" : "horizontal");
+  // Recomputed reactively when its inputs change; `onResize` also writes to
+  // it directly to pick up window resizes, which don't emit a reactive signal.
+  let numericScale = $derived(fitPage(width, height, container, scale));
+  // we need to wait on both promises to render on initial load
+  $effect(() => {
+    // Read `scale` synchronously so the effect tracks it as a dependency;
+    // reading it only inside the async `.then` below would not register it,
+    // and numeric zoom changes (which flow through `scale`) wouldn't re-render.
+    const currentScale = scale;
+    Promise.all([$pdf, page]).then(([pdf, page]) => {
+      render(page, canvas, container, currentScale);
+      textPromise = renderTextLayer(
+        page,
+        textContainer,
+        container,
+        currentScale,
+      );
+    });
+  });
+  $effect(() => {
+    // Read `query` synchronously so the effect re-runs when the search query
+    // changes; reading it only inside the async `.then` would not track it.
+    const currentQuery = query;
+    textPromise?.then(() => {
+      markHighlights(textContainer, currentQuery);
+    });
+  });
+  let redactions_for_page = $derived(
+    [
+      ...($pending[document.id] ?? []),
+      ...($redactions[document.id] ?? []),
+    ].filter((r) => r.page_number === page_number - 1),
+  );
+  let page_level_notes = $derived(
+    getNotes(document)[page_number - 1]?.filter((n) => isPageLevel(n)) ?? [],
+  );
 </script>
 
-<svelte:window on:resize={onResize} />
+<svelte:window onresize={onResize} />
 
-<svelte:document on:visibilitychange={onVisibilityChange} />
+<svelte:document onvisibilitychange={onVisibilityChange} />
 
 <Page
   {page_number}
   wide={scale === "width"}
   tall={scale === "height"}
   track
-  let:visible
-  on:visible={() => {
+  onvisible={() => {
     visible = true;
   }}
   bind:width={pageWidth}
 >
-  {#if page_level_notes.length}
-    <div class="page-notes">
-      {#each page_level_notes as note}
-        <Note {note} />
-      {/each}
-    </div>
-  {/if}
-
-  <div
-    bind:this={container}
-    class="page-container scale-{scale} {orientation}"
-    class:visible
-    class:debug
-    style:--aspect={aspect}
-    style:--scale-factor={numericScale.toFixed(2)}
-    style:--width="{width}px"
-    style:--height="{height}px"
-    data-loaded={loaded}
-    on:click={checkForHighlightClick}
-    on:keydown={checkForHighlightClick}
-    role="none"
-    tabindex="-1"
-  >
-    <canvas bind:this={canvas} {width} {height}></canvas>
-
-    {#if text.length > 0}
-      <div bind:this={textContainer} class="selectable-text">
-        {#each text as word}
-          <span
-            role="presentation"
-            class="word"
-            style="left: {word.x1 * 100}%; top: {word.y1 * 100}%;"
-            >{word.text}</span
-          >
+  {#snippet children({ visible })}
+    {#if page_level_notes.length}
+      <div class="page-notes">
+        {#each page_level_notes as note}
+          <Note {note} />
         {/each}
       </div>
-    {:else}
-      <div bind:this={textContainer} class="selectable-text embedded">
-        <!-- pdfjs.renderTextLayer will fill this in -->
-      </div>
     {/if}
 
-    <AnnotationLayer page_number={page_number - 1} />
+    <div
+      bind:this={container}
+      class="page-container scale-{scale} {orientation}"
+      class:visible
+      class:debug
+      style:--aspect={aspect}
+      style:--scale-factor={numericScale.toFixed(2)}
+      style:--width="{width}px"
+      style:--height="{height}px"
+      data-loaded={loaded}
+      onclick={checkForHighlightClick}
+      onkeydown={checkForHighlightClick}
+      role="none"
+      tabindex="-1"
+    >
+      <canvas bind:this={canvas} {width} {height}></canvas>
 
-    {#if redactions_for_page.length > 0 || $mode === "redacting"}
-      <RedactionLayer
-        page_number={page_number - 1}
-        active={$mode === "redacting"}
-        id={document.id.toString()}
-      />
-    {/if}
-  </div>
+      {#if text.length > 0}
+        <div bind:this={textContainer} class="selectable-text">
+          {#each text as word}
+            <span
+              role="presentation"
+              class="word"
+              style="left: {word.x1 * 100}%; top: {word.y1 * 100}%;"
+              >{word.text}</span
+            >
+          {/each}
+        </div>
+      {:else}
+        <div bind:this={textContainer} class="selectable-text embedded">
+          <!-- pdfjs.renderTextLayer will fill this in -->
+        </div>
+      {/if}
+
+      <AnnotationLayer page_number={page_number - 1} />
+
+      {#if redactions_for_page.length > 0 || $mode === "redacting"}
+        <RedactionLayer
+          page_number={page_number - 1}
+          active={$mode === "redacting"}
+          id={document.id.toString()}
+        />
+      {/if}
+    </div>
+  {/snippet}
 </Page>
 
 <style>

--- a/src/lib/components/viewer/Page.svelte
+++ b/src/lib/components/viewer/Page.svelte
@@ -5,9 +5,11 @@ Assumes it's a child of a ViewerContext
 -->
 
 <script lang="ts">
+  import type { Maybe } from "$lib/api/types";
+
   import { page } from "$app/stores";
 
-  import { createEventDispatcher, onMount } from "svelte";
+  import { type Snippet, onMount } from "svelte";
   import { _ } from "svelte-i18n";
 
   import PageActions from "./PageActions.svelte";
@@ -22,13 +24,27 @@ Assumes it's a child of a ViewerContext
   import { getQuery } from "$lib/utils/search";
   import { getViewerHref } from "$lib/utils/viewer";
 
-  export let page_number: number;
-  export let wide = false;
-  export let tall = false;
-  export let track: boolean | "once" = false;
-  export let width: number | undefined = undefined;
+  interface Props {
+    page_number: number;
+    wide?: boolean;
+    tall?: boolean;
+    track?: boolean | "once";
+    width?: number | undefined;
+    title?: Snippet;
+    children?: Snippet<[any]>;
+    onvisible?: () => void;
+  }
 
-  const dispatch = createEventDispatcher();
+  let {
+    page_number,
+    wide = false,
+    tall = false,
+    track = false,
+    width = $bindable(undefined),
+    title,
+    children,
+    onvisible,
+  }: Props = $props();
 
   const documentStore = getDocument();
   const currentPage = getCurrentPage();
@@ -36,19 +52,23 @@ Assumes it's a child of a ViewerContext
   const embed = isEmbedded();
 
   let io: IntersectionObserver;
-  let container: HTMLElement;
-  let visible: boolean;
+  let container: Maybe<HTMLElement> = $state();
+  let visible = $state(false);
 
-  $: document = $documentStore;
-  $: id = pageHashUrl(page_number).replace("#", "");
-  $: href = getViewerHref({ document, mode: $mode, page: page_number, embed });
-  $: documentHref = getViewerHref({
-    document,
-    mode: "document",
-    page: page_number,
-    embed,
-    query: getQuery($page.url, "q"),
-  });
+  let document = $derived($documentStore);
+  let id = $derived(pageHashUrl(page_number).replace("#", ""));
+  let href = $derived(
+    getViewerHref({ document, mode: $mode, page: page_number, embed }),
+  );
+  let documentHref = $derived(
+    getViewerHref({
+      document,
+      mode: "document",
+      page: page_number,
+      embed,
+      query: getQuery($page.url, "q"),
+    }),
+  );
 
   function watch(el: HTMLElement, once = false): IntersectionObserver {
     const io = new IntersectionObserver(
@@ -57,7 +77,7 @@ Assumes it's a child of a ViewerContext
           if (entry.isIntersecting) {
             // update state
             visible = true;
-            dispatch("visible");
+            onvisible?.();
 
             if (once) {
               observer.unobserve(el);
@@ -91,12 +111,12 @@ Assumes it's a child of a ViewerContext
     return io;
   }
 
-  function unwatch(io: IntersectionObserver, el: HTMLElement) {
-    io?.unobserve(el);
+  function unwatch(io: IntersectionObserver, el: Maybe<HTMLElement>) {
+    if (el) io?.unobserve(el);
   }
 
   onMount(() => {
-    if (track) {
+    if (track && container) {
       io = watch(container, track === "once");
     }
 
@@ -114,7 +134,7 @@ Assumes it's a child of a ViewerContext
   class:wide
   class:tall
 >
-  <div class="title"><slot name="title" /></div>
+  <div class="title">{@render title?.()}</div>
   <header>
     <h4 class="pageNumber">
       <a href={documentHref}>
@@ -127,7 +147,7 @@ Assumes it's a child of a ViewerContext
       <PageActions {document} {page_number} pageWidth={width} />
     {/if}
   </header>
-  <slot {id} {href} {visible} {documentHref} />
+  {@render children?.({ id, href, visible, documentHref })}
 </div>
 
 <style>

--- a/src/lib/components/viewer/PageActions.svelte
+++ b/src/lib/components/viewer/PageActions.svelte
@@ -24,16 +24,20 @@
   import { remToPx } from "$lib/utils/layout";
   import { getSections } from "$lib/utils/viewer";
 
-  export let document: Document;
-  export let page_number: number;
-  export let pageWidth: number;
+  interface Props {
+    document: Document;
+    page_number: number;
+    pageWidth: number;
+  }
 
-  let pageShareOpen = false;
-  let pageNote = false;
-  let editSection = false;
+  let { document, page_number, pageWidth }: Props = $props();
+
+  let pageShareOpen = $state(false);
+  let pageNote = $state(false);
+  let editSection = $state(false);
 
   // `page_number` is 1-indexed here; sections are keyed by 0-indexed page.
-  $: section = getSections(document)[page_number - 1];
+  let section = $derived(getSections(document)[page_number - 1]);
 </script>
 
 <div class="page-actions">

--- a/src/lib/components/viewer/RedactionLayer.svelte
+++ b/src/lib/components/viewer/RedactionLayer.svelte
@@ -4,8 +4,8 @@ It's layered over a PDF page and allows us to render redactions and draw new one
 When saved, redactions are burned into the PDF.
 So this layer is only showing unsaved redactions.
 -->
-<script context="module" lang="ts">
-  import type { Redaction, Nullable } from "$lib/api/types";
+<script module lang="ts">
+  import type { Redaction, Nullable, Maybe } from "$lib/api/types";
   import { writable, type Writable } from "svelte/store";
   import { saveStore } from "$lib/utils/storage";
 
@@ -40,17 +40,23 @@ So this layer is only showing unsaved redactions.
   import { _ } from "svelte-i18n";
   import { beforeNavigate } from "$app/navigation";
 
-  export let active = false;
-  export let page_number: number; // 0-indexed
-  export let id: string; // document ID, for namespacing
+  interface Props {
+    active?: boolean;
+    page_number: number; // 0-indexed
+    id: string; // document ID, for namespacing
+  }
+
+  let { active = false, page_number, id }: Props = $props();
 
   const KEY = "redactions";
 
-  let container: HTMLElement;
-  let currentRedaction: Nullable<Redaction> = null;
+  let container: Maybe<HTMLElement> = $state();
+  let currentRedaction: Nullable<Redaction> = $state(null);
 
-  $: redactions_for_page = [...($pending[id] ?? []), ...$redactions].filter(
-    (r) => r.page_number === page_number,
+  let redactions_for_page = $derived(
+    [...($pending[id] ?? []), ...$redactions].filter(
+      (r) => r.page_number === page_number,
+    ),
   );
 
   // handle interaction events
@@ -143,9 +149,9 @@ So this layer is only showing unsaved redactions.
   class:active
   role="application"
   bind:this={container}
-  on:pointerdown={startDrawingBox}
-  on:pointermove={continueDrawingBox}
-  on:pointerup={finishDrawingBox}
+  onpointerdown={startDrawingBox}
+  onpointermove={continueDrawingBox}
+  onpointerup={finishDrawingBox}
 >
   {#each redactions_for_page as redaction}
     <span

--- a/src/lib/components/viewer/Search.svelte
+++ b/src/lib/components/viewer/Search.svelte
@@ -6,7 +6,7 @@ Assumes it's a child of a ViewerContext
   import type { APIResponse, Highlights } from "$lib/api/types";
 
   import { browser } from "$app/environment";
-  import { page } from "$app/stores";
+  import { page } from "$app/state";
 
   import { _ } from "svelte-i18n";
   import { Hourglass24, Search24 } from "svelte-octicons";
@@ -23,12 +23,12 @@ Assumes it's a child of a ViewerContext
 
   const document = getDocument();
 
-  let search: Promise<[number, string[]][]>;
-
-  $: query = getQuery($page.url, "q");
-  $: search = browser
-    ? searchWithin($document.id, query).then(formatResults)
-    : new Promise(() => {});
+  let query = $derived(getQuery(page.url, "q"));
+  let search: Promise<[number, string[]][]> = $derived(
+    browser
+      ? searchWithin($document.id, query).then(formatResults)
+      : new Promise(() => {}),
+  );
 
   // Format page numbers, highlight search results, and remove invalid pages
   function formatResults(results: APIResponse<Highlights>) {

--- a/src/lib/components/viewer/Text.svelte
+++ b/src/lib/components/viewer/Text.svelte
@@ -5,7 +5,7 @@
   Assumes it's a child of a ViewerContext
 -->
 <script lang="ts">
-  import { page } from "$app/stores";
+  import { page } from "$app/state";
   import { onMount } from "svelte";
 
   import Page from "./Page.svelte";
@@ -14,7 +14,7 @@
   import { highlight } from "$lib/utils/search";
   import { getQuery } from "$lib/utils/search";
 
-  export let query = getQuery($page.url, "q");
+  let { query = getQuery(page.url, "q") } = $props();
 
   const currentPage = getCurrentPage();
   const text = getText();

--- a/src/lib/components/viewer/Viewer.svelte
+++ b/src/lib/components/viewer/Viewer.svelte
@@ -39,11 +39,15 @@ Assumes it's a child of a ViewerContext
   const progress = getPDFProgress();
 
   // only show loading for slow-loading pages
-  let showLoading = false;
+  let showLoading = $state(false);
 
-  $: mode = $currentMode;
-  $: showPDF = ["document", "annotating", "redacting"].includes($currentMode);
-  $: loading = $progress.total > 0 ? $progress.loaded / $progress.total : null;
+  let mode = $derived($currentMode);
+  let showPDF = $derived(
+    ["document", "annotating", "redacting"].includes($currentMode),
+  );
+  let loading = $derived(
+    $progress.total > 0 ? $progress.loaded / $progress.total : null,
+  );
 
   onMount(() => {
     const timeout = setTimeout(() => (showLoading = true), 500);

--- a/src/lib/components/viewer/Zoom.svelte
+++ b/src/lib/components/viewer/Zoom.svelte
@@ -17,9 +17,11 @@ Assumes it's a child of a ViewerContext
   const mode = getCurrentMode();
   const zoom = getZoom();
 
-  $: zoomLevels = getZoomLevels($mode);
-  $: initial = getInitialZoom($page.url, $mode);
-  $: $zoom = initial || getDefaultZoom($mode);
+  let zoomLevels = $derived(getZoomLevels($mode));
+  let initial = $derived(getInitialZoom($page.url, $mode));
+  $effect(() => {
+    $zoom = initial || getDefaultZoom($mode);
+  });
 </script>
 
 {#if zoomLevels.length}

--- a/src/lib/components/viewer/stories/AnnotationLayer.stories.svelte
+++ b/src/lib/components/viewer/stories/AnnotationLayer.stories.svelte
@@ -1,26 +1,26 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   import type { Document } from "$lib/api/types";
 
-  import { Story } from "@storybook/addon-svelte-csf";
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import AnnotationLayer from "../AnnotationLayer.svelte";
   import Page from "../Page.svelte";
   import Flex from "$lib/components/common/Flex.svelte";
-
-  export const meta = {
-    title: "Viewer / Annotation Layer",
-    component: AnnotationLayer,
-    parameters: { layout: "centered" },
-  };
 
   import { pageSizes } from "$lib/utils/pageSize";
   import doc from "@/test/fixtures/documents/document-expanded.json";
   import ViewerContext from "../ViewerContext.svelte";
 
+  const { Story } = defineMeta({
+    title: "Viewer / Annotation Layer",
+    component: AnnotationLayer,
+    parameters: { layout: "centered" },
+  });
+
   const document = doc as Document;
   const sizes = pageSizes(document.page_spec!);
 </script>
 
-<Story name="Reading">
+<Story name="Reading" asChild>
   <ViewerContext {document}>
     <Flex class="pages" direction="column" gap={1}>
       {#each sizes as [width, height], page_number}
@@ -34,7 +34,7 @@
   </ViewerContext>
 </Story>
 
-<Story name="Writing">
+<Story name="Writing" asChild>
   <ViewerContext {document} mode="annotating">
     <Flex class="pages" direction="column" gap={1}>
       {#each sizes as [width, height], page_number}

--- a/src/lib/components/viewer/stories/Grid.stories.svelte
+++ b/src/lib/components/viewer/stories/Grid.stories.svelte
@@ -1,18 +1,19 @@
-<script context="module" lang="ts">
-  import { Template, Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import type { Document } from "$lib/api/types";
   import ViewerContext from "../ViewerContext.svelte";
   import Grid from "../Grid.svelte";
 
-  export const meta = {
-    title: "Viewer / Grid",
-    component: Grid,
-    parameters: { layout: "fullscreen" },
-  };
-
   import doc from "@/test/fixtures/documents/examples/lefler-thesis.json";
 
   const document = doc as Document;
+
+  const { Story } = defineMeta({
+    title: "Viewer / Grid",
+    component: Grid,
+    parameters: { layout: "fullscreen" },
+    render: template,
+  });
 
   let args = {
     context: {
@@ -24,11 +25,11 @@
   };
 </script>
 
-<Template let:args>
+{#snippet template(args)}
   <ViewerContext {...args.context}>
     <Grid {...args.props} />
   </ViewerContext>
-</Template>
+{/snippet}
 
 <Story
   name="small"

--- a/src/lib/components/viewer/stories/NoteTab.stories.svelte
+++ b/src/lib/components/viewer/stories/NoteTab.stories.svelte
@@ -1,4 +1,6 @@
 <script module lang="ts">
+  import type { ComponentProps } from "svelte";
+
   import { defineMeta } from "@storybook/addon-svelte-csf";
   import NoteTab from "../NoteTab.svelte";
 
@@ -12,7 +14,7 @@
   let args = {
     access: "public",
     size: "normal",
-  };
+  } satisfies ComponentProps<typeof NoteTab>;
 </script>
 
 <Story name="public note" {args} />

--- a/src/lib/components/viewer/stories/NoteTab.stories.svelte
+++ b/src/lib/components/viewer/stories/NoteTab.stories.svelte
@@ -1,23 +1,19 @@
-<script context="module" lang="ts">
-  import { Template, Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import NoteTab from "../NoteTab.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Viewer / Note tab",
     component: NoteTab,
     tags: ["autodocs"],
     parameters: { layout: "centered" },
-  };
+  });
 
   let args = {
     access: "public",
     size: "normal",
   };
 </script>
-
-<Template let:args>
-  <NoteTab {...args} />
-</Template>
 
 <Story name="public note" {args} />
 

--- a/src/lib/components/viewer/stories/Notes.stories.svelte
+++ b/src/lib/components/viewer/stories/Notes.stories.svelte
@@ -1,16 +1,17 @@
-<script context="module" lang="ts">
-  import { Story, Template } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import type { Document } from "$lib/api/types";
   import doc from "@/test/fixtures/documents/document-expanded.json";
   import pdfFile from "@/test/fixtures/documents/examples/agreement-between-conservatives-and-liberal-democrats-to-form-a-coalition-government.pdf";
   import ViewerContext from "../ViewerContext.svelte";
   import Notes from "../Notes.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Viewer / Notes View",
     component: Notes,
     parameters: { layout: "centered" },
-  };
+    render: template,
+  });
 
   const document = doc as Document;
   const url = new URL(pdfFile, import.meta.url);
@@ -21,11 +22,11 @@
   };
 </script>
 
-<Template let:args>
+{#snippet template(args)}
   <ViewerContext {...args}>
     <Notes />
   </ViewerContext>
-</Template>
+{/snippet}
 
 <Story name="notes using images" args={{ document }} />
 

--- a/src/lib/components/viewer/stories/PDF.stories.svelte
+++ b/src/lib/components/viewer/stories/PDF.stories.svelte
@@ -1,11 +1,11 @@
-<script context="module" lang="ts">
-  import { http, HttpResponse, delay } from "msw";
+<script module lang="ts">
   import type { Document, Section } from "$lib/api/types";
 
-  import { Story, Template } from "@storybook/addon-svelte-csf";
+  import { http, HttpResponse, delay } from "msw";
+  import { defineMeta } from "@storybook/addon-svelte-csf";
 
   import PDF from "../PDF.svelte";
-  import { redactions } from "../RedactionLayer.svelte";
+  import { pending } from "../RedactionLayer.svelte";
 
   import ViewerContext from "../ViewerContext.svelte";
 
@@ -16,13 +16,14 @@
   import doc from "@/test/fixtures/documents/document-expanded.json";
   import redacted from "@/test/fixtures/documents/redactions.json";
 
-  export const meta = {
+  const document = doc as Document;
+
+  const { Story } = defineMeta({
     title: "Viewer / PDF Viewer",
     component: PDF,
     parameters: { layout: "centered" },
-  };
-
-  const document = doc as Document;
+    render: template,
+  });
 
   const loadingUrl = createApiUrl("loading/");
 
@@ -51,13 +52,13 @@
   };
 </script>
 
-<Template let:args>
+{#snippet template(args)}
   <ViewerContext {...args.context}>
     <div style="width: {IMAGE_WIDTHS_MAP.get('large')}px;">
       <PDF {...args.props} />
     </div>
   </ViewerContext>
-</Template>
+{/snippet}
 
 <Story name="Default" {args} />
 
@@ -127,15 +128,15 @@
   }}
 />
 
-<Story name="Redactions in-progress">
+<Story name="Redactions in-progress" asChild>
   <ViewerContext
     document={{ ...document, notes: [] }}
     asset_url={pdfUrl(document)}
   >
     <div style="width: {IMAGE_WIDTHS_MAP.get('large')}px;">
-      <button on:click={() => ($redactions[document.id] = redacted)}
-        >Show redactions</button
-      >
+      <button on:click={() => ($pending[document.id] = redacted)}>
+        Show redactions
+      </button>
       <PDF />
     </div>
   </ViewerContext>

--- a/src/lib/components/viewer/stories/PDFPage.stories.svelte
+++ b/src/lib/components/viewer/stories/PDFPage.stories.svelte
@@ -1,10 +1,10 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   import type { Document } from "$lib/api/types";
 
   import { page } from "$app/stores";
 
   import { writable } from "svelte/store";
-  import { Story } from "@storybook/addon-svelte-csf";
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import PdfPage from "../PDFPage.svelte";
 
   import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
@@ -21,11 +21,11 @@
 
   const document = { ...doc, edit_access: true } as Document;
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Viewer / PDF Page",
     component: PdfPage,
     parameters: { layout: "centered" },
-  };
+  });
 
   const sizes = pageSizes(document.page_spec!);
   const [width, height] = sizes[0]!;
@@ -37,19 +37,19 @@
   }
 </script>
 
-<Story name="fit width" parameters={{ layout: "fullscreen" }}>
+<Story name="fit width" parameters={{ layout: "fullscreen" }} asChild>
   <ViewerContext {document} pdf={writable(load(url))}>
     <PdfPage page_number={1} scale="width" {width} {height} />
   </ViewerContext>
 </Story>
 
-<Story name="embedded text">
+<Story name="embedded text" asChild>
   <ViewerContext {document} pdf={writable(load(url))}>
     <PdfPage page_number={1} scale={1.5} {width} {height} />
   </ViewerContext>
 </Story>
 
-<Story name="server text">
+<Story name="server text" asChild>
   <ViewerContext {document} pdf={writable(load(url))}>
     <PdfPage
       page_number={1}
@@ -74,6 +74,7 @@
       },
     },
   }}
+  asChild
 >
   <ViewerContext {document} pdf={writable(load(url))}>
     <p>Query: {query}</p>
@@ -82,7 +83,7 @@
   </ViewerContext>
 </Story>
 
-<Story name="long section start" parameters={{ layout: "fullscreen" }}>
+<Story name="long section start" parameters={{ layout: "fullscreen" }} asChild>
   <ViewerContext {document} pdf={writable(load(url))}>
     <PdfPage page_number={1} scale="width" {width} {height} />
   </ViewerContext>

--- a/src/lib/components/viewer/stories/PageActions.stories.svelte
+++ b/src/lib/components/viewer/stories/PageActions.stories.svelte
@@ -1,0 +1,57 @@
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+  import type { Document } from "$lib/api/types";
+  import PageActions from "../PageActions.svelte";
+
+  import doc from "@/test/fixtures/documents/document-expanded.json";
+
+  const document = doc as Document;
+  // The fixture has `edit_access: false`; override to expose the
+  // note/section actions that only appear for editors.
+  const editable = { ...document, edit_access: true } as Document;
+
+  const { Story } = defineMeta({
+    title: "Viewer / Page Actions",
+    component: PageActions,
+    parameters: { layout: "centered" },
+    render: template,
+  });
+
+  // A page wide enough (> 32rem) shows the inline actions; a narrower
+  // page collapses them into a kebab dropdown.
+  const WIDE = 640;
+  const NARROW = 320;
+
+  let args = {
+    props: {
+      document,
+      page_number: 1,
+      pageWidth: WIDE,
+    },
+  };
+</script>
+
+{#snippet template(args)}
+  <PageActions {...args.props} />
+{/snippet}
+
+<Story
+  name="Wide, editor"
+  args={{
+    ...args,
+    props: { ...args.props, document: editable, pageWidth: WIDE },
+  }}
+/>
+
+<Story
+  name="Wide, viewer"
+  args={{ ...args, props: { ...args.props, document, pageWidth: WIDE } }}
+/>
+
+<Story
+  name="Narrow, editor"
+  args={{
+    ...args,
+    props: { ...args.props, document: editable, pageWidth: NARROW },
+  }}
+/>

--- a/src/lib/components/viewer/stories/RedactionLayer.stories.svelte
+++ b/src/lib/components/viewer/stories/RedactionLayer.stories.svelte
@@ -13,18 +13,9 @@
   });
 
   const id = "1";
-</script>
 
-<script lang="ts">
-  import { onMount } from "svelte";
-
-  onMount(() => {
-    $redactions = redacted;
-
-    return () => {
-      $redactions = [];
-    };
-  });
+  // Seed the shared redactions store so the layers have something to display.
+  redactions.set(redacted);
 </script>
 
 {#snippet template(args)}

--- a/src/lib/components/viewer/stories/RedactionLayer.stories.svelte
+++ b/src/lib/components/viewer/stories/RedactionLayer.stories.svelte
@@ -1,15 +1,16 @@
-<script context="module" lang="ts">
-  import { Story, Template } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import RedactionLayer, { redactions } from "../RedactionLayer.svelte";
   import Flex from "../../common/Flex.svelte";
 
   import redacted from "@/test/fixtures/documents/redactions.json";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Viewer / Redaction Layer",
     component: RedactionLayer,
     parameters: { layout: "centered" },
-  };
+    render: template,
+  });
 
   const id = "1";
 </script>
@@ -26,7 +27,7 @@
   });
 </script>
 
-<Template let:args>
+{#snippet template(args)}
   <Flex class="pages" direction="column" gap={1}>
     {#each redacted as page}
       <div class="page">
@@ -34,7 +35,7 @@
       </div>
     {/each}
   </Flex>
-</Template>
+{/snippet}
 
 <Story name="display redactions" />
 

--- a/src/lib/components/viewer/stories/Search.stories.svelte
+++ b/src/lib/components/viewer/stories/Search.stories.svelte
@@ -1,18 +1,18 @@
-<script context="module" lang="ts">
-  import { Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import Search from "../Search.svelte";
-
-  export const meta = {
-    title: "Viewer / Search",
-    component: Search,
-    parameters: { layout: "centered" },
-  };
 
   import { document } from "@/test/fixtures/documents";
   import { searchWithin } from "@/test/handlers/documents";
   import text from "@/test/fixtures/documents/document.txt.json";
 
   import ViewerContext from "../ViewerContext.svelte";
+
+  const { Story } = defineMeta({
+    title: "Viewer / Search",
+    component: Search,
+    parameters: { layout: "centered" },
+  });
 
   const query = "Trump";
 </script>
@@ -31,6 +31,7 @@
       },
     },
   }}
+  asChild
 >
   <ViewerContext {document} text={Promise.resolve(text)} mode="search">
     <Search />
@@ -51,6 +52,7 @@
       },
     },
   }}
+  asChild
 >
   <ViewerContext {document} text={Promise.resolve(text)} mode="search">
     <Search />
@@ -71,6 +73,7 @@
       },
     },
   }}
+  asChild
 >
   <ViewerContext {document} text={Promise.resolve(text)} mode="search">
     <Search />
@@ -91,6 +94,7 @@
       },
     },
   }}
+  asChild
 >
   <ViewerContext {document} text={Promise.resolve(text)} mode="search">
     <Search />

--- a/src/lib/components/viewer/stories/Text.stories.svelte
+++ b/src/lib/components/viewer/stories/Text.stories.svelte
@@ -1,19 +1,19 @@
-<script context="module" lang="ts">
-  import { Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import Text from "../Text.svelte";
-
-  export const meta = {
-    title: "Viewer / Text",
-    component: Text,
-    parameters: { layout: "centered" },
-  };
 
   import { document } from "@/test/fixtures/documents";
   import text from "@/test/fixtures/documents/document.txt.json";
   import ViewerContext from "../ViewerContext.svelte";
+
+  const { Story } = defineMeta({
+    title: "Viewer / Text",
+    component: Text,
+    parameters: { layout: "centered" },
+  });
 </script>
 
-<Story name="default">
+<Story name="default" asChild>
   <ViewerContext {document} text={Promise.resolve(text)}>
     <Text />
   </ViewerContext>

--- a/src/lib/components/viewer/stories/Viewer.stories.svelte
+++ b/src/lib/components/viewer/stories/Viewer.stories.svelte
@@ -1,7 +1,7 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   import type { Document, DocumentText, ViewerMode } from "$lib/api/types";
 
-  import { Story, Template } from "@storybook/addon-svelte-csf";
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import ViewerContext from "../ViewerContext.svelte";
   import Viewer from "../Viewer.svelte";
 
@@ -13,14 +13,15 @@
 
   const document = doc as Document;
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Viewer / Viewer",
     component: Viewer,
     parameters: {
       layout: "fullscreen",
     },
     tags: ["autodocs"],
-  };
+    render: template,
+  });
 
   let args: {
     document: Document;
@@ -35,13 +36,13 @@
   };
 </script>
 
-<Template let:args>
+{#snippet template(args)}
   <div class="vh">
     <ViewerContext {...args}>
       <Viewer />
     </ViewerContext>
   </div>
-</Template>
+{/snippet}
 
 <Story
   name="Edit Access"

--- a/src/lib/components/viewer/stories/Zoom.stories.svelte
+++ b/src/lib/components/viewer/stories/Zoom.stories.svelte
@@ -1,6 +1,12 @@
 <script module lang="ts">
   import { defineMeta } from "@storybook/addon-svelte-csf";
+  import type { Document } from "$lib/api/types";
+  import ViewerContext from "../ViewerContext.svelte";
   import Zoom from "../Zoom.svelte";
+
+  import doc from "@/test/fixtures/documents/document-expanded.json";
+
+  const document = doc as Document;
 
   const { Story } = defineMeta({
     title: "Viewer / Zoom",
@@ -9,15 +15,29 @@
       layout: "centered",
     },
     tags: ["autodocs"],
+    render: template,
   });
 
+  // Zoom reads its mode from ViewerContext, not from props.
   let args = {
-    mode: "document",
+    context: { document, mode: "document" },
   };
 </script>
 
+{#snippet template(args)}
+  <ViewerContext {...args.context}>
+    <Zoom />
+  </ViewerContext>
+{/snippet}
+
 <Story name="Document Zoom" {args} />
 
-<Story name="Text Zoom" args={{ ...args, mode: "text" }} />
+<Story
+  name="Text Zoom"
+  args={{ ...args, context: { ...args.context, mode: "text" } }}
+/>
 
-<Story name="Grid Zoom" args={{ ...args, mode: "grid" }} />
+<Story
+  name="Grid Zoom"
+  args={{ ...args, context: { ...args.context, mode: "grid" } }}
+/>

--- a/src/lib/components/viewer/stories/Zoom.stories.svelte
+++ b/src/lib/components/viewer/stories/Zoom.stories.svelte
@@ -1,24 +1,20 @@
-<script context="module" lang="ts">
-  import { Template, Story } from "@storybook/addon-svelte-csf";
+<script module lang="ts">
+  import { defineMeta } from "@storybook/addon-svelte-csf";
   import Zoom from "../Zoom.svelte";
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Viewer / Zoom",
     component: Zoom,
     parameters: {
       layout: "centered",
     },
     tags: ["autodocs"],
-  };
+  });
 
   let args = {
     mode: "document",
   };
 </script>
-
-<Template let:args>
-  <Zoom {...args} />
-</Template>
 
 <Story name="Document Zoom" {args} />
 


### PR DESCRIPTION
Closes #1248 
Closes #1230 

This is the last set of components to migrate. It migrates everything in `src/lib/compnoents/viewer` _except_ `ViewerContext`. That will happen as part of #1297 when we consolidate state.

