### PR TITLE
Viewer state refactor

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -40,8 +40,15 @@ const preview: Preview = {
           },
         },
       },
+      // NOTE: @storybook/sveltekit 8.6 only mocks `$app/stores`; it ignores
+      // this `state` block, so components reading `$app/state` (page.url) get an
+      // unpopulated value in Storybook. Kept in sync with `stores` above so it
+      // starts working once Storybook is upgraded to a version that mocks
+      // `$app/state`. Production/tests are unaffected.
       state: {
         page: {
+          url: new URL("https://www.documentcloud.org/"),
+          route: { id: "/" },
           data: {
             breadcrumbs: [],
           },

--- a/plans/storybook-9-upgrade.md
+++ b/plans/storybook-9-upgrade.md
@@ -1,0 +1,205 @@
+# Scope: Storybook 8.6 → 9 Upgrade
+
+## Why
+
+`@storybook/sveltekit` **8.6 does not mock `$app/state`** (only `$app/stores`);
+its dist has zero references to `$app/state`, so `sveltekit_experimental.state`
+is silently ignored. Now that the viewer components read `page` from
+`$app/state`, URL-dependent stories can't inject a URL (e.g. the PDFPage
+"search results" highlight demo is inert). **Storybook 9 fixes this** — its
+SvelteKit framework mocks `$app/state` via `sveltekit_experimental.state`
+(resolved in [storybookjs/storybook#30209](https://github.com/storybookjs/storybook/issues/30209),
+PR [#24795](https://github.com/storybookjs/storybook/pull/24795)). The
+`state.page.url` config already added to `.storybook/preview.ts` starts working
+after the upgrade, no further change needed.
+
+Secondary wins: SB9 is faster (lighter install, on-demand deps), and unblocks
+the Vitest-based test addon.
+
+## Current state (as of this scope)
+
+- Installed: Storybook **8.6.18** (package.json pins `^8.6.14`).
+- Environment already meets SB9 requirements: Node 22 (≥20 ✓), Vite 6 (≥5 ✓),
+  Svelte 5 ✓, `@sveltejs/kit` 2.55 ✓.
+- **148 stories, all Svelte CSF** (`.stories.svelte`). Two _orthogonal_ legacy
+  axes remain (see lists at the bottom); a file can be behind on one, both, or
+  neither:
+  - **CSF API:** 24 still use the old `import { Story, Template }` component API
+    instead of `defineMeta` (124 use `defineMeta`).
+  - **Module-script syntax:** 35 still use Svelte 4 `<script context="module">`
+    instead of `<script module>`.
+  - The repo's `migrate-storybook-csf` skill handles the API conversion.
+- `main.ts` addons: `addon-links`, `addon-essentials`, `addon-interactions`,
+  `storybook-addon-cookie`, `addon-svelte-csf` (with `legacyTemplate: true`).
+- `@storybook/addon-actions` and `@storybook/test` are in package.json but
+  **not** registered as addons; `@storybook/test` has **0 imports** in `src`.
+
+## Compatibility matrix (verified against npm registry)
+
+| Package                         | Now    | SB9 action                                                     | Risk |
+| ------------------------------- | ------ | -------------------------------------------------------------- | ---- |
+| `storybook` (core)              | 8.6.18 | bump `^9`                                                      | low  |
+| `@storybook/svelte`             | 8.6    | bump `^9`                                                      | low  |
+| `@storybook/sveltekit`          | 8.6    | bump `^9` — **this is what gains `$app/state` mocking**        | low  |
+| `@storybook/addon-svelte-csf`   | 5.0.10 | bump `^5.1` — peers already allow `^8.2 \|\| ^9 \|\| ^10`      | low  |
+| `@storybook/addon-links`        | 8.6    | bump to version-matched `^9` (published in lockstep with core) | low  |
+| `@storybook/addon-essentials`   | 8.6    | **remove** — folded into core (controls/actions/viewport/etc.) | low  |
+| `@storybook/addon-interactions` | 8.6    | **remove** — folded into core                                  | low  |
+| `@storybook/addon-actions`      | 8.6    | **remove** — `action` now imported from `storybook/actions`    | low  |
+| `@storybook/test`               | 8.6    | **remove** — 0 usages (was `storybook/test` in SB9 anyway)     | none |
+| `msw-storybook-addon`           | 2.0.6  | bump `2.0.7`; verify loader under SB9 (issue mswjs/#170)       | med  |
+| `storybook-addon-cookie`        | 4.0.1  | **highest risk** — last release Oct 2024, no SB9 peer/testing  | HIGH |
+| `chromatic`                     | 13.3.4 | no change — CLI; useful as visual-regression safety net        | —    |
+
+## Work breakdown
+
+### 1. Run the automigration (does most of the mechanical work)
+
+```
+npx storybook@latest upgrade   # pin to 9.x, not 10, unless we intend 10
+npx storybook doctor           # flags incompatible addons
+```
+
+This bumps versions, removes `addon-essentials`/`addon-interactions` from
+`main.ts`, and runs codemods. **Watch out:** the essentials→core automigration
+is known to _delete_ essentials `options` rather than migrate them
+([#31610](https://github.com/storybookjs/storybook/issues/31610)) — we pass no
+options to essentials, so this is a non-issue for us, but review the `main.ts`
+diff regardless.
+
+### 2. Manual code changes
+
+- **8 stories import `action` from `@storybook/addon-actions`** → change to
+  `import { action } from "storybook/actions"`. Files:
+  `forms/Search`, `common/Toast`, `common/NavItem`, `common/Pin`, `common/Tab`,
+  `common/Paginator`, `inputs/Dropzone`, `inputs/File` (`.stories.svelte`).
+- Remove the dead `@storybook/test` and `@storybook/addon-actions` devDeps.
+- Confirm `addon-svelte-csf`'s `legacyTemplate: true` is still honored (it is in
+  5.1.x) — needed until the 35 legacy stories are migrated.
+
+### 3. De-risk the two third-party addons
+
+- **`storybook-addon-cookie`** — only used for `parameters.cookie` /
+  `cookiePreserve` in `preview.ts` (sets `csrftoken` for MSW-backed stories).
+  If it fails to load under SB9, replacements are cheap: a global decorator or
+  `beforeEach` that sets `document.cookie = "csrftoken=mockToken"`. Budget time
+  to test and possibly drop it.
+- **`msw-storybook-addon`** — used by 15 stories + the global `mswLoader`. 2.0.7
+  is loader-based and generally version-tolerant; verify `initialize()` +
+  `mswLoader` still work and MSW handlers resolve.
+
+### 4. Verify `$app/state` mocking (the actual goal)
+
+- Remove the "inert until upgrade" comments in `.storybook/preview.ts` and
+  `viewer/stories/PDFPage.stories.svelte` once confirmed working.
+- Confirm the PDFPage "search results" story reflects `?q=` from
+  `state.page.url` (Playwright: assert the highlight / the debug `URL:` line
+  shows the santa-anas query URL).
+
+### 5. Full regression pass over 148 stories
+
+- `npm run build-storybook` must succeed.
+- Drive every story's iframe headless (extend the Playwright script from the
+  `$app/state` verification) to catch runtime/render errors. Expect the
+  pre-existing pdfjs `UnknownErrorException` on PDF-loading stories (no backend)
+  — filter those.
+- If Chromatic is wired to CI, use it as the visual-diff safety net.
+
+### 6. Optional but recommended: modernize the legacy stories
+
+Neither axis blocks SB9 (`legacyTemplate: true` keeps the old API working, and
+Svelte 5 still accepts `context="module"` with a deprecation warning), but both
+are on borrowed time — SB10 will likely drop `legacyTemplate`. Best as a
+separate follow-up PR (or two). Two independent lists at the bottom:
+
+- **A. Old `Story`/`Template` API → `defineMeta` (24 files).** Use the
+  `migrate-storybook-csf` skill.
+- **B. `<script context="module">` → `<script module>` (35 files).** Mostly a
+  mechanical rename.
+
+## Effort estimate
+
+- **Core upgrade + addon cleanup + `$app/state` verify:** ~0.5–1 day, _if_
+  both third-party addons cooperate.
+- **`storybook-addon-cookie` replacement** (if it breaks): +0.5 day.
+- **35 legacy-story migration:** separate, ~0.5–1 day, best as its own PR.
+
+## Recommendation
+
+Do the SB9 core upgrade + addon consolidation + `$app/state` verification as one
+focused PR, keeping the legacy-CSF migration separate. The only real unknown is
+`storybook-addon-cookie`; validate it (or its replacement) early since it gates
+every MSW-backed story. SB9 (not SB10) is the conservative target — SB10 exists
+but adds churn without solving our motivating problem.
+
+## List A — old `Story`/`Template` API → `defineMeta` (24)
+
+These `import { Story, Template } from "@storybook/addon-svelte-csf"` and have no
+`defineMeta`.
+
+```
+src/lib/components/documents/stories/CustomizeEmbed.stories.svelte
+src/lib/components/documents/stories/Data.stories.svelte
+src/lib/components/documents/stories/DocumentListItem.stories.svelte
+src/lib/components/documents/stories/Header.stories.svelte
+src/lib/components/documents/stories/Highlight.stories.svelte
+src/lib/components/documents/stories/HighlightGroup.stories.svelte
+src/lib/components/documents/stories/Metadata.stories.svelte
+src/lib/components/documents/stories/NoteHighlights.stories.svelte
+src/lib/components/documents/stories/PageHighlights.stories.svelte
+src/lib/components/documents/stories/Pending.stories.svelte
+src/lib/components/documents/stories/Projects.stories.svelte
+src/lib/components/documents/stories/Revisions.stories.svelte
+src/lib/components/documents/stories/Thumbnail.stories.svelte
+src/lib/components/premium-credits/stories/CreditMeter.stories.svelte
+src/lib/components/premium-credits/stories/PremiumBadge.stories.svelte
+src/lib/components/premium-credits/stories/Price.stories.svelte
+src/lib/components/premium-credits/stories/UpgradePrompt.stories.svelte
+src/lib/components/projects/stories/Collaborators.stories.svelte
+src/lib/components/projects/stories/ProjectHeader.stories.svelte
+src/lib/components/projects/stories/ProjectListItem.stories.svelte
+src/lib/components/projects/stories/ProjectShare.stories.svelte
+src/routes/embed/stories/note-embed.stories.svelte
+src/routes/embed/stories/page-embed.stories.svelte
+src/routes/embed/stories/project-embed.stories.svelte
+```
+
+## List B — `<script context="module">` → `<script module>` (35)
+
+```
+src/lib/components/common/stories/Access.stories.svelte
+src/lib/components/common/stories/Action.stories.svelte
+src/lib/components/common/stories/Badge.stories.svelte
+src/lib/components/common/stories/Button.stories.svelte
+src/lib/components/common/stories/Card.stories.svelte
+src/lib/components/common/stories/Empty.stories.svelte
+src/lib/components/common/stories/Error.stories.svelte
+src/lib/components/common/stories/FieldLabel.stories.svelte
+src/lib/components/common/stories/Flex.stories.svelte
+src/lib/components/common/stories/KV.stories.svelte
+src/lib/components/common/stories/Logo.stories.svelte
+src/lib/components/common/stories/Paginator.stories.svelte
+src/lib/components/common/stories/Pin.stories.svelte
+src/lib/components/common/stories/RelativeTime.stories.svelte
+src/lib/components/common/stories/Tab.stories.svelte
+src/lib/components/common/stories/Toast.stories.svelte
+src/lib/components/common/stories/Tooltip.stories.svelte
+src/lib/components/documents/search/stories/SearchEditor.stories.svelte
+src/lib/components/documents/stories/CustomizeEmbed.stories.svelte
+src/lib/components/documents/stories/Data.stories.svelte
+src/lib/components/documents/stories/DocumentListItem.stories.svelte
+src/lib/components/documents/stories/Header.stories.svelte
+src/lib/components/documents/stories/Metadata.stories.svelte
+src/lib/components/documents/stories/NoteHighlights.stories.svelte
+src/lib/components/documents/stories/PageHighlights.stories.svelte
+src/lib/components/documents/stories/Pending.stories.svelte
+src/lib/components/documents/stories/Projects.stories.svelte
+src/lib/components/documents/stories/Revisions.stories.svelte
+src/lib/components/documents/stories/Thumbnail.stories.svelte
+src/lib/components/projects/stories/Collaborators.stories.svelte
+src/lib/components/projects/stories/ProjectHeader.stories.svelte
+src/lib/components/projects/stories/ProjectShare.stories.svelte
+src/routes/embed/stories/note-embed.stories.svelte
+src/routes/embed/stories/page-embed.stories.svelte
+src/routes/embed/stories/project-embed.stories.svelte
+```

--- a/plans/viewer-state-migration.md
+++ b/plans/viewer-state-migration.md
@@ -348,10 +348,22 @@ refactors:
    class on the note wrapper (`note {mode}`); no rule keys on that class, so no
    visual change.
 
-3. **Embedded-ness now flows from the route, not `DocumentEmbed`.** Previously
-   `DocumentEmbed` called `setContext("embed", true)`. Now the embed route passes
-   `embed` to `ViewerContext`. Same net scope (DocumentEmbed wraps the whole
-   viewer subtree), so no user-facing change — but the signal's origin moved.
+3. **Embedded-ness: provider prop + `DocumentEmbed` self-declaration.** The embed
+   routes pass `embed` to `ViewerContext` (the provider owns the flag). In
+   addition, `DocumentEmbed` re-asserts `viewer.embed = true` on mount — restoring
+   its original "if we're using this layout, we're embedded" contract. This is
+   belt-and-suspenders: `embed` links (`EMBED_URL`) work even if a provider
+   forgot the `embed` prop.
+
+   **Regression this caught:** in the first pass, dropping `DocumentEmbed`'s
+   declaration meant embed contexts that _didn't_ pass `embed` (the two embed
+   Storybook stories) built `APP_URL` links — `embed.documentcloud.org` showed
+   up as `www.documentcloud.org` on CI (dev config hides it because
+   `EMBED_URL === APP_URL` there). Fixed by (a) passing `embed` in those stories,
+   (b) `DocumentEmbed` self-declaring, and (c) two guard tests:
+   `utils/tests/getViewerHref.embed.test.ts` (mocks distinct hosts → `embed:true`
+   uses `EMBED_URL`) and `embeds/tests/DocumentEmbed.test.ts` (`DocumentEmbed`
+   sets `viewer.embed` even when the provider didn't).
 
 Explicitly **not** changed (verified): the reactive-sync surface matches the old
 code — only `document` re-syncs reactively (old code only did

--- a/plans/viewer-state-migration.md
+++ b/plans/viewer-state-migration.md
@@ -1,0 +1,245 @@
+# Viewer State Migration: Stores → `ViewerState` class
+
+## Goal
+
+Replace the grab-bag of Svelte stores/context values currently created and
+provided by [`ViewerContext.svelte`](../src/lib/components/viewer/ViewerContext.svelte)
+with the single runes-based [`ViewerState`](../src/lib/state/viewer.svelte.ts)
+class, provided through `getViewerState` / `setViewerState`.
+
+## Current situation
+
+`ViewerContext.svelte` does two jobs today:
+
+1. **Provider** — creates ~12 context entries (a mix of `writable` stores and
+   plain values) and exposes a typed `getX()` accessor for each.
+2. **Controller** — owns side effects: PDF loading with 403 retry, hash-based
+   scrolling, and `afterNavigate` URL syncing.
+
+### Context entries provided today
+
+| Context key   | Type today                               | In `ViewerState`?         |
+| ------------- | ---------------------------------------- | ------------------------- |
+| `document`    | `Writable<Document>`                     | ✅ `document` (Nullable)  |
+| `text`        | `Promise<Maybe<DocumentText>>` (plain)   | ❌ **missing**            |
+| `asset_url`   | `URL` (plain)                            | ❌ **missing**            |
+| `embed`       | `boolean` (plain)                        | ❌ **missing**            |
+| `newNote`     | `Writable<Nullable<Partial<Note>&BBox>>` | ⚠️ `newNote` (wrong type) |
+| `currentNote` | `Writable<Nullable<Note>>`               | ✅ `currentNote`          |
+| `currentPage` | `Writable<number>`                       | ✅ `page`                 |
+| `currentMode` | `Writable<ViewerMode>`                   | ✅ `mode`                 |
+| `pdf`         | `Writable<Promise<PDFDocumentProxy>>`    | ✅ `pdf` (plain promise)  |
+| `progress`    | `Writable<DocumentLoadProgress>`         | ✅ `progress`             |
+| `zoom`        | `Writable<Zoom>`                         | ❌ **missing**            |
+| `errors`      | `Writable<Error[]>`                      | ✅ `errors`               |
+
+Note `getZoomLevels` in `src/lib/utils/viewer.ts` is unrelated — leave it alone.
+
+### Consumers (all read via `getX()` accessors)
+
+Producers/providers: two route pages + all Storybook stories render
+`<ViewerContext ...>`.
+
+Consumers (call the `getX()` accessors):
+
+- `viewer/PDF.svelte` — document, currentPage, pdf, zoom, errors (reads `$errors`,
+  writes via `errors.update`)
+- `viewer/PDFPage.svelte` — document, currentMode, pdf
+- `viewer/Page.svelte` — currentMode, currentPage, document, embed
+- `viewer/Text.svelte` — text, currentPage, zoom
+- `viewer/Zoom.svelte` — currentMode, zoom (**writes** `$zoom`, `bind:value={$zoom}`)
+- `viewer/Grid.svelte` — document, zoom
+- `viewer/Search.svelte` — document
+- `viewer/Notes.svelte` — document
+- `viewer/AnnotationLayer.svelte` — currentMode, currentNote, document, newNote,
+  embed (**heavy writer**: `$newNote`, `$currentNote`, `documentStore.update`)
+- `viewer/Viewer.svelte` — currentMode, progress, embed
+- `notes/Note.svelte` — currentMode, document (as prop default), embed
+- `notes/NoteExcerpt.svelte` — pdf
+- `sidebar/ViewerActions.svelte` — currentPage
+- `toolbars/PaginationToolbar.svelte` — currentMode, currentPage, document, embed
+  (**writes** `$currentPage`, `bind:page={$currentPage}`)
+- `toolbars/ReadingToolbar.svelte` — currentMode, document, embed
+- `toolbars/RedactionToolbar.svelte` — document
+- `layouts/DocumentLayout.svelte` — document, text (as prop defaults)
+- `embeds/DocumentEmbed.svelte` — document (uses legacy `$:` reactivity)
+
+## Design decisions
+
+### 1. Keep `ViewerContext.svelte` as a thin provider + controller
+
+**Recommended.** A plain `.svelte.ts` class cannot use `onMount`,
+`afterNavigate`, or `<svelte:window on:hashchange>`. Rather than scatter those,
+keep `ViewerContext.svelte` but rewrite its body to:
+
+- accept the same props (so **route pages and stories barely change**),
+- construct one `ViewerState`, populate it, and call `setViewerState(state)`,
+- host the lifecycle/controller logic (PDF load, hash scroll, `afterNavigate`).
+
+This localizes churn to the leaf components' _reads_, and keeps the ~10 story
+files and 2 route pages working with minimal edits.
+
+Delete the module-script `getX()` exports — every consumer switches to
+`getViewerState()`.
+
+### 2. Extend `ViewerState` to cover all data
+
+Add the four missing fields and fix `newNote`:
+
+```ts
+// additions to ViewerState
+text: Promise<Maybe<DocumentText>> = $state(new Promise(() => {}));
+assetUrl: Nullable<URL> = $state(null); // was context "asset_url"
+embed: boolean = $state(false);
+zoom: Zoom = $state(1);
+// fix existing field's type to match AnnotationLayer's partial writes:
+newNote: Nullable<Partial<Note> & BBox> = $state(null);
+```
+
+Decision to confirm: **`document` nullability.** The class defaults to
+`null`, but every consumer treats it as always-present (`document.page_count`,
+etc.). Options: (a) keep `Nullable`, assign in the provider, and have consumers
+read `viewer.document` with the understanding it's set before children mount
+(add a `!` or a getter that throws if unset); or (b) add a `get doc(): Document`
+that asserts non-null for ergonomic child use. Recommend a non-null
+`get document()` accessor is overkill — simplest is to keep the field, assign it
+in the provider before rendering `<slot/>`, and let consumers read
+`viewer.document` (TS may need a non-null assertion at a few call sites).
+
+### 3. Move controller logic
+
+- `loadPDF(assetUrl)` (with 403 retry) → a **method on `ViewerState`** that sets
+  `this.pdf`, `this.progress`, and pushes to `this.errors`. Called from the
+  provider's `onMount`.
+- `scrollToHash` / `onHashChange` / `afterNavigate` → stay in
+  `ViewerContext.svelte`, mutating `state.page` / `state.currentNote` /
+  `state.mode` directly instead of `$store` assignments.
+
+## Migration steps
+
+### Phase 1 — Extend the class ([viewer.svelte.ts](../src/lib/state/viewer.svelte.ts))
+
+1. Add `text`, `assetUrl`, `embed`, `zoom` `$state` fields.
+2. Change `newNote` type to `Nullable<Partial<Note> & BBox>`.
+3. Add a `loadPDF(assetUrl: URL)` method (port logic from
+   `ViewerContext.svelte` lines 168–192), mutating `this.pdf/progress/errors`.
+4. Optionally a constructor / `init(props)` that takes the initial
+   document/text/asset_url/embed/mode/page/zoom/errors.
+
+### Phase 2 — Rewrite the provider ([ViewerContext.svelte](../src/lib/components/viewer/ViewerContext.svelte))
+
+1. Delete the entire module `<script context="module">` block of `getX()`
+   exports (lines 42–89).
+2. In the instance script: keep the same `export let` props; construct
+   `const state = new ViewerState()`, populate fields from props, call
+   `setViewerState(state)`.
+3. Keep `documentStore.set` behavior as `$effect(() => state.document = document)`.
+4. Port `onMount(() => state.loadPDF(asset_url))`, the `<svelte:window>`
+   hashchange/popstate handlers, and `afterNavigate` — rewritten to mutate
+   `state.*`.
+
+### Phase 3 — Migrate consumers
+
+Uniform transform in each consumer:
+
+```ts
+// before
+import { getDocument, getCurrentPage } from ".../ViewerContext.svelte";
+const documentStore = getDocument();
+const currentPage = getCurrentPage();
+let document = $derived($documentStore);
+...$currentPage...
+
+// after
+import { getViewerState } from "$lib/state/viewer.svelte";
+const viewer = getViewerState();
+let document = $derived(viewer.document);   // or read viewer.document directly
+...viewer.page...
+```
+
+Store-write → field-assignment map:
+
+| Old store op                                  | New                                               |
+| --------------------------------------------- | ------------------------------------------------- |
+| `$currentPage = n`                            | `viewer.page = n`                                 |
+| `$mode` / `$currentMode`                      | `viewer.mode`                                     |
+| `$zoom`                                       | `viewer.zoom`                                     |
+| `$currentNote = x` / `$newNote = x`           | `viewer.currentNote` / `viewer.newNote`           |
+| `bind:value={$zoom}` (Zoom)                   | `bind:value={viewer.zoom}`                        |
+| `bind:page={$currentPage}` (Paginator)        | `bind:page={viewer.page}`                         |
+| `errors.update(u => [...u, e])` (PDF)         | `viewer.errors = [...viewer.errors, e]`           |
+| `documentStore.update(...)` (AnnotationLayer) | `viewer.document = { ...viewer.document, notes }` |
+| `getText()` (Text, DocumentLayout)            | `viewer.text`                                     |
+| `getDocument()` default prop (Note)           | `getViewerState().document`                       |
+
+Per-file notes:
+
+- **AnnotationLayer.svelte** — biggest change; many `$newNote`/`$currentNote`
+  reads/writes and the optimistic `documentStore.update` in `onEditNoteSuccess`.
+- **Zoom.svelte** — `$effect` writing `$zoom` and `bind:value={$zoom}`.
+- **PaginationToolbar.svelte** — `next/previous/gotoPage` write `$currentPage`;
+  `bind:page`.
+- **PDF.svelte** — `getErrors()` returns the store today and code calls
+  `errors.update`; switch to array assignment. Also `$errors` reads in markup.
+- **NoteExcerpt.svelte** — `type AsyncPDF = typeof $pdf` and `$pdf` reads →
+  `viewer.pdf`.
+- **Note.svelte** / **DocumentLayout.svelte** — default `$props()` values pull
+  from context getters; replace with `getViewerState()`.
+- **DocumentEmbed.svelte** — still uses legacy `$:`; migrate that line to
+  `$derived` while switching to `viewer.document`.
+
+### Phase 4 — Providers (routes + stories)
+
+- **Route pages** (`(app)/documents/[id]-[slug]/+page.svelte`,
+  `embed/documents/[id]-[slug]/+page.svelte`): unchanged if provider keeps the
+  same prop names (`document`, `mode`, `text`, `asset_url`).
+- **Stories** (~10 files): unchanged _except_ any passing
+  `pdf={writable(load(url))}` — the provider now takes a plain promise, so change
+  to `pdf={load(url)}` in `PDFPage.stories.svelte` and `Note.stories.svelte`.
+
+### Phase 5 — Verify
+
+1. `npm run check` (svelte-check / TS) — expect to chase down `Nullable<Document>`
+   assertions.
+2. `npm run test:unit` — the tests below must stay green across the migration.
+   Update snapshots only if markup is unchanged but wrappers differ
+   (`npm run test:unit -- -u`).
+3. `npm run storybook` — spot-check Viewer, PDF, Notes, Zoom, Search stories.
+4. Manual: load a document viewer (logged-in and embed) at
+   https://www.dev.documentcloud.org/, exercise pagination, zoom, note
+   create/edit, hash navigation.
+
+## Test safety net (added before migration)
+
+The affected components previously had **no** unit coverage. Added:
+
+- **`src/lib/state/tests/viewer.test.svelte.ts`** — unit tests for `ViewerState`
+  (defaults, `loadingProgress`, `loadPDF` success / progress wiring / idempotence
+  / 403-retry / non-403 error / retry cap). Mocks `pdfjs` and the documents API.
+- **`src/lib/components/viewer/tests/ViewerHarness.svelte`** +
+  **`renderInViewer.ts`** — a generic helper that renders any component inside
+  the **real `ViewerContext`** provider, seeding state via its public props.
+  Because it goes through the provider (not reproduced context keys), these
+  tests are expected to pass **unchanged** after the internal migration.
+- **`viewer/tests/Zoom.test.ts`** — zoom option sets + defaults per mode.
+- **`viewer/tests/Notes.test.ts`** — empty-state CTA gated on edit access; one
+  entry per note.
+- **`toolbars/tests/PaginationToolbar.test.ts`** — page-write path: next/prev
+  enable/disable and the displayed page following `next`.
+
+Each test mocks only genuinely external deps (`pdfjs` = network, `$app/*` =
+router). When migrating, keep `ViewerContext`'s prop names stable so
+`renderInViewer` and these tests need no changes.
+
+## Confirmed decisions
+
+1. **`document` nullability** — ✅ Keep the field `Nullable<Document>`. The
+   provider assigns it before children render; consumers read `viewer.document`
+   and add a non-null assertion at the few call sites TS flags. No non-null
+   getter.
+2. **Keep `ViewerContext.svelte`** — ✅ Keep it as the thin provider + controller.
+   Do not inline `new ViewerState()` / `setViewerState()` into routes/stories.
+3. **Field naming** — ✅ Use `assetUrl` (camelCase) for the class field and all
+   internal usage. The **provider prop stays `asset_url`** because that is the
+   backend API's field name (`data.asset_url` flows straight through the route
+   pages). The provider maps prop `asset_url` → `state.assetUrl`.

--- a/plans/viewer-state-migration.md
+++ b/plans/viewer-state-migration.md
@@ -82,6 +82,11 @@ files and 2 route pages working with minimal edits.
 Delete the module-script `getX()` exports — every consumer switches to
 `getViewerState()`.
 
+While rewriting the body, also **upgrade `ViewerContext.svelte` to Svelte 5
+runes syntax** (it's still Svelte 4: `context="module"`, `export let`, `$:`,
+store `$` prefixes, `<slot />`, `on:` directives). See Phase 2 for the concrete
+steps.
+
 ### 2. Extend `ViewerState` to cover all data
 
 Add the four missing fields and fix `newNote`:
@@ -96,15 +101,10 @@ zoom: Zoom = $state(1);
 newNote: Nullable<Partial<Note> & BBox> = $state(null);
 ```
 
-Decision to confirm: **`document` nullability.** The class defaults to
-`null`, but every consumer treats it as always-present (`document.page_count`,
-etc.). Options: (a) keep `Nullable`, assign in the provider, and have consumers
-read `viewer.document` with the understanding it's set before children mount
-(add a `!` or a getter that throws if unset); or (b) add a `get doc(): Document`
-that asserts non-null for ergonomic child use. Recommend a non-null
-`get document()` accessor is overkill — simplest is to keep the field, assign it
-in the provider before rendering `<slot/>`, and let consumers read
-`viewer.document` (TS may need a non-null assertion at a few call sites).
+**`document` nullability — resolved (see Confirmed decisions):** the field stays
+`Nullable<Document>`. The provider assigns it before children render; consumers
+read `viewer.document` and add a non-null assertion at the few sites TS flags.
+No non-null getter. (Implemented in Phase 1: the field is `Nullable<Document>`.)
 
 ### 3. Move controller logic
 
@@ -117,28 +117,79 @@ in the provider before rendering `<slot/>`, and let consumers read
 
 ## Migration steps
 
-### Phase 1 — Extend the class ([viewer.svelte.ts](../src/lib/state/viewer.svelte.ts))
+> **Status (as of this update):**
+> ✅ **Phase 1 complete** (class extended).
+> ✅ **Test safety net in place** (see section below).
+> ✅ **Phase 2 complete** — provider rewritten to construct `ViewerState` +
+> `setViewerState`, Svelte 5 syntax, `getX()` exports deleted.
+> ✅ **Phase 3 complete** — all consumers read `getViewerState()`.
+> ✅ **Phase 4 complete** — routes/stories updated (embed route passes `embed`;
+> stories pass `asset_url` instead of a `pdf` writable).
+> ✅ **Phase 5** — `npm run check` clean (0 errors), full unit suite green
+> (981 pass / 9 todo). Manual browser spot-check still recommended.
+>
+> **Two implementation notes worth remembering:**
+>
+> 1. **Seeding must be synchronous, not a parent `$effect`.** An initial attempt
+>    to sync all props into the state via a single parent `$effect` (mirroring
+>    `SearchState`) failed two safety-net tests: children read `viewer.document`
+>    on their first render (before a parent effect runs → null crash), and a
+>    parent effect running after child effects clobbered child-computed state
+>    (`Zoom` writes `viewer.zoom`, then the parent reset it). Final approach:
+>    seed synchronously inside a `seedState()` function (ordinary reads, so no
+>    `state_referenced_locally` warning), and reactively re-sync only
+>    `document` via `$effect` (the only field the old code synced reactively).
+> 2. **Annotation embed route now provides a real `ViewerContext`, but stays
+>    lightweight.** `embed/documents/[id]/annotations/[note_id]/+page.svelte`
+>    used to hand-roll context and pass `pdf: undefined`, so `NoteExcerpt`
+>    rendered from a page image. `Note`/`NoteExcerpt` now require
+>    `getViewerState()` (which throws without a provider), so the route wraps the
+>    note in `ViewerContext` — with **`loadPdf={false}`**. `ViewerState.pdf` is
+>    `Nullable`; `loadPdf={false}` seeds it to `null`, and `NoteExcerpt` falls
+>    back to `renderImage` when `pdf` is null. So the embed still loads only a
+>    single page image, never the full PDF (covered by
+>    `notes/tests/NoteExcerpt.test.ts`).
 
-1. Add `text`, `assetUrl`, `embed`, `zoom` `$state` fields.
-2. Change `newNote` type to `Nullable<Partial<Note> & BBox>`.
-3. Add a `loadPDF(assetUrl: URL)` method (port logic from
-   `ViewerContext.svelte` lines 168–192), mutating `this.pdf/progress/errors`.
-4. Optionally a constructor / `init(props)` that takes the initial
-   document/text/asset_url/embed/mode/page/zoom/errors.
+### Phase 1 — Extend the class ([viewer.svelte.ts](../src/lib/state/viewer.svelte.ts)) — ✅ DONE
 
-### Phase 2 — Rewrite the provider ([ViewerContext.svelte](../src/lib/components/viewer/ViewerContext.svelte))
+1. ✅ Added `text`, `assetUrl`, `embed`, `zoom` `$state` fields.
+2. ✅ Changed `newNote` type to `Nullable<Partial<Note> & BBox>`.
+3. ✅ Added a `loadPDF(url: URL)` method (ported the 403-retry logic), mutating
+   `this.pdf/progress/errors` and using private `#task` / `#retriesOn403Error`
+   fields. Also moved the pdfjs worker-src init to module scope.
+4. Skipped the optional constructor/`init(props)` — the provider (Phase 2) will
+   assign fields directly.
+
+### Phase 2 — Rewrite the provider ([ViewerContext.svelte](../src/lib/components/viewer/ViewerContext.svelte)) — ✅ DONE
+
+This phase also **migrates `ViewerContext.svelte` to Svelte 5 runes syntax**. The
+component is still written in Svelte 4 style (`<script context="module">`,
+`export let`, `$:`, store `$` prefixes, `<slot />`, `on:` directives); the rewrite
+brings it in line with the runes conventions used elsewhere.
 
 1. Delete the entire module `<script context="module">` block of `getX()`
-   exports (lines 42–89).
-2. In the instance script: keep the same `export let` props; construct
-   `const state = new ViewerState()`, populate fields from props, call
-   `setViewerState(state)`.
-3. Keep `documentStore.set` behavior as `$effect(() => state.document = document)`.
-4. Port `onMount(() => state.loadPDF(asset_url))`, the `<svelte:window>`
-   hashchange/popstate handlers, and `afterNavigate` — rewritten to mutate
-   `state.*`.
+   exports (lines 42–89). No module script remains — `getViewerState` /
+   `setViewerState` are imported from `$lib/state/viewer.svelte`.
+2. Convert props from `export let` to a single `$props()` destructure with an
+   interface. Keep the same prop names (`document`, `text`, `note`, `asset_url`,
+   `embed`, `page`, `mode`, `zoom`, `errors`; the legacy `pdf` writable prop is
+   dropped — the state owns the PDF promise now).
+3. Construct `const state = new ViewerState()`, populate fields from props
+   (mapping `asset_url` → `state.assetUrl`), call `setViewerState(state)`.
+4. Replace the `documentStore` + `$: documentStore.set(document)` reactivity with
+   `$effect(() => { state.document = document; })` (and same for any other prop
+   that should track its source).
+5. Port the controller logic to runes:
+   - `onMount(() => loadPDF(asset_url))` → `onMount(() => state.loadPDF(state.assetUrl!))`.
+   - `scrollToHash` / `onHashChange` / `afterNavigate` handlers rewritten to
+     mutate `state.page` / `state.currentNote` / `state.mode` directly instead of
+     `$store` assignments.
+6. Syntax cleanup: `<slot />` → `{@render children?.()}` (add `children` to
+   `$props()`); `<svelte:window on:hashchange=… on:popstate=…>` →
+   `onhashchange` / `onpopstate` attribute form; read `page` from `$app/state`
+   instead of the `$app/stores` `$page` store where practical.
 
-### Phase 3 — Migrate consumers
+### Phase 3 — Migrate consumers — ✅ DONE
 
 Uniform transform in each consumer:
 
@@ -188,7 +239,7 @@ Per-file notes:
 - **DocumentEmbed.svelte** — still uses legacy `$:`; migrate that line to
   `$derived` while switching to `viewer.document`.
 
-### Phase 4 — Providers (routes + stories)
+### Phase 4 — Providers (routes + stories) — ✅ DONE
 
 - **Route pages** (`(app)/documents/[id]-[slug]/+page.svelte`,
   `embed/documents/[id]-[slug]/+page.svelte`): unchanged if provider keeps the
@@ -197,7 +248,7 @@ Per-file notes:
   `pdf={writable(load(url))}` — the provider now takes a plain promise, so change
   to `pdf={load(url)}` in `PDFPage.stories.svelte` and `Note.stories.svelte`.
 
-### Phase 5 — Verify
+### Phase 5 — Verify — ✅ (typecheck + unit tests; manual spot-check pending)
 
 1. `npm run check` (svelte-check / TS) — expect to chase down `Nullable<Document>`
    assertions.
@@ -209,23 +260,55 @@ Per-file notes:
    https://www.dev.documentcloud.org/, exercise pagination, zoom, note
    create/edit, hash navigation.
 
-## Test safety net (added before migration)
+## Test safety net — ✅ DONE (before Phase 2)
 
-The affected components previously had **no** unit coverage. Added:
+The affected components previously had **no** unit coverage. All component tests
+render through the **real `ViewerContext`** via the `renderInViewer` helper,
+seeding state through the provider's public props and mocking only external deps
+(`pdfjs` = network, `$app/*` = router). Because they exercise the provider's
+public interface — not reproduced context keys — they are expected to pass
+**unchanged** after Phase 2 swaps the internals to `ViewerState`. Real fixtures
+from `src/test/fixtures/` are used throughout (no hand-rolled document/note/text
+data).
 
-- **`src/lib/state/tests/viewer.test.svelte.ts`** — unit tests for `ViewerState`
-  (defaults, `loadingProgress`, `loadPDF` success / progress wiring / idempotence
-  / 403-retry / non-403 error / retry cap). Mocks `pdfjs` and the documents API.
+Harness:
+
 - **`src/lib/components/viewer/tests/ViewerHarness.svelte`** +
-  **`renderInViewer.ts`** — a generic helper that renders any component inside
-  the **real `ViewerContext`** provider, seeding state via its public props.
-  Because it goes through the provider (not reproduced context keys), these
-  tests are expected to pass **unchanged** after the internal migration.
-- **`viewer/tests/Zoom.test.ts`** — zoom option sets + defaults per mode.
-- **`viewer/tests/Notes.test.ts`** — empty-state CTA gated on edit access; one
-  entry per note.
-- **`toolbars/tests/PaginationToolbar.test.ts`** — page-write path: next/prev
-  enable/disable and the displayed page following `next`.
+  **`renderInViewer.ts`** — renders any child inside `ViewerContext`, forwarding
+  context props (`document`, `mode`, `zoom`, `page`, `embed`, `note`, `text`,
+  `errors`).
+
+Unit tests for the class:
+
+- **`src/lib/state/tests/viewer.test.svelte.ts`** (8) — defaults,
+  `loadingProgress`, `loadPDF` success / progress wiring / idempotence /
+  403-retry / non-403 error / retry cap. Mocks `pdfjs` + documents API.
+
+Component tests (all green; the state reads/writes each covers are the migration
+surface):
+
+| Test                                           | Covers                                                                             |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `viewer/tests/Zoom.test.ts` (4)                | option sets + default zoom per mode; the `bind:value` write                        |
+| `viewer/tests/Notes.test.ts` (3)               | empty-state CTA gated on edit access; one entry per note                           |
+| `viewer/tests/Grid.test.ts` (1)                | one linked thumbnail per page in the spec                                          |
+| `viewer/tests/Text.test.ts` (2)                | text block per page (async); `--zoom` custom property                              |
+| `viewer/tests/Search.test.ts` (2)              | result card per matching page; empty state                                         |
+| `viewer/tests/AnnotationLayer.test.ts` (3)     | renders page notes; writing mode; **draw box + Escape-to-close** (the note writer) |
+| `viewer/tests/PDF.test.ts` (2)                 | one page wrapper per page; error view when `errors` seeded                         |
+| `viewer/tests/Page.test.ts` (3)                | page-number link; `PageActions` gated on `embed`                                   |
+| `notes/tests/Note.test.ts` (5)                 | title/content; footer + close-button gating on `embed`/`mode`                      |
+| `toolbars/tests/PaginationToolbar.test.ts` (3) | page-write path: next/prev enable/disable; page follows `next`                     |
+
+`notes/tests/NoteExcerpt.test.ts` (2) was added during Phase 3 to pin the
+image-vs-PDF render decision (spies on `renderImage`/`renderPDF`), guarding that
+a `loadPdf={false}` embed renders from an image and never fetches the PDF.
+
+Deliberately **not** unit-tested (better via Storybook/e2e): `Viewer`
+(routing — low migration risk), `ReadingToolbar` (`clientWidth`-driven
+breakpoints are unreliable in jsdom), `PDFPage` (canvas-only). Still untested if
+coverage is extended later: `RedactionToolbar`, `ViewerActions`,
+`DocumentLayout`, `DocumentEmbed`.
 
 Each test mocks only genuinely external deps (`pdfjs` = network, `$app/*` =
 router). When migrating, keep `ViewerContext`'s prop names stable so
@@ -243,3 +326,38 @@ router). When migrating, keep `ViewerContext`'s prop names stable so
    internal usage. The **provider prop stays `asset_url`** because that is the
    backend API's field name (`data.asset_url` flows straight through the route
    pages). The provider maps prop `asset_url` → `state.assetUrl`.
+
+## Behavioral changes from the refactor
+
+Most of the migration is behavior-preserving (store reads → field reads,
+`$store =` writes → `state.x =` writes). The changes that are _not_ pure
+refactors:
+
+1. **Annotation embed: no behavior change (verified & tested).** The single-note
+   embed still renders from a page image and never fetches the full PDF. It used
+   to hand-roll context with `pdf: undefined`; it now uses a real
+   `ViewerContext` with `loadPdf={false}`, which seeds `ViewerState.pdf` (made
+   `Nullable`) to `null` so `NoteExcerpt` falls back to `renderImage`. Pinned by
+   `notes/tests/NoteExcerpt.test.ts` (image path + no PDF fetch when there's no
+   PDF; PDF path when there is one). `PDF.svelte`/`PDFPage.svelte` assert
+   non-null `pdf` since they only render in a PDF-loading viewer.
+
+2. **Annotation embed viewer mode `"note"` → `"notes"`.** The old code set an
+   invalid `currentMode` of `"note"` (untyped context tolerated it); the provider
+   prop is typed `ViewerMode`, so it is now `"notes"`. Only affected the CSS
+   class on the note wrapper (`note {mode}`); no rule keys on that class, so no
+   visual change.
+
+3. **Embedded-ness now flows from the route, not `DocumentEmbed`.** Previously
+   `DocumentEmbed` called `setContext("embed", true)`. Now the embed route passes
+   `embed` to `ViewerContext`. Same net scope (DocumentEmbed wraps the whole
+   viewer subtree), so no user-facing change — but the signal's origin moved.
+
+Explicitly **not** changed (verified): the reactive-sync surface matches the old
+code — only `document` re-syncs reactively (old code only did
+`documentStore.set(document)`); `text`/`asset_url` are still seeded once (so the
+pre-existing "stale text/asset_url if ViewerContext isn't remounted between
+documents" behavior is preserved, not introduced); `loadPDF` still runs once in
+`onMount`; `errors`, `zoom`, `page`, note create/edit all behave as before. The
+`$app/stores` `$page` → `$app/state` `page` swap in the provider is
+behaviorally equivalent (both track navigation).

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -199,6 +199,11 @@ export interface Document {
 
 export interface DocumentResults extends Page<Document> {}
 
+export interface DocumentLoadProgress {
+  loaded: number;
+  total: number;
+}
+
 export interface Note extends BBox {
   id: number | string;
   user: number | User;

--- a/src/lib/components/embeds/DocumentEmbed.svelte
+++ b/src/lib/components/embeds/DocumentEmbed.svelte
@@ -1,10 +1,9 @@
 <!-- 
   @component
   An embedded document viewer.
-  Assumes it's a child of a ViewerContext
+  Must be a child of a ViewerContext
 -->
 <script lang="ts">
-  import { setContext } from "svelte";
   import { _ } from "svelte-i18n";
   import { Alert16 } from "svelte-octicons";
 
@@ -14,22 +13,25 @@
   import { defaultSettings, type EmbedSettings } from "$lib/utils/embed";
   import { getUserName, isOrg, isUser } from "$lib/api/accounts";
   import { canonicalUrl } from "$lib/api/documents";
-  import { getDocument } from "../viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
 
-  export let settings: Partial<EmbedSettings> = defaultSettings;
+  interface Props {
+    settings?: Partial<EmbedSettings>;
+  }
 
-  const documentStore = getDocument();
+  let { settings = defaultSettings }: Props = $props();
 
-  $: document = $documentStore;
+  const viewer = getViewerState();
 
-  // if we're using this layout, we're embedded
-  setContext("embed", true);
+  let document = $derived(viewer.document!);
 
-  $: user = isUser(document.user) ? getUserName(document.user) : undefined;
-  $: org = isOrg(document.organization)
-    ? document.organization.name
-    : undefined;
-  $: contributedBy = settings.onlyshoworg ? org : `${user} (${org})`;
+  let user = $derived(
+    isUser(document.user) ? getUserName(document.user) : undefined,
+  );
+  let org = $derived(
+    isOrg(document.organization) ? document.organization.name : undefined,
+  );
+  let contributedBy = $derived(settings.onlyshoworg ? org : `${user} (${org})`);
 </script>
 
 <div class="container">

--- a/src/lib/components/embeds/DocumentEmbed.svelte
+++ b/src/lib/components/embeds/DocumentEmbed.svelte
@@ -23,6 +23,11 @@
 
   const viewer = getViewerState();
 
+  // If we're using this layout, we're embedded. Declare it on the shared state
+  // so every descendant builds embed links (EMBED_URL) even if the provider
+  // wasn't told `embed`. Set synchronously, before children render.
+  viewer.embed = true;
+
   let document = $derived(viewer.document!);
 
   let user = $derived(

--- a/src/lib/components/embeds/stories/DocumentEmbed.stories.svelte
+++ b/src/lib/components/embeds/stories/DocumentEmbed.stories.svelte
@@ -1,40 +1,37 @@
-<script context="module" lang="ts">
-  import { Template, Story } from "@storybook/addon-svelte-csf";
-  import DocumentEmbed from "../DocumentEmbed.svelte";
+<script module lang="ts">
+  import type { Document } from "$lib/api/types";
 
+  import { defineMeta } from "@storybook/addon-svelte-csf";
+
+  import DocumentEmbed from "../DocumentEmbed.svelte";
   import EmbedLayout from "../../layouts/EmbedLayout.svelte";
   import ViewerContext from "../../viewer/ViewerContext.svelte";
   import { canonicalUrl } from "$lib/api/documents";
   import { documentExpanded as document } from "@/test/fixtures/documents";
 
-  let args = {
-    document,
-    currentTab: "document",
-  };
-
-  export const meta = {
+  const { Story } = defineMeta({
     title: "Embed / Document",
     component: DocumentEmbed,
     parameters: { layout: "fullscreen", chromatic: { viewports: [320, 1200] } },
-  };
+    render: template,
+  });
+
+  type Args = { document: Document };
 </script>
 
-<Template let:args>
+{#snippet template(args: Args)}
   <div class="vh-100">
     <EmbedLayout canonicalUrl={canonicalUrl(args.document).href}>
-      <ViewerContext document={args.document}>
+      <ViewerContext document={args.document} embed>
         <DocumentEmbed />
       </ViewerContext>
     </EmbedLayout>
   </div>
-</Template>
+{/snippet}
 
-<Story name="Public" {args} />
+<Story name="Public" args={{ document }} />
 
-<Story
-  name="Private"
-  args={{ ...args, document: { ...document, access: "private" } }}
-/>
+<Story name="Private" args={{ document: { ...document, access: "private" } }} />
 
 <style>
   .vh-100 {

--- a/src/lib/components/embeds/tests/DocumentEmbed.test.ts
+++ b/src/lib/components/embeds/tests/DocumentEmbed.test.ts
@@ -1,0 +1,48 @@
+/**
+ * DocumentEmbed is always an embed, so it declares `embed` on the shared viewer
+ * state regardless of whether the ViewerContext provider was told `embed`. This
+ * is the belt-and-suspenders guard: without it, an embed whose provider forgot
+ * `embed` would build APP_URL links instead of EMBED_URL ones.
+ *
+ * <Viewer> is replaced with a probe that reports `viewer.embed`; only pdfjs and
+ * the router are otherwise mocked.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+vi.mock("$app/state", () => ({
+  page: { url: new URL("https://www.documentcloud.org/documents/2622-doc/") },
+}));
+vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
+
+// Stand in for the heavy <Viewer> subtree with a probe that reads viewer.embed.
+vi.mock("../../viewer/Viewer.svelte", () => import("./EmbedProbe.svelte"));
+
+import DocumentEmbed from "../DocumentEmbed.svelte";
+import { renderInViewer } from "../../viewer/tests/renderInViewer";
+import { documentExpanded as document } from "@/test/fixtures/documents";
+
+describe("DocumentEmbed", () => {
+  it("declares embed on the viewer even when the provider wasn't told", () => {
+    // note: no `embed` in the context — DocumentEmbed must set it itself
+    renderInViewer(DocumentEmbed, {
+      props: { settings: { title: 1 } },
+      context: { document },
+    });
+
+    expect(screen.getByTestId("viewer-embed")).toHaveTextContent("true");
+  });
+});

--- a/src/lib/components/embeds/tests/EmbedProbe.svelte
+++ b/src/lib/components/embeds/tests/EmbedProbe.svelte
@@ -1,0 +1,11 @@
+<!-- @component
+Test-only stand-in for <Viewer>: reports the shared viewer's `embed` flag so a
+test can assert what DocumentEmbed declared on the state.
+-->
+<script lang="ts">
+  import { getViewerState } from "$lib/state/viewer.svelte";
+
+  const viewer = getViewerState();
+</script>
+
+<span data-testid="viewer-embed">{String(viewer.embed)}</span>

--- a/src/lib/components/layouts/DocumentLayout.svelte
+++ b/src/lib/components/layouts/DocumentLayout.svelte
@@ -1,5 +1,5 @@
 <!-- @component
-Assumes it's a child of a ViewerContext
+Must be a child of a ViewerContext
 -->
 
 <script lang="ts">
@@ -16,19 +16,19 @@ Assumes it's a child of a ViewerContext
   import Notes from "../viewer/sidebar/Notes.svelte";
   import Projects from "../documents/Projects.svelte";
   import SidebarLayout from "./SidebarLayout.svelte";
+  import SignedIn from "../common/SignedIn.svelte";
   import Viewer from "../viewer/Viewer.svelte";
   import ViewerActions from "$lib/components/sidebar/ViewerActions.svelte";
 
   import { getCurrentUser } from "$lib/utils/permissions";
   import { isOrg } from "$lib/api/accounts";
-  import { getDocument, getText } from "../viewer/ViewerContext.svelte";
-  import SignedIn from "../common/SignedIn.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
 
   const me = getCurrentUser();
+  const viewer = getViewerState();
 
-  let { documentStore = getDocument(), text = getText() } = $props();
-
-  let document = $derived($documentStore);
+  let document = $derived(viewer.document!);
+  let text = $derived(viewer.text);
   let projects = $derived((document.projects ?? []) as Project[]);
 </script>
 

--- a/src/lib/components/layouts/stories/EmbedLayout.stories.svelte
+++ b/src/lib/components/layouts/stories/EmbedLayout.stories.svelte
@@ -38,7 +38,7 @@
 <Story name="With Document" {args}>
   {#snippet template(args: Args)}
     <div class="vh">
-      <ViewerContext {document} {text} asset_url={pdfUrl(document)}>
+      <ViewerContext {document} {text} asset_url={pdfUrl(document)} embed>
         <EmbedLayout
           settings={args.settings}
           canonicalUrl={canonicalUrl(document).href}

--- a/src/lib/components/notes/Note.svelte
+++ b/src/lib/components/notes/Note.svelte
@@ -5,7 +5,7 @@
   It can use *either* a loaded PDF or a document image to render
   a document excerpt.
 
-  Assumes it's a child of a ViewerContext
+  Must be a child of a ViewerContext
 
   To improve:
 
@@ -17,7 +17,7 @@
 
 -->
 <script lang="ts">
-  import type { Note } from "$lib/api/types";
+  import type { Document, Note } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
   import { XCircle16 } from "svelte-octicons";
@@ -28,22 +28,17 @@
   import Share from "../forms/Share.svelte";
 
   import { width, height, isPageLevel } from "$lib/api/notes";
-  import {
-    getCurrentMode,
-    getDocument,
-    isEmbedded,
-  } from "$lib/components/viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
   import NoteContent from "./NoteContent.svelte";
   import NoteExcerpt from "./NoteExcerpt.svelte";
   import NoteActions from "./NoteActions.svelte";
   import NoteTitle from "./NoteTitle.svelte";
   import NoteMetadata from "./NoteMetadata.svelte";
 
-  const embed = isEmbedded();
-  const mode = getCurrentMode();
+  const viewer = getViewerState();
 
   interface Props {
-    document?: any;
+    document?: Document;
     note: Note;
     scale?: number;
     showExcerpt?: boolean;
@@ -51,7 +46,7 @@
   }
 
   let {
-    document = getDocument(),
+    document,
     note,
     scale = 2,
     showExcerpt = true,
@@ -62,15 +57,17 @@
   // the viewer, then set its visibility through context.
   let shareNoteOpen = $state(false);
 
-  let doc = $derived($document);
+  let doc = $derived(document ?? viewer.document!);
   let page_level = $derived(isPageLevel(note));
-  let canEdit = $derived(note.edit_access && !embed);
-  let canShare = $derived(!embed);
-  let canClose = $derived(!embed && !page_level && $mode === "document");
+  let canEdit = $derived(note.edit_access && !viewer.embed);
+  let canShare = $derived(!viewer.embed);
+  let canClose = $derived(
+    !viewer.embed && !page_level && viewer.mode === "document",
+  );
 </script>
 
 <div
-  class="note {note.access} {$mode || 'notes'}"
+  class="note {note.access} {viewer.mode || 'notes'}"
   class:page_level
   style:--x1={note.x1}
   style:--x2={note.x2}
@@ -80,7 +77,7 @@
   style:--note-height={height(note)}
 >
   <header>
-    <NoteTitle {doc} {note} {embed} />
+    <NoteTitle {doc} {note} embed={viewer.embed} />
     {#if canClose}
       <Button minW={false} ghost onclick={() => onclose?.()}>
         <XCircle16 />
@@ -91,7 +88,7 @@
     <NoteExcerpt document={doc} {note} {scale} />
   {/if}
   <NoteContent {note} />
-  {#if !embed}
+  {#if !viewer.embed}
     <footer>
       <NoteActions
         {doc}
@@ -104,7 +101,7 @@
     </footer>
   {/if}
 </div>
-{#if !embed && shareNoteOpen}
+{#if !viewer.embed && shareNoteOpen}
   <Portal>
     <Modal onclose={() => (shareNoteOpen = false)}>
       {#snippet title()}

--- a/src/lib/components/notes/NoteExcerpt.svelte
+++ b/src/lib/components/notes/NoteExcerpt.svelte
@@ -2,7 +2,7 @@
   import type { Document, Note } from "$lib/api/types";
 
   import { _ } from "svelte-i18n";
-  import { getPDF } from "$lib/components/viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
   import { getViewerHref } from "$lib/utils/viewer";
   import { renderImage, renderPDF } from "$lib/utils/notes";
 
@@ -12,22 +12,21 @@
     scale?: number;
   }
 
-  type AsyncPDF = typeof $pdf;
+  const viewer = getViewerState();
+  type AsyncPDF = typeof viewer.pdf;
 
   let { document, note, scale = 2 }: Props = $props();
-
-  const pdf = getPDF();
 
   let canvas: HTMLCanvasElement | undefined = $state();
 
   $effect(() => {
     if (!canvas) return;
-    // The PDF store starts as a never-resolving placeholder, so re-run on
+    // The PDF promise starts as a never-resolving placeholder, so re-run on
     // each change. Latest-wins: cleanup marks a stale run so it won't draw
     // over a newer one (we can't await the previous render — it may hang).
     const targetCanvas = canvas;
     const targetDoc = document;
-    const targetPdf = $pdf;
+    const targetPdf = viewer.pdf;
 
     let cancelled = false;
     render(targetCanvas, targetDoc, targetPdf, () => cancelled).catch(

--- a/src/lib/components/notes/stories/Note.stories.svelte
+++ b/src/lib/components/notes/stories/Note.stories.svelte
@@ -16,7 +16,6 @@
   import pdfFile from "@/test/fixtures/documents/examples/agreement-between-conservatives-and-liberal-democrats-to-form-a-coalition-government.pdf";
   import cji from "@/test/fixtures/documents/examples/cji.json";
   import cjiPdf from "@/test/fixtures/documents/examples/signed-fair-fight-foundation-settlement-2024.pdf";
-  import { writable } from "svelte/store";
   import { pdfUrl } from "$lib/api/documents";
 
   const document = doc as Document;
@@ -38,10 +37,6 @@
   Within a month-and-a-half, <a href="https://en.wikipedia.org/wiki/George_Osborne">George Osborne</a>, the country's new 38 year-old Chancellor of the Exchequor (i.e. the country's Finance Minister)
   will present a budget to Parliament that calls for emergency actions to reduce Britain's forecast $280 billion deficit.`;
 
-  async function load(url: URL) {
-    return pdfjs.getDocument(url).promise;
-  }
-
   const CJI = {
     document: cji as Document,
     note: cji.notes.find((n) => n.id === 2587355) as NoteType,
@@ -56,12 +51,12 @@
   });
 
   type Args = ComponentProps<typeof Note> & {
-    pdf?: ComponentProps<typeof ViewerContext>["pdf"];
+    asset_url?: ComponentProps<typeof ViewerContext>["asset_url"];
   };
 </script>
 
-{#snippet template({ pdf, ...args }: Args)}
-  <ViewerContext {document} asset_url={pdfUrl(document)} {pdf}>
+{#snippet template({ asset_url = pdfUrl(document), ...args }: Args)}
+  <ViewerContext {document} {asset_url}>
     <Note {...args} />
   </ViewerContext>
 {/snippet}
@@ -83,15 +78,11 @@
 
 <Story
   name="render using PDF"
-  args={{ pdf: writable(load(url)), note: { ...note2, content: html } }}
+  args={{ asset_url: url, note: { ...note2, content: html } }}
 />
 
 <Story name="Excerpt from rotated page" asChild>
-  <ViewerContext
-    document={CJI.document}
-    asset_url={pdfUrl(CJI.document)}
-    pdf={writable(load(CJI.url))}
-  >
-    <Note document={writable(CJI.document)} note={CJI.note} scale={2} />
+  <ViewerContext document={CJI.document} asset_url={CJI.url}>
+    <Note document={CJI.document} note={CJI.note} scale={2} />
   </ViewerContext>
 </Story>

--- a/src/lib/components/notes/tests/Note.test.ts
+++ b/src/lib/components/notes/tests/Note.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Behavioral tests for a single Note, rendered through the real ViewerContext
+ * provider via renderInViewer. Focuses on the mode/embed conditionals the
+ * stores -> ViewerState migration must preserve (footer actions, close button).
+ *
+ * Only pdfjs (network) and the router are mocked.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { screen, within } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
+
+import Note from "../Note.svelte";
+import { renderInViewer } from "../../viewer/tests/renderInViewer";
+import { document } from "@/test/fixtures/documents";
+import { note } from "@/test/fixtures/notes";
+
+/** Buttons inside the note's header (the close button, when present). */
+function headerButtons(container: HTMLElement) {
+  const header = container.querySelector("header") as HTMLElement;
+  return within(header).queryAllByRole("button");
+}
+
+describe("Note", () => {
+  it("renders the note title and content", () => {
+    renderInViewer(Note, {
+      props: { note, showExcerpt: false },
+      context: { document, mode: "notes", embed: true },
+    });
+
+    expect(screen.getByText(note.title!)).toBeInTheDocument();
+    expect(screen.getByText(/revolutionary proposal/)).toBeInTheDocument();
+  });
+
+  it("hides the actions footer in embed mode", () => {
+    const { container } = renderInViewer(Note, {
+      props: { note, showExcerpt: false },
+      context: { document, mode: "document", embed: true },
+    });
+
+    expect(container.querySelector("footer")).toBeNull();
+  });
+
+  it("shows the actions footer when not embedded", () => {
+    const { container } = renderInViewer(Note, {
+      props: { note, showExcerpt: false },
+      context: { document, mode: "document", embed: false },
+    });
+
+    expect(container.querySelector("footer")).not.toBeNull();
+  });
+
+  it("offers a close button only in document mode (not embedded)", () => {
+    const { container } = renderInViewer(Note, {
+      props: { note, showExcerpt: false },
+      context: { document, mode: "document", embed: false },
+    });
+    expect(headerButtons(container)).toHaveLength(1);
+  });
+
+  it("has no close button outside document mode", () => {
+    const { container } = renderInViewer(Note, {
+      props: { note, showExcerpt: false },
+      context: { document, mode: "notes", embed: false },
+    });
+    expect(headerButtons(container)).toHaveLength(0);
+  });
+});

--- a/src/lib/components/notes/tests/NoteExcerpt.test.ts
+++ b/src/lib/components/notes/tests/NoteExcerpt.test.ts
@@ -1,0 +1,81 @@
+/**
+ * NoteExcerpt renders the context around a note either from the loaded PDF or,
+ * when the viewer has no PDF (a lightweight single-note embed), from a page
+ * image. These tests pin that behavior so the embed stays lightweight:
+ *
+ * - `loadPdf: false` → render from a page image, never fetch the PDF.
+ * - a loaded PDF     → render from the PDF.
+ *
+ * The two render paths (`renderImage` / `renderPDF`) are spied on so no real
+ * canvas or network work happens; only pdfjs and the router are otherwise
+ * mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { waitFor } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+
+const { getDocument } = vi.hoisted(() => ({ getDocument: vi.fn() }));
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument,
+}));
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+vi.mock("$app/state", () => ({
+  page: {
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  },
+}));
+vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
+
+const { renderImage, renderPDF } = vi.hoisted(() => ({
+  renderImage: vi.fn(async () => {}),
+  renderPDF: vi.fn(async () => {}),
+}));
+vi.mock("$lib/utils/notes", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("$lib/utils/notes")>()),
+  renderImage,
+  renderPDF,
+}));
+
+import NoteExcerpt from "../NoteExcerpt.svelte";
+import { renderInViewer } from "../../viewer/tests/renderInViewer";
+import { document } from "@/test/fixtures/documents";
+import { note } from "@/test/fixtures/notes";
+
+describe("NoteExcerpt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders from a page image and never fetches the PDF when the viewer has no PDF", async () => {
+    renderInViewer(NoteExcerpt, {
+      props: { document, note },
+      context: { document, embed: true, loadPdf: false },
+    });
+
+    await waitFor(() => expect(renderImage).toHaveBeenCalled());
+    expect(renderPDF).not.toHaveBeenCalled();
+    // the whole point of a single-note embed: no document PDF is loaded
+    expect(getDocument).not.toHaveBeenCalled();
+  });
+
+  it("renders from the loaded PDF when the viewer has one", async () => {
+    const pdf = { getPage: vi.fn() };
+    getDocument.mockReturnValue({
+      promise: Promise.resolve(pdf),
+      onProgress: null,
+    });
+
+    renderInViewer(NoteExcerpt, {
+      props: { document, note },
+      context: { document }, // loadPdf defaults to true
+    });
+
+    await waitFor(() => expect(renderPDF).toHaveBeenCalled());
+    expect(renderImage).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/sidebar/ViewerActions.svelte
+++ b/src/lib/components/sidebar/ViewerActions.svelte
@@ -39,7 +39,7 @@
   import Revisions from "$lib/components/documents/Revisions.svelte";
   import Share from "$lib/components/forms/Share.svelte";
 
-  import { getCurrentPage } from "../viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
   import { getPendingDocuments } from "$lib/components/processing/ProcessContext.svelte";
 
   import { getUpgradeUrl } from "$lib/api/accounts";
@@ -53,7 +53,7 @@
 
   let { document, user }: Props = $props();
 
-  const page = getCurrentPage();
+  const viewer = getViewerState();
   const pending = getPendingDocuments();
 
   const labels: Record<Action, string> = {
@@ -169,7 +169,7 @@
       {/snippet}
 
       {#if visible === "share"}
-        <Share {document} page={$page} />
+        <Share {document} page={viewer.page} />
       {/if}
 
       {#if visible === "edit"}

--- a/src/lib/components/toolbars/PaginationToolbar.svelte
+++ b/src/lib/components/toolbars/PaginationToolbar.svelte
@@ -1,5 +1,5 @@
 <!-- @component
- Assumes it's a child of a ViewerContext
+ Must be a child of a ViewerContext
 -->
 
 <script lang="ts">
@@ -24,17 +24,9 @@
   import { remToPx } from "$lib/utils/layout";
   import { scrollToPage } from "$lib/utils/scroll";
   import { sortedSections } from "$lib/utils/viewer";
-  import {
-    getCurrentMode,
-    getCurrentPage,
-    getDocument,
-    isEmbedded,
-  } from "$lib/components/viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
 
-  const documentStore = getDocument();
-  const embed = isEmbedded();
-  const currentMode = getCurrentMode();
-  const currentPage = getCurrentPage();
+  const viewer = getViewerState();
 
   let sectionsOpen = $state(false);
   let width: number = $state(800);
@@ -43,31 +35,31 @@
     TWO_ROWS: width <= remToPx(34),
   });
 
-  let document = $derived($documentStore);
+  let document = $derived(viewer.document!);
   let sections = $derived(sortedSections(document));
   let totalPages = $derived(document.page_count);
   let showPDF = $derived(
-    ["document", "annotating", "redacting"].includes($currentMode),
+    ["document", "annotating", "redacting"].includes(viewer.mode),
   );
-  let canEditSections = $derived(!embed && document.edit_access);
+  let canEditSections = $derived(!viewer.embed && document.edit_access);
 
   // pagination
   function next() {
-    $currentPage = Math.min($currentPage + 1, totalPages);
-    scrollToPage($currentPage);
-    replaceState(pageHashUrl($currentPage), {});
+    viewer.page = Math.min(viewer.page + 1, totalPages);
+    scrollToPage(viewer.page);
+    replaceState(pageHashUrl(viewer.page), {});
   }
 
   function previous() {
-    $currentPage = Math.max($currentPage - 1, 1);
-    scrollToPage($currentPage);
-    replaceState(pageHashUrl($currentPage), {});
+    viewer.page = Math.max(viewer.page - 1, 1);
+    scrollToPage(viewer.page);
+    replaceState(pageHashUrl(viewer.page), {});
   }
 
   function gotoPage(n: number) {
-    $currentPage = n;
-    scrollToPage($currentPage);
-    replaceState(pageHashUrl($currentPage), {});
+    viewer.page = n;
+    scrollToPage(viewer.page);
+    replaceState(pageHashUrl(viewer.page), {});
   }
 </script>
 
@@ -131,17 +123,17 @@
     {/if}
   </div>
 
-  {#if shouldPaginate($currentMode)}
+  {#if shouldPaginate(viewer.mode)}
     <div class="paginator">
       <Paginator
         goToNav
         ongoto={(n) => gotoPage(n)}
         onnext={next}
         onprevious={previous}
-        bind:page={$currentPage}
+        bind:page={viewer.page}
         {totalPages}
-        has_next={$currentPage < totalPages}
-        has_previous={$currentPage > 1}
+        has_next={viewer.page < totalPages}
+        has_previous={viewer.page > 1}
       />
     </div>
   {/if}

--- a/src/lib/components/toolbars/ReadingToolbar.svelte
+++ b/src/lib/components/toolbars/ReadingToolbar.svelte
@@ -5,7 +5,7 @@ Must be a child of a ViewerContext
 <script lang="ts">
   import type { ReadMode, WriteMode } from "$lib/api/types";
 
-  import { page } from "$app/stores";
+  import { page } from "$app/state";
 
   import { _ } from "svelte-i18n";
   import {
@@ -34,7 +34,7 @@ Must be a child of a ViewerContext
   import { getViewerHref } from "$lib/utils/viewer";
   import { getViewerState } from "$lib/state/viewer.svelte";
 
-  let { query = getQuery($page.url, "q") } = $props();
+  let { query = getQuery(page.url, "q") } = $props();
 
   let width: number = $state(800);
 

--- a/src/lib/components/toolbars/ReadingToolbar.svelte
+++ b/src/lib/components/toolbars/ReadingToolbar.svelte
@@ -1,5 +1,5 @@
 <!-- @component
-Assumes it's a child of a ViewerContext
+Must be a child of a ViewerContext
  -->
 
 <script lang="ts">
@@ -32,19 +32,13 @@ Assumes it's a child of a ViewerContext
   import { remToPx } from "$lib/utils/layout";
   import { getQuery } from "$lib/utils/search";
   import { getViewerHref } from "$lib/utils/viewer";
-  import {
-    getCurrentMode,
-    getDocument,
-    isEmbedded,
-  } from "$lib/components/viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
 
   let { query = getQuery($page.url, "q") } = $props();
 
   let width: number = $state(800);
 
-  const documentStore = getDocument();
-  const mode = getCurrentMode();
-  const embed = isEmbedded();
+  const viewer = getViewerState();
 
   const readModeTabs: Map<ReadMode, string> = new Map([
     ["document", $_("mode.document")],
@@ -76,8 +70,8 @@ Assumes it's a child of a ViewerContext
     search: Search16,
   };
 
-  let document = $derived($documentStore);
-  let canWrite = $derived(!embed && document.edit_access);
+  let document = $derived(viewer.document!);
+  let canWrite = $derived(!viewer.embed && document.edit_access);
   let BREAKPOINTS = $derived({
     READ_MENU: width > remToPx(52),
     WRITE_MENU: width < remToPx(37),
@@ -86,7 +80,7 @@ Assumes it's a child of a ViewerContext
 
   let current = $derived(
     Array.from(readModeDropdownItems ?? []).find(
-      ([value]) => value === $mode,
+      ([value]) => value === viewer.mode,
     )?.[1],
   );
 </script>
@@ -97,8 +91,13 @@ Assumes it's a child of a ViewerContext
       <div class="tabs" role="tablist">
         {#each readModeTabs.entries() as [value, name]}
           <Tab
-            active={$mode === value}
-            href={getViewerHref({ document, mode: value, embed, query })}
+            active={viewer.mode === value}
+            href={getViewerHref({
+              document,
+              mode: value,
+              embed: viewer.embed,
+              query,
+            })}
           >
             {@const TabIcon = icons[value]}
             {#if TabIcon}
@@ -113,7 +112,7 @@ Assumes it's a child of a ViewerContext
         {#snippet anchor()}
           <NavItem>
             {#snippet start()}
-              {@const CurrentModeIcon = icons[$mode]}
+              {@const CurrentModeIcon = icons[viewer.mode]}
               {#if CurrentModeIcon}
                 <CurrentModeIcon />
               {/if}
@@ -128,8 +127,13 @@ Assumes it's a child of a ViewerContext
           <Menu>
             {#each readModeDropdownItems.entries() as [value, name]}
               <MenuItem
-                selected={$mode === value}
-                href={getViewerHref({ document, mode: value, embed, query })}
+                selected={viewer.mode === value}
+                href={getViewerHref({
+                  document,
+                  mode: value,
+                  embed: viewer.embed,
+                  query,
+                })}
                 preserveQS
                 onclick={close}
               >
@@ -143,8 +147,12 @@ Assumes it's a child of a ViewerContext
             {#if BREAKPOINTS.WRITE_MENU && canWrite}
               {#each writeModes as [value, name]}
                 <MenuItem
-                  selected={$mode === value}
-                  href={getViewerHref({ document, mode: value, embed })}
+                  selected={viewer.mode === value}
+                  href={getViewerHref({
+                    document,
+                    mode: value,
+                    embed: viewer.embed,
+                  })}
                   onclick={close}
                 >
                   {@const WriteModeIcon = icons[value]}
@@ -166,7 +174,12 @@ Assumes it's a child of a ViewerContext
         {#each writeModes as [value, name]}
           <Button
             ghost
-            href={getViewerHref({ document, mode: value, embed, query })}
+            href={getViewerHref({
+              document,
+              mode: value,
+              embed: viewer.embed,
+              query,
+            })}
           >
             {@const WriteModeIcon = icons[value]}
             {#if WriteModeIcon}

--- a/src/lib/components/toolbars/RedactionToolbar.svelte
+++ b/src/lib/components/toolbars/RedactionToolbar.svelte
@@ -1,5 +1,5 @@
 <!-- @component
-Assumes it's a child of a ViewerContext 
+Must be a child of a ViewerContext 
 -->
 
 <script lang="ts">
@@ -25,10 +25,10 @@ Assumes it's a child of a ViewerContext
   import { redactions, undo, clear } from "../viewer/RedactionLayer.svelte";
   import { remToPx } from "$lib/utils/layout";
   import { getViewerHref } from "$lib/utils/viewer";
-  import { getDocument } from "../viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
 
-  const documentStore = getDocument();
-  let document = $derived($documentStore);
+  const viewer = getViewerState();
+  let document = $derived(viewer.document!);
 
   let width: number = $state(800);
   let confirmOpen = $state(false);

--- a/src/lib/components/toolbars/tests/PaginationToolbar.test.ts
+++ b/src/lib/components/toolbars/tests/PaginationToolbar.test.ts
@@ -6,8 +6,6 @@
  *
  * Only external dependencies are mocked: pdfjs (network) and the router.
  */
-import type { Document } from "$lib/api/types";
-
 import { describe, it, expect, vi } from "vitest";
 import { screen, fireEvent } from "@testing-library/svelte";
 import { readable } from "svelte/store";
@@ -34,10 +32,9 @@ vi.mock("$app/navigation", () => ({
 
 import PaginationToolbar from "../PaginationToolbar.svelte";
 import { renderInViewer } from "../../viewer/tests/renderInViewer";
-import documentFixture from "@/test/fixtures/documents/document.json";
+import { document } from "@/test/fixtures/documents";
 
-const document = documentFixture as unknown as Document; // page_count: 7
-
+const lastPage = document.page_count;
 const pageInput = () => screen.getByRole("spinbutton") as HTMLInputElement;
 
 describe("PaginationToolbar", () => {
@@ -50,7 +47,9 @@ describe("PaginationToolbar", () => {
     expect(screen.getByTitle("Previous Page")).toBeDisabled();
     expect(screen.getByTitle("Next Page")).toBeEnabled();
     // total page count is shown
-    expect(screen.getByText(/of\s+7/)).toBeInTheDocument();
+    expect(
+      screen.getByText(new RegExp(`of\\s+${lastPage}`)),
+    ).toBeInTheDocument();
   });
 
   it("advances the page when Next is clicked", async () => {
@@ -66,10 +65,10 @@ describe("PaginationToolbar", () => {
 
   it("disables Next on the last page", () => {
     renderInViewer(PaginationToolbar, {
-      context: { document, mode: "document", page: 7 },
+      context: { document, mode: "document", page: lastPage },
     });
 
-    expect(pageInput()).toHaveValue(7);
+    expect(pageInput()).toHaveValue(lastPage);
     expect(screen.getByTitle("Next Page")).toBeDisabled();
     expect(screen.getByTitle("Previous Page")).toBeEnabled();
   });

--- a/src/lib/components/toolbars/tests/PaginationToolbar.test.ts
+++ b/src/lib/components/toolbars/tests/PaginationToolbar.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Behavioral tests for PaginationToolbar, rendered through the real
+ * ViewerContext provider via renderInViewer. This is the main writer of the
+ * viewer's current-page state, so the test drives next/previous and asserts
+ * the displayed page follows.
+ *
+ * Only external dependencies are mocked: pdfjs (network) and the router.
+ */
+import type { Document } from "$lib/api/types";
+
+import { describe, it, expect, vi } from "vitest";
+import { screen, fireEvent } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+// PaginationToolbar calls replaceState; ViewerContext registers afterNavigate.
+const { replaceState } = vi.hoisted(() => ({ replaceState: vi.fn() }));
+vi.mock("$app/navigation", () => ({
+  replaceState,
+  afterNavigate: vi.fn(),
+}));
+
+import PaginationToolbar from "../PaginationToolbar.svelte";
+import { renderInViewer } from "../../viewer/tests/renderInViewer";
+import documentFixture from "@/test/fixtures/documents/document.json";
+
+const document = documentFixture as unknown as Document; // page_count: 7
+
+const pageInput = () => screen.getByRole("spinbutton") as HTMLInputElement;
+
+describe("PaginationToolbar", () => {
+  it("starts on page 1 with previous disabled and next enabled", () => {
+    renderInViewer(PaginationToolbar, {
+      context: { document, mode: "document", page: 1 },
+    });
+
+    expect(pageInput()).toHaveValue(1);
+    expect(screen.getByTitle("Previous Page")).toBeDisabled();
+    expect(screen.getByTitle("Next Page")).toBeEnabled();
+    // total page count is shown
+    expect(screen.getByText(/of\s+7/)).toBeInTheDocument();
+  });
+
+  it("advances the page when Next is clicked", async () => {
+    renderInViewer(PaginationToolbar, {
+      context: { document, mode: "document", page: 1 },
+    });
+
+    await fireEvent.click(screen.getByTitle("Next Page"));
+
+    expect(pageInput()).toHaveValue(2);
+    expect(replaceState).toHaveBeenCalled();
+  });
+
+  it("disables Next on the last page", () => {
+    renderInViewer(PaginationToolbar, {
+      context: { document, mode: "document", page: 7 },
+    });
+
+    expect(pageInput()).toHaveValue(7);
+    expect(screen.getByTitle("Next Page")).toBeDisabled();
+    expect(screen.getByTitle("Previous Page")).toBeEnabled();
+  });
+});

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -7,7 +7,7 @@ and instances of the EditNote form.
 
 Only one note can be added/edited at a time.
 
-Assumes it's a child of a ViewerContext
+Must be a child of a ViewerContext
 -->
 <script lang="ts">
   import type { BBox, Maybe, Note as NoteType, Nullable } from "$lib/api/types";
@@ -22,13 +22,7 @@ Assumes it's a child of a ViewerContext
   import NoteTab from "./NoteTab.svelte";
 
   import { width, height, isPageLevel, noteHashUrl } from "$lib/api/notes";
-  import {
-    getCurrentMode,
-    getCurrentNote,
-    getDocument,
-    getNewNote,
-    isEmbedded,
-  } from "$lib/components/viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
   import { getNotes, getViewerHref } from "$lib/utils/viewer";
   import Tooltip from "../common/Tooltip.svelte";
 
@@ -39,22 +33,18 @@ Assumes it's a child of a ViewerContext
 
   let { scale = 1.5, page_number }: Props = $props();
 
-  const documentStore = getDocument();
-  const embed = isEmbedded();
-  const mode = getCurrentMode();
-  const currentNote = getCurrentNote();
-  const newNote = getNewNote();
+  const viewer = getViewerState();
 
   let drawStart: Nullable<[x: number, y: number]> = null;
   let drawing = $state(false);
 
-  let document = $derived($documentStore);
+  let document = $derived(viewer.document!);
   let notes = $derived(
     getNotes(document)[page_number]?.filter((note) => !isPageLevel(note)) ?? [],
   );
-  let writing = $derived($mode === "annotating");
+  let writing = $derived(viewer.mode === "annotating");
   let activeNote = $derived(
-    Boolean($currentNote) || (Boolean($newNote) && !drawing),
+    Boolean(viewer.currentNote) || (Boolean(viewer.newNote) && !drawing),
   );
 
   function getNoteId(note: NoteType) {
@@ -75,12 +65,12 @@ Assumes it's a child of a ViewerContext
     closeNote();
 
     drawing = true;
-    $currentNote = null;
-    $newNote = null;
+    viewer.currentNote = null;
+    viewer.newNote = null;
     const [x, y] = getLayerPosition(e);
     drawStart = [x, y];
     // when starting, the note is a 0px shape
-    $newNote = {
+    viewer.newNote = {
       x1: x,
       x2: x,
       y1: y,
@@ -91,7 +81,7 @@ Assumes it's a child of a ViewerContext
 
   function continueDrawingBox(e: PointerEvent) {
     if (e.target !== e.currentTarget) return;
-    if (!drawing || !newNote || !drawStart || !$newNote) return;
+    if (!drawing || !drawStart || !viewer.newNote) return;
 
     const [x, y] = getLayerPosition(e);
     const [startX, startY] = drawStart;
@@ -104,7 +94,7 @@ Assumes it's a child of a ViewerContext
     const y1 = movingDown ? startY : y;
     const y2 = movingDown ? y : startY;
 
-    $newNote = {
+    viewer.newNote = {
       x1,
       x2,
       y1,
@@ -115,10 +105,10 @@ Assumes it's a child of a ViewerContext
 
   function finishDrawingBox(e: PointerEvent) {
     if (e.target !== e.currentTarget) return;
-    if (!newNote || !drawing || !$newNote) return;
+    if (!drawing || !viewer.newNote) return;
 
-    $newNote = {
-      ...$newNote,
+    viewer.newNote = {
+      ...viewer.newNote,
       // now initialize some note values
       page_number,
       title: "",
@@ -142,17 +132,22 @@ Assumes it's a child of a ViewerContext
   function openNote(e: MouseEvent, note: NoteType) {
     const target = e.target as HTMLAnchorElement;
     const href =
-      target?.href || getViewerHref({ document, note, mode: $mode, embed });
-    $currentNote = note;
-    $newNote = null;
+      target?.href ||
+      getViewerHref({ document, note, mode: viewer.mode, embed: viewer.embed });
+    viewer.currentNote = note;
+    viewer.newNote = null;
     goto(href);
   }
 
   function closeNote() {
     drawing = false;
-    $newNote = null;
-    $currentNote = null;
-    const href = getViewerHref({ document, mode: $mode, embed });
+    viewer.newNote = null;
+    viewer.currentNote = null;
+    const href = getViewerHref({
+      document,
+      mode: viewer.mode,
+      embed: viewer.embed,
+    });
     goto(href);
   }
 
@@ -176,10 +171,10 @@ Assumes it's a child of a ViewerContext
     // When a note is added or edited, add or replace it in the array.
     // When it's deleted, `editedNote` will be undefined so we'll skip this.
     if (editedNote) newDocNotes?.push(editedNote);
-    // Update the $documentStore with new value for `document.notes`.
-    documentStore.update((document) => ({ ...document, notes: newDocNotes }));
-    // Finally, invalidate the document. After it's refetched, the
-    // $documentStore will be updated with fresh data from the API.
+    // Make an optimistic update to `viewer.document` for `document.notes`.
+    viewer.document = { ...document, notes: newDocNotes };
+    // Finally, invalidate the document. After it's refetched,
+    // viewer.document will be updated with fresh data from the API.
     invalidate(`document:${document.id}`);
   }
 </script>
@@ -200,7 +195,12 @@ Assumes it's a child of a ViewerContext
     <a
       id={getNoteId(note)}
       class="note-tab"
-      href={getViewerHref({ document, note, mode: $mode, embed })}
+      href={getViewerHref({
+        document,
+        note,
+        mode: viewer.mode,
+        embed: viewer.embed,
+      })}
       title={note.title}
       style:top="calc({note.y1} * 100%)"
       onclick={(e) => openNote(e, note)}
@@ -208,9 +208,14 @@ Assumes it's a child of a ViewerContext
       <Tooltip caption={note.title}><NoteTab access={note.access} /></Tooltip>
     </a>
     <a
-      href={getViewerHref({ document, note, mode: $mode, embed })}
+      href={getViewerHref({
+        document,
+        note,
+        mode: viewer.mode,
+        embed: viewer.embed,
+      })}
       class="note-highlight {note.access}"
-      class:active={$currentNote?.id === note.id}
+      class:active={viewer.currentNote?.id === note.id}
       title={note.title}
       style:top="{note.y1 * 100}%"
       style:left="{note.x1 * 100}%"
@@ -222,24 +227,24 @@ Assumes it's a child of a ViewerContext
     </a>
   {/each}
 
-  {#if $currentNote && !Boolean($newNote) && $currentNote.page_number === page_number}
+  {#if viewer.currentNote && !Boolean(viewer.newNote) && viewer.currentNote.page_number === page_number}
     <div
       class="note card"
-      style={positionNote($currentNote, 1.5)}
+      style={positionNote(viewer.currentNote, 1.5)}
       transition:fly={{ duration: 250, y: "-1.1rem" }}
     >
       {#if writing}
         <EditNote
-          note={$currentNote}
+          note={viewer.currentNote}
           {document}
           {page_number}
           onclose={closeNote}
-          onsuccess={(note) => onEditNoteSuccess(note, $currentNote)}
+          onsuccess={(note) => onEditNoteSuccess(note, viewer.currentNote)}
         />
       {:else}
-        {#key $currentNote.id}
+        {#key viewer.currentNote.id}
           <Note
-            note={$currentNote}
+            note={viewer.currentNote}
             showExcerpt={false}
             {scale}
             onclose={closeNote}
@@ -249,24 +254,24 @@ Assumes it's a child of a ViewerContext
     </div>
   {/if}
 
-  {#if $newNote && $newNote.page_number === page_number}
+  {#if viewer.newNote && viewer.newNote.page_number === page_number}
     <div
-      class="box {$newNote.access}"
-      style:top="{$newNote.y1 * 100}%"
-      style:left="{$newNote.x1 * 100}%"
-      style:width="{width($newNote) * 100}%"
-      style:height="{height($newNote) * 100}%"
+      class="box {viewer.newNote.access}"
+      style:top="{viewer.newNote.y1 * 100}%"
+      style:left="{viewer.newNote.x1 * 100}%"
+      style:width="{width(viewer.newNote) * 100}%"
+      style:height="{height(viewer.newNote) * 100}%"
     ></div>
 
     {#if !drawing}
       <div
         class="note card"
-        style={positionNote($newNote, 1.5)}
+        style={positionNote(viewer.newNote, 1.5)}
         transition:fly={{ duration: 250, y: "-1.1rem" }}
       >
         <EditNote
           {document}
-          note={$newNote}
+          note={viewer.newNote}
           onclose={closeNote}
           onsuccess={(note) => onEditNoteSuccess(note, undefined)}
         />

--- a/src/lib/components/viewer/Grid.svelte
+++ b/src/lib/components/viewer/Grid.svelte
@@ -3,7 +3,7 @@
   Show a grid of thumbnail images for a single document.
   Each image should link to its respective page.
 
-  Assumes it's a child of a ViewerContext.
+  Must be a child of a ViewerContext.
 
   Pages are only rendered in the browser to limit server-side page size.
 -->
@@ -18,10 +18,7 @@
   import { IMAGE_WIDTHS_MAP } from "@/config/config.js";
   import { pageImageUrl } from "$lib/api/documents";
   import { pageSizesFromSpec } from "$lib/utils/pageSize";
-  import {
-    getDocument,
-    getZoom,
-  } from "$lib/components/viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
   import { zoomToSize } from "$lib/utils/viewer";
 
   interface Props {
@@ -30,8 +27,7 @@
 
   let { size = "thumbnail" }: Props = $props();
 
-  const documentStore = getDocument();
-  const zoom = getZoom();
+  const viewer = getViewerState();
 
   const SCALE = {
     thumbnail: 1,
@@ -40,9 +36,9 @@
     large: 3,
   };
 
-  let document = $derived($documentStore);
+  let document = $derived(viewer.document!);
   $effect(() => {
-    size = zoomToSize($zoom);
+    size = zoomToSize(viewer.zoom);
   });
   let sizes = $derived(pageSizesFromSpec(document.page_spec));
   let scale = $derived(SCALE[size] ?? 1);

--- a/src/lib/components/viewer/Notes.svelte
+++ b/src/lib/components/viewer/Notes.svelte
@@ -1,5 +1,5 @@
 <!-- @component
-Assumes it's a child of a ViewerContext
+Must be a child of a ViewerContext
  -->
 
 <script lang="ts">
@@ -10,11 +10,11 @@ Assumes it's a child of a ViewerContext
   import Note from "../notes/Note.svelte";
 
   import { getViewerHref } from "$lib/utils/viewer";
-  import { getDocument } from "$lib/components/viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
 
-  const documentStore = getDocument();
+  const viewer = getViewerState();
 
-  let document = $derived($documentStore);
+  let document = $derived(viewer.document!);
   let notes = $derived(document.notes ?? []);
   let annotate = $derived(getViewerHref({ document, mode: "annotating" }));
 </script>

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -5,7 +5,7 @@
 
   This is only the pages of the document, contained inside the larger viewer.
 
-  Assumes it's a child of a ViewerContext
+  Must be a child of a ViewerContext
 -->
 <script lang="ts">
   import { browser } from "$app/environment";
@@ -16,47 +16,38 @@
   import { scrollToPage } from "$lib/utils/scroll";
   import { remToPx } from "$lib/utils/layout";
   import { getSections, pageSizes, zoomToScale } from "$lib/utils/viewer";
-  import {
-    getCurrentPage,
-    getDocument,
-    getErrors,
-    getPDF,
-    getZoom,
-  } from "./ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
   import Error from "../common/Error.svelte";
 
-  const documentStore = getDocument();
-  const currentPage = getCurrentPage();
-  const pdf = getPDF();
-  const zoom = getZoom();
+  const viewer = getViewerState();
 
   let width: number = $state(800);
 
-  let document = $derived($documentStore);
-  let scale = $derived(zoomToScale($zoom));
+  let document = $derived(viewer.document!);
+  let scale = $derived(zoomToScale(viewer.zoom));
   let sizes = $derived(document.page_spec ? pageSizes(document.page_spec) : []);
   let sections = $derived(getSections(document));
-  let errors = $derived(getErrors());
 
   // handle missing page_spec
+  // (PDF is only rendered when the viewer loads one, so `pdf` is non-null here)
   $effect(() => {
-    $pdf
-      .then((p) => {
+    viewer
+      .pdf!.then((p) => {
         if (sizes.length === 0) {
           sizes = Array(p.numPages).fill([0, 0]);
         }
       })
       .catch((e) => {
         console.warn(e);
-        errors.update((errs) => [...errs, e]);
+        viewer.errors = [...viewer.errors, e];
       });
   });
 
   onMount(() => {
-    $pdf
-      .then((p) => {
-        if ($currentPage > 1) {
-          scrollToPage($currentPage);
+    viewer
+      .pdf!.then((p) => {
+        if (viewer.page > 1) {
+          scrollToPage(viewer.page);
         }
 
         // @ts-ignore
@@ -64,14 +55,14 @@
       })
       .catch((e) => {
         console.warn(e);
-        errors.update((errs) => [...errs, e]);
+        viewer.errors = [...viewer.errors, e];
       });
   });
 </script>
 
-{#if Boolean($errors?.length)}
+{#if Boolean(viewer.errors?.length)}
   <Error>
-    {#each $errors as error}
+    {#each viewer.errors as error}
       <p>{String(error)}</p>
     {/each}
   </Error>

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -29,10 +29,13 @@
   let sections = $derived(getSections(document));
 
   // handle missing page_spec
-  // (PDF is only rendered when the viewer loads one, so `pdf` is non-null here)
+  // (PDF normally only renders when the viewer loads one, but guard `pdf` in
+  // case this component ends up in a viewer that never loads a PDF)
   $effect(() => {
-    viewer
-      .pdf!.then((p) => {
+    const pdf = viewer.pdf;
+    if (!pdf) return;
+    pdf
+      .then((p) => {
         if (sizes.length === 0) {
           sizes = Array(p.numPages).fill([0, 0]);
         }
@@ -44,8 +47,10 @@
   });
 
   onMount(() => {
-    viewer
-      .pdf!.then((p) => {
+    const pdf = viewer.pdf;
+    if (!pdf) return;
+    pdf
+      .then((p) => {
         if (viewer.page > 1) {
           scrollToPage(viewer.page);
         }

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -3,7 +3,7 @@ A single page of a PDF document.
 This component exists to manage state and rendering for a single page,
 working with PDF.svelte.
 
-Assumes it's a child of a ViewerContext
+Must be a child of a ViewerContext
 
 Selectable text can be rendered in one of two ways:
 - Extracted from the PDF page (preferred)
@@ -26,17 +26,11 @@ Selectable text can be rendered in one of two ways:
   // writable ui
   import { highlight } from "$lib/utils/search";
   import { isPageLevel } from "$lib/api/notes";
-  import {
-    getDocument,
-    getCurrentMode,
-    getPDF,
-  } from "$lib/components/viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
   import { getQuery } from "$lib/utils/search";
   import { fitPage, getNotes } from "$lib/utils/viewer";
 
-  const documentStore = getDocument();
-  const mode = getCurrentMode();
-  const pdf = getPDF();
+  const viewer = getViewerState();
 
   interface Props {
     page_number: number; // 1-indexed
@@ -187,7 +181,7 @@ Selectable text can be rendered in one of two ways:
       canvas &&
       !canvas.hidden
     ) {
-      Promise.all([$pdf, page]).then(([pdf, page]) => {
+      Promise.all([viewer.pdf, page]).then(([pdf, page]) => {
         render(page, canvas, container, scale);
       });
     }
@@ -197,11 +191,12 @@ Selectable text can be rendered in one of two ways:
   $effect(() => {
     query = getQuery($pageStore.url, "q");
   });
-  let document = $derived($documentStore);
+  let document = $derived(viewer.document!);
   // render when anything changes
+  // (PDFPage is only rendered when the viewer loads a PDF, so `pdf` is non-null)
   let page = $derived(
     visible
-      ? Promise.resolve($pdf).then((pdf) => pdf?.getPage(page_number))
+      ? Promise.resolve(viewer.pdf!).then((pdf) => pdf.getPage(page_number))
       : undefined,
   );
   // handle 0 sizing when page_spec is unavailable
@@ -228,7 +223,7 @@ Selectable text can be rendered in one of two ways:
     // reading it only inside the async `.then` below would not register it,
     // and numeric zoom changes (which flow through `scale`) wouldn't re-render.
     const currentScale = scale;
-    Promise.all([$pdf, page]).then(([pdf, page]) => {
+    Promise.all([viewer.pdf, page]).then(([pdf, page]) => {
       render(page, canvas, container, currentScale);
       textPromise = renderTextLayer(
         page,
@@ -316,10 +311,10 @@ Selectable text can be rendered in one of two ways:
 
       <AnnotationLayer page_number={page_number - 1} />
 
-      {#if redactions_for_page.length > 0 || $mode === "redacting"}
+      {#if redactions_for_page.length > 0 || viewer.mode === "redacting"}
         <RedactionLayer
           page_number={page_number - 1}
-          active={$mode === "redacting"}
+          active={viewer.mode === "redacting"}
           id={document.id.toString()}
         />
       {/if}

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -12,7 +12,7 @@ Selectable text can be rendered in one of two ways:
 <script lang="ts">
   import type { Maybe, TextPosition } from "$lib/api/types";
 
-  import { page as pageStore } from "$app/stores";
+  import { page as pageState } from "$app/state";
 
   import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
   import { _ } from "svelte-i18n";
@@ -49,7 +49,7 @@ Selectable text can be rendered in one of two ways:
     width = $bindable(),
     height = $bindable(),
     text = [],
-    query = $bindable(getQuery($pageStore.url, "q")),
+    query = $bindable(getQuery(pageState.url, "q")),
     debug = false,
   }: Props = $props();
 
@@ -189,14 +189,15 @@ Selectable text can be rendered in one of two ways:
 
   let pageWidth: Maybe<number> = $state();
   $effect(() => {
-    query = getQuery($pageStore.url, "q");
+    query = getQuery(pageState.url, "q");
   });
   let document = $derived(viewer.document!);
   // render when anything changes
-  // (PDFPage is only rendered when the viewer loads a PDF, so `pdf` is non-null)
+  // (PDFPage normally only renders when the viewer loads a PDF, but guard `pdf`
+  // in case this component ends up in a viewer that never loads a PDF)
   let page = $derived(
-    visible
-      ? Promise.resolve(viewer.pdf!).then((pdf) => pdf.getPage(page_number))
+    visible && viewer.pdf
+      ? Promise.resolve(viewer.pdf).then((pdf) => pdf.getPage(page_number))
       : undefined,
   );
   // handle 0 sizing when page_spec is unavailable

--- a/src/lib/components/viewer/Page.svelte
+++ b/src/lib/components/viewer/Page.svelte
@@ -7,7 +7,7 @@ Must be a child of a ViewerContext
 <script lang="ts">
   import type { Maybe } from "$lib/api/types";
 
-  import { page } from "$app/stores";
+  import { page } from "$app/state";
 
   import { type Snippet, onMount } from "svelte";
   import { _ } from "svelte-i18n";
@@ -63,7 +63,7 @@ Must be a child of a ViewerContext
       mode: "document",
       page: page_number,
       embed: viewer.embed,
-      query: getQuery($page.url, "q"),
+      query: getQuery(page.url, "q"),
     }),
   );
 

--- a/src/lib/components/viewer/Page.svelte
+++ b/src/lib/components/viewer/Page.svelte
@@ -1,7 +1,7 @@
 <!-- @component
 Page is a generic container for Viewer content.
 
-Assumes it's a child of a ViewerContext
+Must be a child of a ViewerContext
 -->
 
 <script lang="ts">
@@ -15,12 +15,7 @@ Assumes it's a child of a ViewerContext
   import PageActions from "./PageActions.svelte";
 
   import { pageHashUrl } from "$lib/api/documents";
-  import {
-    getCurrentMode,
-    getCurrentPage,
-    getDocument,
-    isEmbedded,
-  } from "$lib/components/viewer/ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
   import { getQuery } from "$lib/utils/search";
   import { getViewerHref } from "$lib/utils/viewer";
 
@@ -46,26 +41,28 @@ Assumes it's a child of a ViewerContext
     onvisible,
   }: Props = $props();
 
-  const documentStore = getDocument();
-  const currentPage = getCurrentPage();
-  const mode = getCurrentMode();
-  const embed = isEmbedded();
+  const viewer = getViewerState();
 
   let io: IntersectionObserver;
   let container: Maybe<HTMLElement> = $state();
   let visible = $state(false);
 
-  let document = $derived($documentStore);
+  let document = $derived(viewer.document!);
   let id = $derived(pageHashUrl(page_number).replace("#", ""));
   let href = $derived(
-    getViewerHref({ document, mode: $mode, page: page_number, embed }),
+    getViewerHref({
+      document,
+      mode: viewer.mode,
+      page: page_number,
+      embed: viewer.embed,
+    }),
   );
   let documentHref = $derived(
     getViewerHref({
       document,
       mode: "document",
       page: page_number,
-      embed,
+      embed: viewer.embed,
       query: getQuery($page.url, "q"),
     }),
   );
@@ -91,10 +88,10 @@ Assumes it's a child of a ViewerContext
             rootBounds &&
             boundingClientRect.top > rootBounds.top &&
             boundingClientRect.top < rootBounds.height / 2 &&
-            currentPage // in case context is missing
+            viewer // in case context is missing
           ) {
-            $currentPage = page_number;
-            // replaceState(pageHashUrl($currentPage), {});
+            viewer.page = page_number;
+            // replaceState(pageHashUrl(viewer.page), {});
           }
         });
       },
@@ -143,7 +140,7 @@ Assumes it's a child of a ViewerContext
       </a>
     </h4>
 
-    {#if !embed}
+    {#if !viewer.embed}
       <PageActions {document} {page_number} pageWidth={width} />
     {/if}
   </header>

--- a/src/lib/components/viewer/Search.svelte
+++ b/src/lib/components/viewer/Search.svelte
@@ -1,5 +1,5 @@
 <!-- @component
-Assumes it's a child of a ViewerContext
+Must be a child of a ViewerContext
  -->
 
 <script lang="ts">
@@ -15,18 +15,19 @@ Assumes it's a child of a ViewerContext
   import Error from "../common/Error.svelte";
   import Highlight from "../documents/Highlight.svelte";
 
-  import { getDocument } from "./ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
   import { getQuery, highlight, pageNumber } from "$lib/utils/search";
   import { getViewerHref } from "$lib/utils/viewer";
   import { qs } from "$lib/utils/navigation";
   import { searchWithin } from "$lib/api/documents";
 
-  const document = getDocument();
+  const viewer = getViewerState();
+  let document = $derived(viewer.document!);
 
   let query = $derived(getQuery(page.url, "q"));
   let search: Promise<[number, string[]][]> = $derived(
     browser
-      ? searchWithin($document.id, query).then(formatResults)
+      ? searchWithin(document.id, query).then(formatResults)
       : new Promise(() => {}),
   );
 
@@ -68,7 +69,7 @@ Assumes it's a child of a ViewerContext
     {/if}
     {#each resultsPages as [pageNumber, resultsList]}
       {@const href = getViewerHref({
-        document: $document,
+        document,
         page: pageNumber,
         mode: "document",
         query,

--- a/src/lib/components/viewer/Text.svelte
+++ b/src/lib/components/viewer/Text.svelte
@@ -2,33 +2,31 @@
   @component
   Text wraps a list of Page components with plain text contents
   
-  Assumes it's a child of a ViewerContext
+  Must be a child of a ViewerContext
 -->
 <script lang="ts">
   import { page } from "$app/state";
   import { onMount } from "svelte";
 
   import Page from "./Page.svelte";
-  import { getText, getCurrentPage, getZoom } from "./ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
   import { scrollToPage } from "$lib/utils/scroll";
   import { highlight } from "$lib/utils/search";
   import { getQuery } from "$lib/utils/search";
 
   let { query = getQuery(page.url, "q") } = $props();
 
-  const currentPage = getCurrentPage();
-  const text = getText();
-  const zoom = getZoom();
+  const viewer = getViewerState();
 
   onMount(async () => {
-    if ($currentPage > 1) {
-      scrollToPage($currentPage);
+    if (viewer.page > 1) {
+      scrollToPage(viewer.page);
     }
   });
 </script>
 
-<div class="textPages" style:--zoom={+$zoom || 1}>
-  {#await text then text}
+<div class="textPages" style:--zoom={+viewer.zoom || 1}>
+  {#await viewer.text then text}
     {#each text?.pages ?? [] as { page, contents }}
       <Page page_number={page + 1} track>
         <pre>

--- a/src/lib/components/viewer/Viewer.svelte
+++ b/src/lib/components/viewer/Viewer.svelte
@@ -1,7 +1,7 @@
 <!-- @component
 The document viewer.
 
-Assumes it's a child of a ViewerContext
+Must be a child of a ViewerContext
 -->
 
 <script lang="ts">
@@ -18,35 +18,29 @@ Assumes it's a child of a ViewerContext
   import Text from "./Text.svelte";
   import Grid from "./Grid.svelte";
   import Notes from "./Notes.svelte";
+  import Search from "./Search.svelte";
 
   // toolbars
   import AnnotationToolbar from "../toolbars/AnnotationToolbar.svelte";
+  import LoadingToolbar from "../toolbars/LoadingToolbar.svelte";
   import PaginationToolbar from "../toolbars/PaginationToolbar.svelte";
   import ReadingToolbar from "../toolbars/ReadingToolbar.svelte";
   import RedactionToolbar from "../toolbars/RedactionToolbar.svelte";
 
-  // utils
-  import {
-    getCurrentMode,
-    getPDFProgress,
-    isEmbedded,
-  } from "./ViewerContext.svelte";
-  import LoadingToolbar from "../toolbars/LoadingToolbar.svelte";
-  import Search from "./Search.svelte";
-
-  const embed = isEmbedded();
-  const currentMode = getCurrentMode();
-  const progress = getPDFProgress();
+  // state
+  import { getViewerState } from "$lib/state/viewer.svelte";
+  const viewer = getViewerState();
 
   // only show loading for slow-loading pages
   let showLoading = $state(false);
 
-  let mode = $derived($currentMode);
+  let embed = $derived(viewer.embed);
+  let mode = $derived(viewer.mode);
   let showPDF = $derived(
-    ["document", "annotating", "redacting"].includes($currentMode),
+    ["document", "annotating", "redacting"].includes(viewer.mode),
   );
   let loading = $derived(
-    $progress.total > 0 ? $progress.loaded / $progress.total : null,
+    viewer.progress.total > 0 ? viewer.loadingProgress : null,
   );
 
   onMount(() => {

--- a/src/lib/components/viewer/ViewerContext.svelte
+++ b/src/lib/components/viewer/ViewerContext.svelte
@@ -2,7 +2,7 @@
 Provides context for its children. Useful as a parent of Viewer in
 layouts, stories, and tests.
  -->
-<script lang="ts" context="module">
+<script lang="ts">
   import type {
     Maybe,
     Nullable,
@@ -11,135 +11,82 @@ layouts, stories, and tests.
     Note,
     ViewerMode,
     Zoom,
-    BBox,
   } from "$lib/api/types";
 
   import { afterNavigate } from "$app/navigation";
+  import { page as pageState } from "$app/state";
+  import { type Snippet, onMount } from "svelte";
 
-  import { getContext, onMount, setContext } from "svelte";
-  import { type Writable, writable } from "svelte/store";
-
-  import {
-    pageFromHash,
-    pdfUrl,
-    shouldPaginate,
-    assetUrl,
-  } from "$lib/api/documents";
-
-  import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
-  if (!pdfjs.GlobalWorkerOptions.workerSrc) {
-    pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-      "pdfjs-dist/legacy/build/pdf.worker.mjs",
-      import.meta.url,
-    ).href;
-  }
-
-  interface DocumentLoadProgress {
-    loaded: number;
-    total: number;
-  }
-
-  export function getDocument(): Writable<Document> {
-    return getContext("document");
-  }
-
-  export function getText(): Promise<Maybe<DocumentText>> {
-    return getContext("text");
-  }
-
-  export function getAssetUrl(): URL {
-    return getContext("asset_url");
-  }
-
-  export function isEmbedded(): boolean {
-    // are we embedded?
-    return getContext("embed") ?? false;
-  }
-
-  export function getNewNote(): Writable<Nullable<Partial<Note> & BBox>> {
-    return getContext("newNote");
-  }
-
-  export function getCurrentNote(): Writable<Nullable<Note>> {
-    return getContext("currentNote");
-  }
-
-  export function getCurrentPage(): Writable<number> {
-    return getContext("currentPage");
-  }
-
-  export function getCurrentMode(): Writable<ViewerMode> {
-    return getContext("currentMode");
-  }
-
-  export function getPDF(): Writable<Promise<pdfjs.PDFDocumentProxy>> {
-    return getContext("pdf");
-  }
-
-  export function getPDFProgress(): Writable<DocumentLoadProgress> {
-    return getContext("progress");
-  }
-
-  export function getZoom(): Writable<Zoom> {
-    return getContext("zoom");
-  }
-
-  export function getErrors(): Writable<Error[]> {
-    return getContext("errors");
-  }
-</script>
-
-<script lang="ts">
-  import { page as pageStore } from "$app/stores";
+  import { pageFromHash, pdfUrl, shouldPaginate } from "$lib/api/documents";
   import { noteFromHash } from "$lib/api/notes";
 
-  export let document: Document;
-  export let text: Promise<Maybe<DocumentText>> = new Promise(() => {});
-  export let note: Nullable<Note> = null;
-  export let asset_url: URL = pdfUrl(document);
-  export let embed: boolean = false;
-  export let page: number = 1;
-  export let mode: ViewerMode = "document";
-  export let zoom: Zoom = 1;
-  export let errors: Error[] = [];
+  import { ViewerState, setViewerState } from "$lib/state/viewer.svelte";
 
-  // https://mozilla.github.io/pdf.js/api/draft/module-pdfjsLib-PDFDocumentProxy.html
-  export let pdf: Writable<Promise<pdfjs.PDFDocumentProxy>> = writable(
-    new Promise(() => {}),
-  );
-  let task: Maybe<Nullable<pdfjs.PDFDocumentLoadingTask>> = null;
+  interface Props {
+    document: Document;
+    text?: Promise<Maybe<DocumentText>>;
+    note?: Nullable<Note>;
+    asset_url?: URL;
+    embed?: boolean;
+    page?: number;
+    mode?: ViewerMode;
+    zoom?: Zoom;
+    errors?: Error[];
+    /**
+     * Whether to load the document PDF on mount. Lightweight embeds that only
+     * show a single note (rendered from a page image) can set this to `false`
+     * to avoid fetching the whole PDF.
+     */
+    loadPdf?: boolean;
+    children?: Snippet;
+  }
 
-  const progress = writable<DocumentLoadProgress>({
-    loaded: 0,
-    total: 0,
+  let {
+    document,
+    text = new Promise(() => {}),
+    note = null,
+    asset_url = pdfUrl(document),
+    embed = false,
+    page = 1,
+    mode = "document",
+    zoom = 1,
+    errors = [],
+    loadPdf = true,
+    children,
+  }: Props = $props();
+
+  // Construct the single viewer state for this subtree and provide it.
+  const viewer = new ViewerState();
+  setViewerState(viewer);
+
+  // Seed the state from props synchronously, before children read it on their
+  // first render. Wrapped in a function so these are ordinary reads rather than
+  // top-level reactive captures.
+  function seedState() {
+    viewer.document = document;
+    viewer.text = text;
+    viewer.assetUrl = asset_url;
+    viewer.embed = embed;
+    viewer.mode = mode;
+    viewer.zoom = zoom;
+    viewer.page = page;
+    viewer.currentNote = note;
+    viewer.errors = errors;
+    // No PDF pipeline for this viewer: consumers render from page images.
+    if (!loadPdf) viewer.pdf = null;
+  }
+  seedState();
+
+  // The document can change without ViewerContext remounting (navigating
+  // between documents), so keep it in sync. Other fields are seeded once and
+  // then owned by the viewer, so re-seeding them here would clobber in-view
+  // interactions (zoom, page).
+  $effect(() => {
+    viewer.document = document;
   });
 
-  // React to document changes
-  const documentStore = writable(document);
-  $: documentStore.set(document);
-
-  // stores we need deeper in the component tree, available via context
-  setContext("document", documentStore);
-  setContext("text", text);
-  setContext("asset_url", asset_url);
-  setContext("embed", embed);
-  setContext("newNote", writable(null));
-  setContext("currentNote", writable(note));
-  setContext("currentPage", writable(page));
-  setContext("currentMode", writable(mode));
-  setContext("zoom", writable(zoom));
-  setContext("progress", progress);
-  setContext("pdf", pdf);
-  setContext("errors", writable(errors));
-
-  $: currentDoc = getDocument();
-  $: currentMode = getCurrentMode();
-  $: currentPage = getCurrentPage();
-  $: currentNote = getCurrentNote();
-  $: currentErrors = getErrors();
-
-  $: noteMatchingPageHash = (note: Note) =>
-    note.id === noteFromHash($pageStore.url.hash);
+  const noteMatchingPageHash = (note: Note) =>
+    note.id === noteFromHash(pageState.url.hash);
 
   function scrollToHash(hash?: string) {
     const page: Nullable<number> = hash ? pageFromHash(hash) : null;
@@ -153,64 +100,40 @@ layouts, stories, and tests.
     // Scroll to the element, if it's available, and update the current page
     if (el && page) {
       el.scrollIntoView();
-      $currentPage = page;
+      viewer.page = page;
     }
   }
 
   function onHashChange() {
     const { hash } = window.location;
-    $currentNote = $currentDoc.notes?.find(noteMatchingPageHash) ?? null;
-    if (shouldPaginate($currentMode)) {
+    viewer.currentNote =
+      viewer.document?.notes?.find(noteMatchingPageHash) ?? null;
+    if (shouldPaginate(viewer.mode)) {
       scrollToHash(hash);
-    }
-  }
-
-  let retriesOn403Error = 0;
-  function loadPDF(asset_url: URL) {
-    if (!task) {
-      task = pdfjs.getDocument({ url: asset_url });
-      $pdf = task.promise;
-
-      task.onProgress = (p: DocumentLoadProgress) => {
-        $progress = p;
-      };
-
-      task.promise.catch(async (error) => {
-        if (error.status === 403 && retriesOn403Error < 5) {
-          // try to load the document again using a fresh asset_url
-          const fresh_asset_url = await assetUrl(document);
-          task = null;
-          retriesOn403Error++;
-          loadPDF(fresh_asset_url);
-        } else {
-          console.error(error);
-          $currentErrors = [...$currentErrors, error];
-          throw error;
-        }
-      });
     }
   }
 
   onMount(() => {
     // we might move this to a load function
-    loadPDF(asset_url);
+    if (loadPdf) viewer.loadPDF(asset_url);
   });
 
   afterNavigate(() => {
-    // refresh stores from URL state
-    const { hash } = $pageStore.url;
+    // refresh state from URL
+    const { hash } = pageState.url;
     const hashPage = pageFromHash(hash);
     if (hashPage) {
-      $currentPage = hashPage;
+      viewer.page = hashPage;
     }
-    $currentMode = mode;
-    $currentNote = $currentDoc.notes?.find(noteMatchingPageHash) ?? null;
+    viewer.mode = mode;
+    viewer.currentNote =
+      viewer.document?.notes?.find(noteMatchingPageHash) ?? null;
     if (shouldPaginate(mode) && (hashPage || 0) > 1) {
       scrollToHash(hash);
     }
   });
 </script>
 
-<svelte:window on:hashchange={onHashChange} on:popstate={onHashChange} />
+<svelte:window onhashchange={onHashChange} onpopstate={onHashChange} />
 
-<slot />
+{@render children?.()}

--- a/src/lib/components/viewer/Zoom.svelte
+++ b/src/lib/components/viewer/Zoom.svelte
@@ -4,7 +4,7 @@ Shared zoom component for all viewer routes.
 Must be a child of a ViewerContext
 -->
 <script lang="ts">
-  import { page } from "$app/stores";
+  import { page } from "$app/state";
   import { _ } from "svelte-i18n";
 
   import {
@@ -17,7 +17,7 @@ Must be a child of a ViewerContext
   const viewer = getViewerState();
 
   let zoomLevels = $derived(getZoomLevels(viewer.mode));
-  let initial = $derived(getInitialZoom($page.url, viewer.mode));
+  let initial = $derived(getInitialZoom(page.url, viewer.mode));
   $effect(() => {
     viewer.zoom = initial || getDefaultZoom(viewer.mode);
   });

--- a/src/lib/components/viewer/Zoom.svelte
+++ b/src/lib/components/viewer/Zoom.svelte
@@ -1,7 +1,7 @@
 <!-- @component
 Shared zoom component for all viewer routes.
 
-Assumes it's a child of a ViewerContext
+Must be a child of a ViewerContext
 -->
 <script lang="ts">
   import { page } from "$app/stores";
@@ -12,26 +12,25 @@ Assumes it's a child of a ViewerContext
     getZoomLevels,
     getInitialZoom,
   } from "$lib/utils/viewer";
-  import { getCurrentMode, getZoom } from "./ViewerContext.svelte";
+  import { getViewerState } from "$lib/state/viewer.svelte";
 
-  const mode = getCurrentMode();
-  const zoom = getZoom();
+  const viewer = getViewerState();
 
-  let zoomLevels = $derived(getZoomLevels($mode));
-  let initial = $derived(getInitialZoom($page.url, $mode));
+  let zoomLevels = $derived(getZoomLevels(viewer.mode));
+  let initial = $derived(getInitialZoom($page.url, viewer.mode));
   $effect(() => {
-    $zoom = initial || getDefaultZoom($mode);
+    viewer.zoom = initial || getDefaultZoom(viewer.mode);
   });
 </script>
 
 {#if zoomLevels.length}
   <label class="zoom">
-    {#if $mode === "grid"}
+    {#if viewer.mode === "grid"}
       {$_("zoom.size")}
     {:else}
       {$_("zoom.zoom")}
     {/if}
-    <select name="zoom" bind:value={$zoom}>
+    <select name="zoom" bind:value={viewer.zoom}>
       {#each zoomLevels as [value, label]}
         <option {value}>{$_(label)}</option>
       {/each}

--- a/src/lib/components/viewer/stories/PDFPage.stories.svelte
+++ b/src/lib/components/viewer/stories/PDFPage.stories.svelte
@@ -3,7 +3,6 @@
 
   import { page } from "$app/stores";
 
-  import { writable } from "svelte/store";
   import { defineMeta } from "@storybook/addon-svelte-csf";
   import PdfPage from "../PDFPage.svelte";
 
@@ -31,26 +30,22 @@
   const [width, height] = sizes[0]!;
   const query = "los angeles";
   const url = new URL(pdfFile, import.meta.url);
-
-  async function load(url: URL): Promise<pdfjs.PDFDocumentProxy> {
-    return pdfjs.getDocument(url).promise;
-  }
 </script>
 
 <Story name="fit width" parameters={{ layout: "fullscreen" }} asChild>
-  <ViewerContext {document} pdf={writable(load(url))}>
+  <ViewerContext {document} asset_url={url}>
     <PdfPage page_number={1} scale="width" {width} {height} />
   </ViewerContext>
 </Story>
 
 <Story name="embedded text" asChild>
-  <ViewerContext {document} pdf={writable(load(url))}>
+  <ViewerContext {document} asset_url={url}>
     <PdfPage page_number={1} scale={1.5} {width} {height} />
   </ViewerContext>
 </Story>
 
 <Story name="server text" asChild>
-  <ViewerContext {document} pdf={writable(load(url))}>
+  <ViewerContext {document} asset_url={url}>
     <PdfPage
       page_number={1}
       scale={1.5}
@@ -76,7 +71,7 @@
   }}
   asChild
 >
-  <ViewerContext {document} pdf={writable(load(url))}>
+  <ViewerContext {document} asset_url={url}>
     <p>Query: {query}</p>
     <p>URL: {$page.url}</p>
     <PdfPage page_number={1} scale={1.5} {width} {height} />
@@ -84,7 +79,7 @@
 </Story>
 
 <Story name="long section start" parameters={{ layout: "fullscreen" }} asChild>
-  <ViewerContext {document} pdf={writable(load(url))}>
+  <ViewerContext {document} asset_url={url}>
     <PdfPage page_number={1} scale="width" {width} {height} />
   </ViewerContext>
 </Story>

--- a/src/lib/components/viewer/stories/PDFPage.stories.svelte
+++ b/src/lib/components/viewer/stories/PDFPage.stories.svelte
@@ -1,7 +1,7 @@
 <script module lang="ts">
   import type { Document } from "$lib/api/types";
 
-  import { page } from "$app/stores";
+  import { page } from "$app/state";
 
   import { defineMeta } from "@storybook/addon-svelte-csf";
   import PdfPage from "../PDFPage.svelte";
@@ -59,8 +59,11 @@
 <Story
   name="search results"
   parameters={{
+    // PDFPage derives its search query from `$app/state` (page.url). Storybook
+    // 8.6 doesn't mock `$app/state`, so this override is inert until Storybook
+    // is upgraded; the highlight demo won't reflect the query in the meantime.
     sveltekit_experimental: {
-      stores: {
+      state: {
         page: {
           url: new URL(
             `https://www.dev.documentcloud.org/documents/20000040-the-santa-anas/?q=${query}`,
@@ -73,7 +76,7 @@
 >
   <ViewerContext {document} asset_url={url}>
     <p>Query: {query}</p>
-    <p>URL: {$page.url}</p>
+    <p>URL: {page.url}</p>
     <PdfPage page_number={1} scale={1.5} {width} {height} />
   </ViewerContext>
 </Story>

--- a/src/lib/components/viewer/tests/AnnotationLayer.test.ts
+++ b/src/lib/components/viewer/tests/AnnotationLayer.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Behavioral tests for AnnotationLayer, the viewer's main note writer, rendered
+ * through the real ViewerContext provider via renderInViewer.
+ *
+ * Covers rendering existing notes, entering "writing" mode, and the
+ * draw-a-box / escape-to-close interaction — the note-drawing state that the
+ * stores -> ViewerState migration must preserve.
+ *
+ * jsdom has no PointerEvent, so pointer interactions are dispatched as
+ * MouseEvents (offsetX/clientWidth are 0 in jsdom, which is fine here).
+ */
+import type { Document } from "$lib/api/types";
+
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+const { goto, invalidate } = vi.hoisted(() => ({
+  goto: vi.fn(),
+  invalidate: vi.fn(),
+}));
+vi.mock("$app/navigation", () => ({
+  goto,
+  invalidate,
+  afterNavigate: vi.fn(),
+}));
+
+import AnnotationLayer from "../AnnotationLayer.svelte";
+import { renderInViewer } from "./renderInViewer";
+import { document as base } from "@/test/fixtures/documents";
+import { notePage } from "@/test/fixtures/notes";
+const notes = notePage.results; // 15 real, positioned notes across several pages
+const page0Notes = notes.filter((n) => n.page_number === 0);
+
+function docWith(ns: typeof notes): Document {
+  return { ...base, notes: ns };
+}
+
+describe("AnnotationLayer", () => {
+  it("renders positioned notes for its page as highlights", () => {
+    const { container } = renderInViewer(AnnotationLayer, {
+      props: { page_number: 0 },
+      context: { document: docWith(notes), mode: "document" },
+    });
+
+    // only the notes on page 0 belong to this layer
+    const highlights = container.querySelectorAll(".note-highlight");
+    expect(highlights).toHaveLength(page0Notes.length);
+    expect(highlights[0]!.textContent).toContain(page0Notes[0]!.title);
+  });
+
+  it("enters writing mode when the viewer mode is annotating", () => {
+    const { container } = renderInViewer(AnnotationLayer, {
+      props: { page_number: 0 },
+      context: { document: docWith([]), mode: "annotating" },
+    });
+
+    expect(container.querySelector(".notes.writing")).not.toBeNull();
+  });
+
+  it("draws a box on pointer-down and clears it on Escape", async () => {
+    const { container } = renderInViewer(AnnotationLayer, {
+      props: { page_number: 0 },
+      context: { document: docWith([]), mode: "annotating" },
+    });
+
+    const surface = container.querySelector(".notes") as HTMLElement;
+
+    // start drawing a note box
+    await fireEvent(surface, new MouseEvent("pointerdown", { bubbles: true }));
+    expect(container.querySelector(".box")).not.toBeNull();
+
+    // Escape cancels the in-progress note and navigates back
+    await fireEvent.keyDown(window, { key: "Escape" });
+    expect(container.querySelector(".box")).toBeNull();
+    expect(goto).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/viewer/tests/Grid.test.ts
+++ b/src/lib/components/viewer/tests/Grid.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Behavioral tests for the Grid (thumbnail) viewer pane, rendered through the
+ * real ViewerContext provider via renderInViewer. Only pdfjs (network) and the
+ * router are mocked.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { readable } from "svelte/store";
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
+
+import Grid from "../Grid.svelte";
+import { renderInViewer } from "./renderInViewer";
+import { document } from "@/test/fixtures/documents";
+
+describe("Grid", () => {
+  it("renders one thumbnail image per page, linked to the page", () => {
+    const { container } = renderInViewer(Grid, {
+      context: { document, mode: "grid", embed: true },
+    });
+
+    const images = container.querySelectorAll("img");
+    expect(images).toHaveLength(document.page_count);
+
+    // each image is wrapped in a link to its page
+    images.forEach((img, i) => {
+      expect(img.getAttribute("alt")).toContain(`Page ${i + 1}`);
+      expect(img.closest("a")).not.toBeNull();
+    });
+  });
+});

--- a/src/lib/components/viewer/tests/Notes.test.ts
+++ b/src/lib/components/viewer/tests/Notes.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Behavioral tests for the Notes viewer pane, rendered through the real
+ * ViewerContext provider via renderInViewer. Only pdfjs (network) and the
+ * SvelteKit router are mocked.
+ */
+import type { Document, Note } from "$lib/api/types";
+
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
+
+import Notes from "../Notes.svelte";
+import { renderInViewer } from "./renderInViewer";
+import documentFixture from "@/test/fixtures/documents/document.json";
+
+const base = documentFixture as unknown as Document;
+
+/** A page-level note (all bbox coords null) — renders without a PDF excerpt. */
+function pageLevelNote(id: number): Note {
+  return {
+    id,
+    title: `Note ${id}`,
+    content: "note body",
+    page_number: 0,
+    access: "public",
+    x1: null,
+    x2: null,
+    y1: null,
+    y2: null,
+    edit_access: false,
+  } as unknown as Note;
+}
+
+function doc(overrides: Partial<Document>): Document {
+  return { ...base, ...overrides };
+}
+
+describe("Notes", () => {
+  it("prompts editors to annotate when there are no notes", () => {
+    renderInViewer(Notes, {
+      context: { document: doc({ notes: [], edit_access: true }) },
+    });
+
+    // the empty state offers a call-to-action link into annotating mode
+    const cta = screen.getByRole("link");
+    expect(cta).toBeInTheDocument();
+    expect(cta.getAttribute("href")).toContain("annotating");
+  });
+
+  it("shows no annotate CTA for viewers without edit access", () => {
+    renderInViewer(Notes, {
+      context: { document: doc({ notes: [], edit_access: false }) },
+    });
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders one entry per note", () => {
+    const { container } = renderInViewer(Notes, {
+      context: {
+        document: doc({
+          notes: [pageLevelNote(1), pageLevelNote(2), pageLevelNote(3)],
+          edit_access: false,
+        }),
+        embed: true, // skip the note footer (actions/metadata) to keep it light
+      },
+    });
+
+    expect(container.querySelectorAll(".note-wrapper")).toHaveLength(3);
+    // the empty-state CTA should not appear when notes exist
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/components/viewer/tests/Notes.test.ts
+++ b/src/lib/components/viewer/tests/Notes.test.ts
@@ -3,7 +3,7 @@
  * ViewerContext provider via renderInViewer. Only pdfjs (network) and the
  * SvelteKit router are mocked.
  */
-import type { Document, Note } from "$lib/api/types";
+import type { Document } from "$lib/api/types";
 
 import { describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/svelte";
@@ -26,25 +26,10 @@ vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
 
 import Notes from "../Notes.svelte";
 import { renderInViewer } from "./renderInViewer";
-import documentFixture from "@/test/fixtures/documents/document.json";
+import { document as base } from "@/test/fixtures/documents";
+import { notePage } from "@/test/fixtures/notes";
 
-const base = documentFixture as unknown as Document;
-
-/** A page-level note (all bbox coords null) — renders without a PDF excerpt. */
-function pageLevelNote(id: number): Note {
-  return {
-    id,
-    title: `Note ${id}`,
-    content: "note body",
-    page_number: 0,
-    access: "public",
-    x1: null,
-    x2: null,
-    y1: null,
-    y2: null,
-    edit_access: false,
-  } as unknown as Note;
-}
+const notes = notePage.results; // 15 real notes
 
 function doc(overrides: Partial<Document>): Document {
   return { ...base, ...overrides };
@@ -71,18 +56,18 @@ describe("Notes", () => {
   });
 
   it("renders one entry per note", () => {
+    const sample = notes.slice(0, 3);
     const { container } = renderInViewer(Notes, {
       context: {
-        document: doc({
-          notes: [pageLevelNote(1), pageLevelNote(2), pageLevelNote(3)],
-          edit_access: false,
-        }),
+        document: doc({ notes: sample, edit_access: false }),
         embed: true, // skip the note footer (actions/metadata) to keep it light
       },
     });
 
-    expect(container.querySelectorAll(".note-wrapper")).toHaveLength(3);
-    // the empty-state CTA should not appear when notes exist
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(container.querySelectorAll(".note-wrapper")).toHaveLength(
+      sample.length,
+    );
+    // the first note's title is shown
+    expect(screen.getByText(sample[0]!.title!)).toBeInTheDocument();
   });
 });

--- a/src/lib/components/viewer/tests/PDF.test.ts
+++ b/src/lib/components/viewer/tests/PDF.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Behavioral tests for the PDF pane, rendered through the real ViewerContext
+ * provider via renderInViewer.
+ *
+ * PDF renders a PDFPage per page (each wrapped in <Page track>), so an
+ * IntersectionObserver stub is needed. pdfjs stays pending (no canvas draw),
+ * and the router is mocked. The error branch is driven by seeding `errors`.
+ */
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { screen } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+vi.mock("$app/state", () => ({
+  page: {
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  },
+}));
+vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+import PDF from "../PDF.svelte";
+import { renderInViewer } from "./renderInViewer";
+import { document } from "@/test/fixtures/documents";
+
+describe("PDF", () => {
+  it("renders a page for each page in the document spec", () => {
+    const { container } = renderInViewer(PDF, {
+      context: { document, mode: "document" },
+    });
+
+    expect(container.querySelector(".pages")).not.toBeNull();
+    // one Page wrapper per page in page_spec (612.0x792.0:0-19 => 20 pages)
+    expect(container.querySelectorAll(".page")).toHaveLength(
+      document.page_count,
+    );
+  });
+
+  it("shows an error view instead of pages when loading failed", () => {
+    const { container } = renderInViewer(PDF, {
+      context: {
+        document,
+        mode: "document",
+        errors: [new Error("could not load document")],
+      },
+    });
+
+    expect(screen.getByText(/could not load document/)).toBeInTheDocument();
+    expect(container.querySelector(".pages")).toBeNull();
+  });
+});

--- a/src/lib/components/viewer/tests/Page.test.ts
+++ b/src/lib/components/viewer/tests/Page.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Behavioral tests for the generic Page container, rendered through the real
+ * ViewerContext provider via renderInViewer.
+ *
+ * Covers the page-number link and the embed gating of PageActions — the
+ * `embed` read the migration must preserve. (The IntersectionObserver ->
+ * currentPage write only happens with `track`, which isn't practical to drive
+ * in jsdom, so it's left to e2e.)
+ *
+ * Only pdfjs (network) and the router are mocked.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { readable } from "svelte/store";
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+vi.mock("$app/state", () => ({
+  page: {
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  },
+}));
+vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
+
+import Page from "../Page.svelte";
+import { renderInViewer } from "./renderInViewer";
+import { document } from "@/test/fixtures/documents";
+
+describe("Page", () => {
+  it("renders a page-number link", () => {
+    const { container } = renderInViewer(Page, {
+      props: { page_number: 3 },
+      context: { document, mode: "document" },
+    });
+
+    const link = container.querySelector(".pageNumber a") as HTMLAnchorElement;
+    expect(link).not.toBeNull();
+    expect(link.textContent).toContain("3");
+    expect(link.getAttribute("href")).toBeTruthy();
+  });
+
+  it("renders page actions when not embedded", () => {
+    const { container } = renderInViewer(Page, {
+      props: { page_number: 1 },
+      context: { document, mode: "document", embed: false },
+    });
+
+    expect(container.querySelector(".page-actions")).not.toBeNull();
+  });
+
+  it("omits page actions in embed mode", () => {
+    const { container } = renderInViewer(Page, {
+      props: { page_number: 1 },
+      context: { document, mode: "document", embed: true },
+    });
+
+    expect(container.querySelector(".page-actions")).toBeNull();
+  });
+});

--- a/src/lib/components/viewer/tests/Search.test.ts
+++ b/src/lib/components/viewer/tests/Search.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Behavioral tests for the Search viewer pane, rendered through the real
+ * ViewerContext provider via renderInViewer.
+ *
+ * The within-document search API is mocked (partial mock so ViewerContext's
+ * other uses of $lib/api/documents keep working); pdfjs and the router are
+ * mocked as elsewhere.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { screen, waitFor } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/?q=Boston"),
+  }),
+}));
+vi.mock("$app/state", () => ({
+  page: {
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/?q=Boston"),
+  },
+}));
+vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
+
+const { searchWithin } = vi.hoisted(() => ({ searchWithin: vi.fn() }));
+vi.mock("$lib/api/documents", async (orig) => ({
+  ...(await orig<typeof import("$lib/api/documents")>()),
+  searchWithin,
+}));
+
+import Search from "../Search.svelte";
+import { renderInViewer } from "./renderInViewer";
+import {
+  document,
+  searchWithin as searchResults,
+} from "@/test/fixtures/documents";
+
+describe("Search", () => {
+  it("lists a result card per matching page", async () => {
+    searchWithin.mockResolvedValue({ data: searchResults });
+
+    const { container } = renderInViewer(Search, {
+      context: { document, mode: "search" },
+    });
+
+    await waitFor(() =>
+      expect(container.querySelectorAll("a.card").length).toBeGreaterThan(0),
+    );
+
+    // one card per matching page in the searchWithin fixture
+    expect(container.querySelectorAll("a.card")).toHaveLength(
+      Object.keys(searchResults).length,
+    );
+    expect(searchWithin).toHaveBeenCalledWith(document.id, "Boston");
+  });
+
+  it("shows an empty state when there are no matches", async () => {
+    searchWithin.mockResolvedValue({ data: {} });
+
+    const { container } = renderInViewer(Search, {
+      context: { document, mode: "search" },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/no matching results/i)).toBeInTheDocument(),
+    );
+    expect(container.querySelectorAll("a.card")).toHaveLength(0);
+  });
+});

--- a/src/lib/components/viewer/tests/Text.test.ts
+++ b/src/lib/components/viewer/tests/Text.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Behavioral tests for the Text viewer pane, rendered through the real
+ * ViewerContext provider via renderInViewer.
+ *
+ * Text renders each page inside <Page track>, which sets up an
+ * IntersectionObserver — stubbed here since jsdom lacks it. pdfjs (network)
+ * and the router are mocked as elsewhere.
+ */
+import type { DocumentText } from "$lib/api/types";
+
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { screen, waitFor } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+vi.mock("$app/state", () => ({
+  page: {
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  },
+}));
+vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
+
+// Page uses IntersectionObserver when tracking visibility.
+beforeAll(() => {
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+import Text from "../Text.svelte";
+import { renderInViewer } from "./renderInViewer";
+import { document } from "@/test/fixtures/documents";
+import textFixture from "@/test/fixtures/documents/document.txt.json";
+
+const text = textFixture as DocumentText; // 3 pages of real OCR text
+
+describe("Text", () => {
+  it("renders a text block for each page once the text resolves", async () => {
+    const { container } = renderInViewer(Text, {
+      context: { document, mode: "text", text: Promise.resolve(text) },
+    });
+
+    await waitFor(() =>
+      expect(container.querySelectorAll("pre")).toHaveLength(text.pages.length),
+    );
+    // page 0 of the fixture is Joan Didion's "The Santa Anas"
+    expect(screen.getByText(/Joan Didion/)).toBeInTheDocument();
+  });
+
+  it("exposes the zoom level as the --zoom custom property", async () => {
+    const { container } = renderInViewer(Text, {
+      context: {
+        document,
+        mode: "text",
+        zoom: 1.5,
+        text: Promise.resolve(text),
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/Joan Didion/)).toBeInTheDocument(),
+    );
+
+    const pages = container.querySelector(".textPages") as HTMLElement;
+    expect(pages.style.getPropertyValue("--zoom")).toBe("1.5");
+  });
+});

--- a/src/lib/components/viewer/tests/ViewerHarness.svelte
+++ b/src/lib/components/viewer/tests/ViewerHarness.svelte
@@ -1,0 +1,26 @@
+<!-- @component
+Generic test harness: renders any child component inside the real
+ViewerContext provider, forwarding context props (document, mode, zoom, …).
+
+Used via the `renderInViewer` helper. Because it delegates to ViewerContext
+itself, tests go through the viewer's public prop API and don't reproduce its
+internal context wiring — so they survive the stores -> ViewerState migration.
+-->
+<script lang="ts">
+  import type { Component, ComponentProps } from "svelte";
+
+  import ViewerContext from "../ViewerContext.svelte";
+
+  interface Props {
+    child: Component<any>;
+    childProps?: Record<string, unknown>;
+    // forwarded to ViewerContext (document, mode, zoom, …)
+    context: ComponentProps<typeof ViewerContext>;
+  }
+
+  const { child: Child, childProps = {}, context }: Props = $props();
+</script>
+
+<ViewerContext {...context}>
+  <Child {...childProps} />
+</ViewerContext>

--- a/src/lib/components/viewer/tests/Zoom.test.ts
+++ b/src/lib/components/viewer/tests/Zoom.test.ts
@@ -7,8 +7,6 @@
  * Only genuinely external dependencies are mocked: pdfjs (network) and the
  * SvelteKit router.
  */
-import type { Document } from "$lib/api/types";
-
 import { describe, it, expect, vi } from "vitest";
 import { screen } from "@testing-library/svelte";
 import { readable } from "svelte/store";
@@ -32,9 +30,7 @@ vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
 
 import Zoom from "../Zoom.svelte";
 import { renderInViewer } from "./renderInViewer";
-import documentFixture from "@/test/fixtures/documents/document.json";
-
-const document = documentFixture as unknown as Document;
+import { document } from "@/test/fixtures/documents";
 
 /** `value` attributes of the zoom <select>'s options, in order. */
 function optionValues() {

--- a/src/lib/components/viewer/tests/Zoom.test.ts
+++ b/src/lib/components/viewer/tests/Zoom.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Behavioral tests for Zoom, rendered through the real ViewerContext provider
+ * (via renderInViewer) so they exercise the viewer's public interface rather
+ * than its internal state plumbing — and survive the stores -> ViewerState
+ * migration unchanged.
+ *
+ * Only genuinely external dependencies are mocked: pdfjs (network) and the
+ * SvelteKit router.
+ */
+import type { Document } from "$lib/api/types";
+
+import { describe, it, expect, vi } from "vitest";
+import { screen } from "@testing-library/svelte";
+import { readable } from "svelte/store";
+
+// pdfjs would hit the network when ViewerContext mounts and loads the PDF.
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument: vi.fn(() => ({
+    promise: new Promise(() => {}),
+    onProgress: null,
+  })),
+}));
+
+// ViewerContext reads the page store; Zoom reads it for the initial zoom.
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
+  }),
+}));
+vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
+
+import Zoom from "../Zoom.svelte";
+import { renderInViewer } from "./renderInViewer";
+import documentFixture from "@/test/fixtures/documents/document.json";
+
+const document = documentFixture as unknown as Document;
+
+/** `value` attributes of the zoom <select>'s options, in order. */
+function optionValues() {
+  const select = screen.getByRole("combobox");
+  return Array.from(
+    select.querySelectorAll("option"),
+    (o) => (o as HTMLOptionElement).value,
+  );
+}
+
+describe("Zoom", () => {
+  it("offers width/height fit plus percentages in document mode", () => {
+    renderInViewer(Zoom, { context: { document, mode: "document" } });
+
+    expect(optionValues()).toEqual([
+      "width",
+      "height",
+      "0.5",
+      "0.75",
+      "1",
+      "1.25",
+      "1.5",
+      "2",
+    ]);
+  });
+
+  it("defaults to fit-width in document mode", () => {
+    renderInViewer(Zoom, { context: { document, mode: "document" } });
+    expect(screen.getByRole("combobox")).toHaveValue("width");
+  });
+
+  it("offers only size presets in grid mode and defaults to small", () => {
+    renderInViewer(Zoom, { context: { document, mode: "grid" } });
+
+    expect(optionValues()).toEqual(["thumbnail", "small", "normal", "large"]);
+    expect(screen.getByRole("combobox")).toHaveValue("small");
+  });
+
+  it("renders no control in notes mode (notes don't zoom)", () => {
+    renderInViewer(Zoom, { context: { document, mode: "notes" } });
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/components/viewer/tests/renderInViewer.ts
+++ b/src/lib/components/viewer/tests/renderInViewer.ts
@@ -24,9 +24,9 @@ export interface ViewerContextProps {
   text?: Promise<Maybe<DocumentText>>;
 }
 
-interface Options<Props extends Record<string, unknown>> {
+interface Options {
   /** Props passed to the component under test. */
-  props?: Props;
+  props?: Record<string, unknown>;
   /** Props passed to ViewerContext to seed viewer state. */
   context: ViewerContextProps;
 }
@@ -38,10 +38,14 @@ interface Options<Props extends Record<string, unknown>> {
  * establishes context before the component under test renders), but wraps the
  * actual ViewerContext so tests exercise the public provider rather than a
  * hand-rolled context stub.
+ *
+ * `child` is typed loosely (`Component<any>`): component prop interfaces aren't
+ * assignable to `Record<string, unknown>`, and the harness forwards props
+ * untyped anyway. Each component still validates its props at render time.
  */
-export function renderInViewer<Props extends Record<string, unknown>>(
-  child: Component<Props>,
-  { props = {} as Props, context }: Options<Props>,
+export function renderInViewer(
+  child: Component<any>,
+  { props = {}, context }: Options,
 ) {
   return render(ViewerHarness, {
     props: { child, childProps: props, context },

--- a/src/lib/components/viewer/tests/renderInViewer.ts
+++ b/src/lib/components/viewer/tests/renderInViewer.ts
@@ -23,6 +23,8 @@ export interface ViewerContextProps {
   note?: Nullable<Note>;
   text?: Promise<Maybe<DocumentText>>;
   errors?: Error[];
+  /** Set false for a lightweight viewer that never loads the document PDF. */
+  loadPdf?: boolean;
 }
 
 interface Options {

--- a/src/lib/components/viewer/tests/renderInViewer.ts
+++ b/src/lib/components/viewer/tests/renderInViewer.ts
@@ -1,0 +1,49 @@
+import type { Component } from "svelte";
+import type {
+  Document,
+  DocumentText,
+  Maybe,
+  Note,
+  Nullable,
+  ViewerMode,
+  Zoom,
+} from "$lib/api/types";
+
+import { render } from "@testing-library/svelte";
+
+import ViewerHarness from "./ViewerHarness.svelte";
+
+/** Props ViewerContext accepts, used to seed viewer state for a test. */
+export interface ViewerContextProps {
+  document: Document;
+  mode?: ViewerMode;
+  zoom?: Zoom;
+  page?: number;
+  embed?: boolean;
+  note?: Nullable<Note>;
+  text?: Promise<Maybe<DocumentText>>;
+}
+
+interface Options<Props extends Record<string, unknown>> {
+  /** Props passed to the component under test. */
+  props?: Props;
+  /** Props passed to ViewerContext to seed viewer state. */
+  context: ViewerContextProps;
+}
+
+/**
+ * Render a component inside the real ViewerContext provider.
+ *
+ * Mirrors the Svelte docs' context component-testing pattern (a wrapper that
+ * establishes context before the component under test renders), but wraps the
+ * actual ViewerContext so tests exercise the public provider rather than a
+ * hand-rolled context stub.
+ */
+export function renderInViewer<Props extends Record<string, unknown>>(
+  child: Component<Props>,
+  { props = {} as Props, context }: Options<Props>,
+) {
+  return render(ViewerHarness, {
+    props: { child, childProps: props, context },
+  });
+}

--- a/src/lib/components/viewer/tests/renderInViewer.ts
+++ b/src/lib/components/viewer/tests/renderInViewer.ts
@@ -22,6 +22,7 @@ export interface ViewerContextProps {
   embed?: boolean;
   note?: Nullable<Note>;
   text?: Promise<Maybe<DocumentText>>;
+  errors?: Error[];
 }
 
 interface Options {

--- a/src/lib/state/tests/viewer.test.svelte.ts
+++ b/src/lib/state/tests/viewer.test.svelte.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for the ViewerState class.
+ *
+ * Uses the .svelte.ts extension so Svelte rune syntax ($state) inside the class
+ * under test is compiled. `pdfjs` and the documents API are mocked so `loadPDF`
+ * can be exercised without touching the network.
+ */
+import type { Document } from "$lib/api/types";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from "vitest";
+
+// `vi.mock` factories are hoisted above the file, so the mocks they reference
+// must be created with `vi.hoisted`.
+const { getDocument, assetUrl } = vi.hoisted(() => ({
+  getDocument: vi.fn(),
+  assetUrl: vi.fn(),
+}));
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
+  // truthy workerSrc so the module-init guard skips `new URL(...)`
+  GlobalWorkerOptions: { workerSrc: "mock-worker" },
+  getDocument,
+}));
+vi.mock("$lib/api/documents", () => ({ assetUrl }));
+
+import { ViewerState } from "$lib/state/viewer.svelte";
+import documentFixture from "@/test/fixtures/documents/document.json";
+
+const doc = documentFixture as unknown as Document;
+
+/** A fake pdfjs loading task with a controllable promise. */
+function makeTask(promise: Promise<unknown>) {
+  return { promise, onProgress: null as unknown };
+}
+
+// The unrecoverable-error path re-throws inside a `.catch`, producing an
+// intentionally floating rejection that mirrors production. Swallow it so it
+// doesn't fail unrelated assertions.
+const swallow = () => {};
+beforeAll(() => process.on("unhandledRejection", swallow));
+afterAll(() => process.off("unhandledRejection", swallow));
+
+describe("ViewerState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("has sensible defaults", () => {
+    const v = new ViewerState();
+    expect(v.document).toBeNull();
+    expect(v.mode).toBe("document");
+    expect(v.page).toBe(1);
+    expect(v.zoom).toBe(1);
+    expect(v.embed).toBe(false);
+    expect(v.errors).toEqual([]);
+    expect(v.currentNote).toBeNull();
+    expect(v.newNote).toBeNull();
+    expect(v.progress).toEqual({ loaded: 0, total: 0 });
+  });
+
+  it("loadingProgress guards against a zero total", () => {
+    const v = new ViewerState();
+    expect(v.loadingProgress).toBe(0);
+    v.progress = { loaded: 5, total: 0 };
+    expect(v.loadingProgress).toBe(0);
+  });
+
+  it("loadingProgress reports the loaded ratio", () => {
+    const v = new ViewerState();
+    v.progress = { loaded: 3, total: 12 };
+    expect(v.loadingProgress).toBe(0.25);
+  });
+
+  it("loadPDF stores the pdf promise and wires progress updates", async () => {
+    const pdf = { numPages: 7 };
+    const task = makeTask(Promise.resolve(pdf));
+    getDocument.mockReturnValue(task);
+
+    const v = new ViewerState();
+    const url = new URL("https://example.com/doc.pdf");
+    v.loadPDF(url);
+
+    expect(getDocument).toHaveBeenCalledWith({ url });
+    await expect(v.pdf).resolves.toBe(pdf);
+
+    // the class installs its own onProgress handler on the task
+    (task.onProgress as (p: unknown) => void)({ loaded: 4, total: 8 });
+    expect(v.progress).toEqual({ loaded: 4, total: 8 });
+  });
+
+  it("loadPDF is a no-op while a task is already in flight", () => {
+    getDocument.mockReturnValue(makeTask(Promise.resolve({})));
+    const v = new ViewerState();
+    v.loadPDF(new URL("https://example.com/a.pdf"));
+    v.loadPDF(new URL("https://example.com/b.pdf"));
+    expect(getDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries with a fresh asset URL on a 403", async () => {
+    const err = Object.assign(new Error("Forbidden"), { status: 403 });
+    const firstTask = makeTask(Promise.reject(err));
+    // keep the initial rejection from being flagged unhandled
+    firstTask.promise.catch(() => {});
+    const secondPdf = { numPages: 1 };
+    const secondTask = makeTask(Promise.resolve(secondPdf));
+    getDocument.mockReturnValueOnce(firstTask).mockReturnValueOnce(secondTask);
+
+    const freshUrl = new URL("https://example.com/fresh.pdf");
+    assetUrl.mockResolvedValue(freshUrl);
+
+    const v = new ViewerState();
+    v.document = doc;
+    v.loadPDF(new URL("https://example.com/stale.pdf"));
+
+    await vi.waitFor(() => expect(getDocument).toHaveBeenCalledTimes(2));
+    expect(assetUrl).toHaveBeenCalledWith(doc);
+    expect(getDocument).toHaveBeenLastCalledWith({ url: freshUrl });
+    await expect(v.pdf).resolves.toBe(secondPdf);
+  });
+
+  it("records non-403 errors instead of retrying", async () => {
+    const err = Object.assign(new Error("boom"), { status: 500 });
+    const task = makeTask(Promise.reject(err));
+    task.promise.catch(() => {});
+    getDocument.mockReturnValue(task);
+
+    const v = new ViewerState();
+    v.document = doc;
+    v.loadPDF(new URL("https://example.com/a.pdf"));
+
+    await vi.waitFor(() => expect(v.errors).toContain(err));
+    expect(assetUrl).not.toHaveBeenCalled();
+  });
+
+  it("stops retrying 403s after 5 attempts", async () => {
+    const err = Object.assign(new Error("Forbidden"), { status: 403 });
+    getDocument.mockImplementation(() => {
+      const t = makeTask(Promise.reject(err));
+      t.promise.catch(() => {});
+      return t;
+    });
+    assetUrl.mockResolvedValue(new URL("https://example.com/fresh.pdf"));
+
+    const v = new ViewerState();
+    v.document = doc;
+    v.loadPDF(new URL("https://example.com/stale.pdf"));
+
+    // 1 initial + 5 retries
+    await vi.waitFor(() => expect(getDocument).toHaveBeenCalledTimes(6));
+    await vi.waitFor(() => expect(v.errors).toContain(err));
+  });
+});

--- a/src/lib/state/viewer.svelte.ts
+++ b/src/lib/state/viewer.svelte.ts
@@ -1,0 +1,92 @@
+/**
+ * Viewer state encapsulates all data and state needed to render the document viewer.
+ * There are three versions of the viewer: logged-in, logged-out and embed.
+ *
+ * This viewer state class should be a singleton for each document URL.
+ */
+
+import type {
+  Document,
+  DocumentLoadProgress,
+  DocumentText,
+  Maybe,
+  Nullable,
+  Note,
+  ViewerMode,
+  Zoom,
+  BBox,
+} from "$lib/api/types";
+
+import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
+import { createContext } from "svelte";
+
+import { assetUrl } from "$lib/api/documents";
+
+if (!pdfjs.GlobalWorkerOptions.workerSrc) {
+  pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+    "pdfjs-dist/legacy/build/pdf.worker.mjs",
+    import.meta.url,
+  ).href;
+}
+
+export class ViewerState {
+  // document parts
+  document: Nullable<Document> = $state(null);
+  text: Promise<Maybe<DocumentText>> = $state(new Promise(() => {}));
+  assetUrl: Nullable<URL> = $state(null); // backend field is `asset_url`
+  embed: boolean = $state(false);
+  errors: Error[] = $state([]);
+  mode: ViewerMode = $state("document");
+  page: number = $state(1); // 1-indexed
+  pdf: Promise<pdfjs.PDFDocumentProxy> = $state(new Promise(() => {}));
+  progress: DocumentLoadProgress = $state({ loaded: 0, total: 0 });
+  zoom: Zoom = $state(1);
+
+  // notes
+  currentNote: Nullable<Note> = $state(null);
+  newNote: Nullable<Partial<Note> & BBox> = $state(null);
+
+  // internal PDF loading state
+  #task: Nullable<pdfjs.PDFDocumentLoadingTask> = null;
+  #retriesOn403Error = 0;
+
+  get loadingProgress(): number {
+    if (this.progress.total === 0) return 0;
+    return this.progress.loaded / this.progress.total;
+  }
+
+  /**
+   * Load the PDF from an asset URL, tracking progress and errors.
+   * On a 403 (expired private asset URL), retry with a fresh URL up to 5 times.
+   */
+  loadPDF(url: URL): void {
+    if (this.#task) return;
+
+    this.#task = pdfjs.getDocument({ url });
+    this.pdf = this.#task.promise;
+
+    this.#task.onProgress = (p: DocumentLoadProgress) => {
+      this.progress = p;
+    };
+
+    this.#task.promise.catch(async (error) => {
+      if (
+        error.status === 403 &&
+        this.#retriesOn403Error < 5 &&
+        this.document
+      ) {
+        // try to load the document again using a fresh asset_url
+        const freshUrl = await assetUrl(this.document);
+        this.#task = null;
+        this.#retriesOn403Error++;
+        this.loadPDF(freshUrl);
+      } else {
+        console.error(error);
+        this.errors = [...this.errors, error];
+        throw error;
+      }
+    });
+  }
+}
+
+export const [getViewerState, setViewerState] = createContext<ViewerState>();

--- a/src/lib/state/viewer.svelte.ts
+++ b/src/lib/state/viewer.svelte.ts
@@ -38,7 +38,12 @@ export class ViewerState {
   errors: Error[] = $state([]);
   mode: ViewerMode = $state("document");
   page: number = $state(1); // 1-indexed
-  pdf: Promise<pdfjs.PDFDocumentProxy> = $state(new Promise(() => {}));
+  // A never-resolving placeholder until `loadPDF` runs. `null` means this viewer
+  // has no PDF at all (e.g. a single-note embed), so consumers render from a
+  // page image instead of loading the document.
+  pdf: Nullable<Promise<pdfjs.PDFDocumentProxy>> = $state(
+    new Promise(() => {}),
+  );
   progress: DocumentLoadProgress = $state({ loaded: 0, total: 0 });
   zoom: Zoom = $state(1);
 

--- a/src/lib/utils/tests/getViewerHref.embed.test.ts
+++ b/src/lib/utils/tests/getViewerHref.embed.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Guards that viewer links built inside an embed resolve to EMBED_URL, not
+ * APP_URL.
+ *
+ * The default dev config sets EMBED_URL === APP_URL, which is exactly why a
+ * missing `embed` flag can slip through unnoticed (the hosts look identical
+ * everywhere except staging/production). Here we mock the config so the two
+ * hosts differ, then assert which host `getViewerHref` uses for each case.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/config/config.js")>()),
+  APP_URL: "https://www.documentcloud.org/",
+  EMBED_URL: "https://embed.documentcloud.org/",
+}));
+
+import { getViewerHref } from "../viewer";
+import { document } from "@/test/fixtures/documents";
+
+describe("getViewerHref host", () => {
+  it("uses EMBED_URL for document links when embed is true", () => {
+    const href = getViewerHref({ document, embed: true });
+    expect(new URL(href).host).toBe("embed.documentcloud.org");
+  });
+
+  it("uses APP_URL for document links when embed is false", () => {
+    const href = getViewerHref({ document, embed: false });
+    expect(new URL(href).host).toBe("www.documentcloud.org");
+  });
+});

--- a/src/lib/utils/viewer.ts
+++ b/src/lib/utils/viewer.ts
@@ -224,8 +224,8 @@ export function getZoomLevels(mode: ViewerMode): ZoomLevels {
   }
 }
 
-export function getInitialZoom(url: URL, mode: ViewerMode): Maybe<Zoom> {
-  const zoom = url.searchParams?.get("zoom");
+export function getInitialZoom(url: Maybe<URL>, mode: ViewerMode): Maybe<Zoom> {
+  const zoom = url?.searchParams?.get("zoom");
 
   if (!zoom) return undefined;
 

--- a/src/routes/(app)/documents/[id]-[slug]/+page.svelte
+++ b/src/routes/(app)/documents/[id]-[slug]/+page.svelte
@@ -1,7 +1,3 @@
-<!-- @component
-  Assumes it's a child of a ViewerContext
- -->
-
 <script lang="ts">
   import { browser } from "$app/environment";
   import { page } from "$app/state";

--- a/src/routes/embed/documents/[id]-[slug]/+page.svelte
+++ b/src/routes/embed/documents/[id]-[slug]/+page.svelte
@@ -1,7 +1,3 @@
-<!-- @component
-Assumes it's a child of a ViewerContext
- -->
-
 <script lang="ts">
   import { browser } from "$app/environment";
 
@@ -42,7 +38,7 @@ Assumes it's a child of a ViewerContext
   />
 </svelte:head>
 
-<ViewerContext {document} {mode} {text} {asset_url}>
+<ViewerContext {document} {mode} {text} {asset_url} embed>
   <EmbedLayout
     settings={data.settings}
     canonicalUrl={canonical_url}

--- a/src/routes/embed/documents/[id]/annotations/[note_id]/+page.svelte
+++ b/src/routes/embed/documents/[id]/annotations/[note_id]/+page.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import { page } from "$app/state";
-  import { onMount, setContext } from "svelte";
-  import { writable } from "svelte/store";
+  import { onMount } from "svelte";
   import { _ } from "svelte-i18n";
 
   import EmbedLayout from "$lib/components/layouts/EmbedLayout.svelte";
   import Note from "$lib/components/notes/Note.svelte";
+  import ViewerContext from "$lib/components/viewer/ViewerContext.svelte";
 
   import { informSize } from "$lib/utils/embed";
   import { pageImageUrl } from "$lib/api/documents";
@@ -28,11 +28,6 @@
     `${note.title} (${$_("documents.pageAbbrev")} ${note.page_number + 1})`,
   );
   let debug = $derived(page?.url?.searchParams?.has("debug") ?? false);
-
-  setContext("document", () => writable(doc));
-  setContext("embed", true);
-  setContext("currentMode", writable("note"));
-  setContext("pdf", undefined);
 
   onMount(() => {
     if (window.document.readyState === "complete" && embedContainer) {
@@ -75,7 +70,9 @@
   <EmbedLayout canonicalUrl={viewerUrl} type="note">
     <div class="note-container" bind:this={embedContainer}>
       <div class="card">
-        <Note document={writable(doc)} {note} />
+        <ViewerContext document={doc} {note} embed mode="notes" loadPdf={false}>
+          <Note {note} />
+        </ViewerContext>
       </div>
     </div>
   </EmbedLayout>


### PR DESCRIPTION
Consolidating all viewer state into one class, in `src/lib/state/viewer.svelte.ts`, plus an extensive test suite for safety.

Everything in the viewer should _just work_ like it did before. This is entirely internal, but it opens up later fixes for viewer work.