### PR TITLE
Zoom improvements

### DIFF
--- a/src/langs/json/de.json
+++ b/src/langs/json/de.json
@@ -174,7 +174,10 @@
   },
   "zoom": {
     "fitWidth": "Breite anpassen",
-    "fitHeight": "Höhe anpassen"
+    "fitHeight": "Höhe anpassen",
+    "auto": "Automatisch",
+    "zoomOut": "Verkleinern",
+    "zoomIn": "Vergrößern"
   },
   "titleHeader": {
     "contributedBy": "Beitrag von {name}"

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -434,7 +434,9 @@
     "thumbnail": "Tiny",
     "small": "Small",
     "normal": "Medium",
-    "large": "Large"
+    "large": "Large",
+    "zoomOut": "Zoom Out",
+    "zoomIn": "Zoom In"
   },
   "embed": {
     "download": "Download",

--- a/src/langs/json/en.json
+++ b/src/langs/json/en.json
@@ -430,6 +430,7 @@
     "size": "Size",
     "fitWidth": "Fit Width",
     "fitHeight": "Fit Height",
+    "auto": "Auto",
     "thumbnail": "Tiny",
     "small": "Small",
     "normal": "Medium",

--- a/src/langs/json/es.json
+++ b/src/langs/json/es.json
@@ -361,10 +361,13 @@
     "size": "Tama\u00f1o",
     "fitWidth": "Largo de ajuste",
     "fitHeight": "Altura de ejercicio",
+    "auto": "Autom\u00e1tico",
     "thumbnail": "Peque\u00f1o",
     "small": "Peque\u00f1o",
     "normal": "Medio",
-    "large": "Grande"
+    "large": "Grande",
+    "zoomOut": "Alejar",
+    "zoomIn": "Acercar"
   },
   "embed": {
     "download": "Descargar",

--- a/src/langs/json/fr.json
+++ b/src/langs/json/fr.json
@@ -361,10 +361,13 @@
     "size": "Taille",
     "fitWidth": "Largeur de forme",
     "fitHeight": "Hauteur",
+    "auto": "Automatique",
     "thumbnail": "Petit",
     "small": "Petit",
     "normal": "Moyen",
-    "large": "Grande"
+    "large": "Grande",
+    "zoomOut": "Zoom arri\u00e8re",
+    "zoomIn": "Zoom avant"
   },
   "embed": {
     "download": "T\u00e9l\u00e9charger",

--- a/src/langs/json/it.json
+++ b/src/langs/json/it.json
@@ -361,10 +361,13 @@
     "size": "Dimensione",
     "fitWidth": "Larghezza di corpo",
     "fitHeight": "Altezza di corrispondenza",
+    "auto": "Automatico",
     "thumbnail": "Piccolo",
     "small": "Piccolo",
     "normal": "Medium",
-    "large": "Grande"
+    "large": "Grande",
+    "zoomOut": "Riduci zoom",
+    "zoomIn": "Ingrandisci"
   },
   "embed": {
     "download": "Scarica",

--- a/src/langs/json/ru.json
+++ b/src/langs/json/ru.json
@@ -184,7 +184,10 @@
   },
   "zoom": {
     "fitWidth": "Подгонять ширину",
-    "fitHeight": "Подгонять высоту"
+    "fitHeight": "Подгонять высоту",
+    "auto": "Авто",
+    "zoomOut": "Уменьшить",
+    "zoomIn": "Увеличить"
   },
   "titleHeader": {
     "contributedBy": "Внесено {name}"

--- a/src/langs/json/uk.json
+++ b/src/langs/json/uk.json
@@ -187,7 +187,10 @@
   },
   "zoom": {
     "fitWidth": "Вмістити за шириною",
-    "fitHeight": "Вмістити за висотою"
+    "fitHeight": "Вмістити за висотою",
+    "auto": "Авто",
+    "zoomOut": "Зменшити",
+    "zoomIn": "Збільшити"
   },
   "titleHeader": {
     "contributedBy": "Внесено {name}"

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -23,7 +23,7 @@ export type WriteMode = "redacting" | "annotating";
 
 export type ViewerMode = ReadMode | WriteMode;
 
-export type Zoom = number | Sizes | "width" | "height";
+export type Zoom = number | Sizes | "auto";
 
 export type ZoomLevels = [string | number, string][];
 

--- a/src/lib/api/types.d.ts
+++ b/src/lib/api/types.d.ts
@@ -25,7 +25,7 @@ export type ViewerMode = ReadMode | WriteMode;
 
 export type Zoom = number | Sizes | "auto";
 
-export type ZoomLevels = [string | number, string][];
+export type ZoomLevels = [Zoom, string][];
 
 export type Maybe<T> = T | undefined;
 

--- a/src/lib/components/common/Paginator.svelte
+++ b/src/lib/components/common/Paginator.svelte
@@ -214,4 +214,14 @@
   .pageNumber.error {
     outline-color: var(--caution);
   }
+
+  @media (max-width: 40rem) {
+    .page {
+      display: none;
+    }
+
+    .current {
+      margin: 0 0.25rem;
+    }
+  }
 </style>

--- a/src/lib/components/icons/ZoomFit16.svelte
+++ b/src/lib/components/icons/ZoomFit16.svelte
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16">
+  <path
+    fill-rule="evenodd"
+    d="M0 7.5a7.5 7.5 0 1 1 13.307 4.747l2.473 2.473a.749.749 0 1 1-1.06 1.06l-2.473-2.473A7.5 7.5 0 0 1 0 7.5Zm7.5-6a6 6 0 1 0 0 12 6 6 0 0 0 0-12Z"
+  />
+  <path
+    fill-rule="evenodd"
+    d="M4 4H7V5.5H5.5V7H4ZM11 4H8V5.5H9.5V7H11ZM11 11H8V9.5H9.5V8H11ZM4 11H7V9.5H5.5V8H4Z"
+  />
+</svg>

--- a/src/lib/components/toolbars/PaginationToolbar.svelte
+++ b/src/lib/components/toolbars/PaginationToolbar.svelte
@@ -21,7 +21,6 @@
   import Zoom from "../viewer/Zoom.svelte";
 
   import { pageHashUrl, shouldPaginate } from "$lib/api/documents";
-  import { remToPx } from "$lib/utils/layout";
   import { scrollToPage } from "$lib/utils/scroll";
   import { sortedSections } from "$lib/utils/viewer";
   import { getViewerState } from "$lib/state/viewer.svelte";
@@ -30,10 +29,6 @@
 
   let sectionsOpen = $state(false);
   let width: number = $state(800);
-
-  let BREAKPOINTS = $derived({
-    TWO_ROWS: width <= remToPx(34),
-  });
 
   let document = $derived(viewer.document!);
   let sections = $derived(sortedSections(document));
@@ -63,11 +58,7 @@
   }
 </script>
 
-<div
-  class="toolbar"
-  class:twoRows={BREAKPOINTS.TWO_ROWS}
-  bind:clientWidth={width}
->
+<div class="toolbar" bind:clientWidth={width}>
   <div class="sections">
     {#if showPDF && (sections.length > 0 || canEditSections)}
       <Dropdown position="top-start" --offset="5px">
@@ -77,7 +68,7 @@
               {#snippet start()}
                 <ListOrdered16 />
               {/snippet}
-              Sections
+              <span class="sections-label"> Sections </span>
               {#snippet end()}
                 <ChevronUp12 />
               {/snippet}
@@ -173,12 +164,16 @@
   .zoom {
     flex: 1 1 12em;
   }
-  .toolbar.twoRows {
-    flex-wrap: wrap;
-    padding: 0.25rem;
-  }
-  .toolbar.twoRows .paginator {
-    order: -1;
-    flex: 1 1 100%;
+
+  @media (max-width: 40rem) {
+    .sections-label {
+      position: absolute;
+      clip: rect(1px, 1px, 1px, 1px);
+      padding: 0;
+      border: 0;
+      height: 1px;
+      width: 1px;
+      overflow: hidden;
+    }
   }
 </style>

--- a/src/lib/components/toolbars/PaginationToolbar.svelte
+++ b/src/lib/components/toolbars/PaginationToolbar.svelte
@@ -171,7 +171,7 @@
   }
   .sections,
   .zoom {
-    flex: 1 1 8em;
+    flex: 1 1 12em;
   }
   .toolbar.twoRows {
     flex-wrap: wrap;

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -229,7 +229,7 @@ Must be a child of a ViewerContext
 
   {#if viewer.currentNote && !Boolean(viewer.newNote) && viewer.currentNote.page_number === page_number}
     <div
-      class="note card"
+      class="note card pin-x"
       style={positionNote(viewer.currentNote, 1.5)}
       transition:fly={{ duration: 250, y: "-1.1rem" }}
     >
@@ -265,7 +265,7 @@ Must be a child of a ViewerContext
 
     {#if !drawing}
       <div
-        class="note card"
+        class="note card pin-x"
         style={positionNote(viewer.newNote, 1.5)}
         transition:fly={{ duration: 250, y: "-1.1rem" }}
       >
@@ -314,12 +314,10 @@ Must be a child of a ViewerContext
     position: absolute;
     left: -1.5rem;
     width: 44rem;
-    max-width: 100%;
     z-index: var(--z-note);
     background: var(--white);
     border: 1px solid var(--gray-2);
     box-shadow: var(--shadow-2);
-    transform: translateX(var(--scroll-left));
   }
 
   .card {

--- a/src/lib/components/viewer/AnnotationLayer.svelte
+++ b/src/lib/components/viewer/AnnotationLayer.svelte
@@ -319,6 +319,7 @@ Must be a child of a ViewerContext
     background: var(--white);
     border: 1px solid var(--gray-2);
     box-shadow: var(--shadow-2);
+    transform: translateX(var(--scroll-left));
   }
 
   .card {

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -14,15 +14,14 @@
   import PdfPage from "./PDFPage.svelte";
 
   import { scrollToPage } from "$lib/utils/scroll";
-  import { getSections, pageSizes, zoomToScale } from "$lib/utils/viewer";
+  import { getSections } from "$lib/utils/viewer";
   import { getViewerState } from "$lib/state/viewer.svelte";
   import Error from "../common/Error.svelte";
 
   const viewer = getViewerState();
 
   let document = $derived(viewer.document!);
-  let scale = $derived(zoomToScale(viewer.zoom));
-  let sizes = $derived(document.page_spec ? pageSizes(document.page_spec) : []);
+  let sizes = $derived(viewer.pageSizes);
   let sections = $derived(getSections(document));
 
   // handle missing page_spec
@@ -81,17 +80,23 @@
   -->
   <div class="sizer">
     <div class="pages">
-      {#if browser}
-        {#each sizes as [width, height], n}
-          {@const page_number = n + 1}
-          {#if sections[n]}
-            <h3 class="section">
-              {sections[n].title}
-            </h3>
-          {/if}
-          <PdfPage {page_number} {scale} {width} {height} />
-        {/each}
-      {/if}
+      <div
+        class="inner"
+        style:--scale-factor={viewer.scale.toFixed(2)}
+        bind:clientWidth={viewer.width}
+      >
+        {#if browser}
+          {#each sizes as [width, height], n}
+            {@const page_number = n + 1}
+            {#if sections[n]}
+              <h3 class="section">
+                {sections[n].title}
+              </h3>
+            {/if}
+            <PdfPage {page_number} {width} {height} />
+          {/each}
+        {/if}
+      </div>
     </div>
   </div>
 {/if}
@@ -103,24 +108,31 @@
     width: 100%;
   }
   .pages {
+    padding: 3rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+    width: 100%;
+  }
+  .inner {
     display: flex;
     flex-direction: column;
     margin: 0 auto;
-    padding: 3rem;
     gap: 1.5rem;
     width: 100%;
-    overflow-x: auto;
-    overflow-y: hidden;
   }
   @container (width < 35rem) {
     .pages {
       padding: 1.5rem;
+    }
+    .inner {
       gap: 0.75rem;
     }
   }
   @container (width > 70rem) {
     .pages {
       padding: 4.5rem;
+    }
+    .inner {
       gap: 2.25rem;
     }
   }

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -84,7 +84,6 @@
     <div class="pages" {@attach pinX}>
       <div
         class="inner"
-        style:--scale-factor={scale}
         bind:clientWidth={viewer.width}
       >
         {#if browser && viewer.width !== undefined}

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -25,6 +25,8 @@
   let sections = $derived(getSections(document));
   let scale = $derived(viewer.scale);
 
+  let scrollLeft = $state(0);
+
   // handle missing page_spec
   // (PDF normally only renders when the viewer loads one, but guard `pdf` in
   // case this component ends up in a viewer that never loads a PDF)
@@ -80,7 +82,12 @@
     resized — which would shift every page below the change (#1203).
   -->
   <div class="sizer">
-    <div class="pages">
+    <div
+      class="pages"
+      onscroll={({ target }: { target: HTMLDivElement }) =>
+        (scrollLeft = target.scrollLeft)}
+      style:--scroll-left="{scrollLeft}px"
+    >
       <div
         class="inner"
         style:--scale-factor={scale}
@@ -144,5 +151,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    transform: translateX(var(--scroll-left));
   }
 </style>

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -23,6 +23,7 @@
   let document = $derived(viewer.document!);
   let sizes = $derived(viewer.pageSizes);
   let sections = $derived(getSections(document));
+  let scale = $derived(viewer.scale);
 
   // handle missing page_spec
   // (PDF normally only renders when the viewer loads one, but guard `pdf` in
@@ -82,7 +83,7 @@
     <div class="pages">
       <div
         class="inner"
-        style:--scale-factor={viewer.scale.toFixed(2)}
+        style:--scale-factor={scale.toFixed(2)}
         bind:clientWidth={viewer.width}
       >
         {#if browser}
@@ -93,7 +94,7 @@
                 {sections[n].title}
               </h3>
             {/if}
-            <PdfPage {page_number} {width} {height} />
+            <PdfPage {page_number} {scale} {width} {height} />
           {/each}
         {/if}
       </div>

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -16,6 +16,7 @@
   import { scrollToPage } from "$lib/utils/scroll";
   import { getSections } from "$lib/utils/viewer";
   import { getViewerState } from "$lib/state/viewer.svelte";
+  import { pinX } from "$lib/utils/pinX.svelte";
   import Error from "../common/Error.svelte";
 
   const viewer = getViewerState();
@@ -24,8 +25,6 @@
   let sizes = $derived(viewer.pageSizes);
   let sections = $derived(getSections(document));
   let scale = $derived(viewer.scale);
-
-  let scrollLeft = $state(0);
 
   // handle missing page_spec
   // (PDF normally only renders when the viewer loads one, but guard `pdf` in
@@ -82,12 +81,7 @@
     resized — which would shift every page below the change (#1203).
   -->
   <div class="sizer">
-    <div
-      class="pages"
-      onscroll={({ target }: { target: HTMLDivElement }) =>
-        (scrollLeft = target.scrollLeft)}
-      style:--scroll-left="{scrollLeft}px"
-    >
+    <div class="pages" {@attach pinX}>
       <div
         class="inner"
         style:--scale-factor={scale}
@@ -97,7 +91,7 @@
           {#each sizes as [width, height], n}
             {@const page_number = n + 1}
             {#if sections[n]}
-              <h3 class="section">
+              <h3 class="section pin-x">
                 {sections[n].title}
               </h3>
             {/if}
@@ -151,6 +145,5 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    transform: translateX(var(--scroll-left));
   }
 </style>

--- a/src/lib/components/viewer/PDF.svelte
+++ b/src/lib/components/viewer/PDF.svelte
@@ -34,7 +34,7 @@
     pdf
       .then((p) => {
         if (sizes.length === 0) {
-          sizes = Array(p.numPages).fill([0, 0]);
+          viewer.pageSizes = Array(p.numPages).fill([0, 0]);
         }
       })
       .catch((e) => {
@@ -83,10 +83,10 @@
     <div class="pages">
       <div
         class="inner"
-        style:--scale-factor={scale.toFixed(2)}
+        style:--scale-factor={scale}
         bind:clientWidth={viewer.width}
       >
-        {#if browser}
+        {#if browser && viewer.width !== undefined}
           {#each sizes as [width, height], n}
             {@const page_number = n + 1}
             {#if sections[n]}

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -257,7 +257,7 @@ Selectable text can be rendered in one of two ways:
 <Page {page_number} track bind:width={pageWidth} bind:visible>
   {#snippet children({ visible })}
     {#if page_level_notes.length}
-      <div class="page-notes pin-x">
+      <div class={["page-notes", visible && "pin-x"]}>
         {#each page_level_notes as note}
           <Note {note} />
         {/each}
@@ -266,7 +266,7 @@ Selectable text can be rendered in one of two ways:
 
     <div
       bind:this={container}
-      class="page-container {orientation}"
+      class={["page-container", orientation, visible && "visible"]}
       class:visible
       class:debug
       style:--aspect={aspect}
@@ -320,6 +320,12 @@ Selectable text can be rendered in one of two ways:
     background-color: var(--white, white);
     box-shadow: var(--shadow-1);
     width: var(--width, "100%");
+    content-visibility: auto;
+  }
+
+  /* Onscreen pages can't use content-visiblity: auto because it clips the annotation layer */
+  .visible {
+    content-visibility: visible;
   }
 
   .page-notes {

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -256,6 +256,7 @@ Selectable text can be rendered in one of two ways:
     {/if}
 
     <div
+      bind:this={container}
       class="page-container {orientation}"
       class:visible
       class:debug

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -112,6 +112,12 @@ Selectable text can be rendered in one of two ways:
     if (!page) return;
 
     const viewport = page.getViewport({ scale });
+
+    if (textLayer) {
+      textLayer.update({ viewport });
+      return;
+    }
+
     const content = await page.getTextContent();
 
     textLayer = new pdfjs.TextLayer({

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -29,7 +29,7 @@ Selectable text can be rendered in one of two ways:
   import { isPageLevel } from "$lib/api/notes";
   import { getViewerState } from "$lib/state/viewer.svelte";
   import { getQuery } from "$lib/utils/search";
-  import { getNotes } from "$lib/utils/viewer";
+  import { getNotes, PT_TO_PX } from "$lib/utils/viewer";
 
   const viewer = getViewerState();
 
@@ -66,6 +66,11 @@ Selectable text can be rendered in one of two ways:
 
   // visibility, for loading optimization
   let visible: boolean = $state(false);
+
+  // Width and height props have already been converted from pt to px in `pageSizes`,
+  // but the PDF.js render methods use the unconverted pt values, so we need to pass
+  // them a converted scale
+  let pxScale = $derived(scale * PT_TO_PX);
 
   async function render(
     page: Maybe<PDFPageProxy>,
@@ -218,14 +223,14 @@ Selectable text can be rendered in one of two ways:
   let layoutWidth = $derived(Math.floor(width * scale));
   // we need to wait on both promises to render on initial load
   $effect(() => {
-    // Read `scale` synchronously so the effect tracks it as a dependency;
+    // Read `pxScale` synchronously so the effect tracks it as a dependency;
     // reading it only inside the async `.then` below would not register it,
-    // and numeric zoom changes (which flow through `scale`) wouldn't re-render.
-    scale;
+    // and numeric zoom changes (which flow through `pxScale`) wouldn't re-render.
+    pxScale;
     if (!visible) return;
     Promise.all([viewer.pdf, page]).then(([pdf, page]) => {
-      render(page, canvas, scale);
-      textPromise = renderTextLayer(page, textContainer, scale);
+      render(page, canvas, pxScale);
+      textPromise = renderTextLayer(page, textContainer, pxScale);
     });
   });
   $effect(() => {
@@ -267,7 +272,7 @@ Selectable text can be rendered in one of two ways:
       style:--aspect={aspect}
       style:--width="{layoutWidth}px"
       style:--height="{height}px"
-      style:--scale-factor={scale}
+      style:--scale-factor={pxScale}
       data-loaded={loaded}
       onclick={checkForHighlightClick}
       onkeydown={checkForHighlightClick}

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -34,6 +34,7 @@ Selectable text can be rendered in one of two ways:
 
   interface Props {
     page_number: number; // 1-indexed
+    scale: number;
     width: number;
     height: number;
     text?: TextPosition[];
@@ -44,6 +45,7 @@ Selectable text can be rendered in one of two ways:
 
   let {
     page_number,
+    scale,
     width = $bindable(),
     height = $bindable(),
     text = [],
@@ -63,9 +65,6 @@ Selectable text can be rendered in one of two ways:
 
   // visibility, for loading optimization
   let visible: boolean = $state(false);
-
-  // global document scale
-  let scale = $derived(viewer.scale);
 
   async function render(
     page, // pdf.getPage
@@ -209,6 +208,10 @@ Selectable text can be rendered in one of two ways:
   let layoutWidth = $derived(Math.floor(width * scale));
   // we need to wait on both promises to render on initial load
   $effect(() => {
+    // Read `scale` synchronously so the effect tracks it as a dependency;
+    // reading it only inside the async `.then` below would not register it,
+    // and numeric zoom changes (which flow through `scale`) wouldn't re-render.
+    scale;
     Promise.all([viewer.pdf, page]).then(([pdf, page]) => {
       render(page, canvas);
       textPromise = renderTextLayer(page, textContainer);

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -28,13 +28,12 @@ Selectable text can be rendered in one of two ways:
   import { isPageLevel } from "$lib/api/notes";
   import { getViewerState } from "$lib/state/viewer.svelte";
   import { getQuery } from "$lib/utils/search";
-  import { fitPage, getNotes } from "$lib/utils/viewer";
+  import { getNotes } from "$lib/utils/viewer";
 
   const viewer = getViewerState();
 
   interface Props {
     page_number: number; // 1-indexed
-    scale: number | "width" | "height";
     width: number;
     height: number;
     text?: TextPosition[];
@@ -45,7 +44,6 @@ Selectable text can be rendered in one of two ways:
 
   let {
     page_number,
-    scale,
     width = $bindable(),
     height = $bindable(),
     text = [],
@@ -66,11 +64,12 @@ Selectable text can be rendered in one of two ways:
   // visibility, for loading optimization
   let visible: boolean = $state(false);
 
+  // global document scale
+  let scale = $derived(viewer.scale);
+
   async function render(
     page, // pdf.getPage
     canvas: Maybe<HTMLCanvasElement>,
-    container: Maybe<HTMLElement>,
-    scale: number | "width" | "height",
   ) {
     // only one render task at a time;
     if (renderTask) {
@@ -78,11 +77,10 @@ Selectable text can be rendered in one of two ways:
     }
 
     // check that we have things
-    if (!canvas || !container || !scale || !page) return;
+    if (!canvas || !page) return;
 
-    const numericScale = fitPage(width, height, container, scale);
     const context = canvas.getContext("2d");
-    const viewport = page.getViewport({ scale: numericScale });
+    const viewport = page.getViewport({ scale });
     const dpr = window?.devicePixelRatio ?? 1;
 
     const transform = dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : null;
@@ -108,20 +106,14 @@ Selectable text can be rendered in one of two ways:
   async function renderTextLayer(
     page, // PdfPageProxy
     textContainer: Maybe<HTMLElement>,
-    pageContainer: Maybe<HTMLElement>,
-    scale: number | "width" | "height",
   ) {
     if (text.length > 0) return;
     if (!textContainer) return;
 
     if (!page) return;
 
-    const numericScale = fitPage(width, height, pageContainer, scale);
-    const viewport = page.getViewport({ scale: numericScale });
+    const viewport = page.getViewport({ scale });
     const content = await page.getTextContent();
-
-    // svelte's reactivity ends up a step behind, so do this here
-    container?.style.setProperty("--scale-factor", numericScale.toFixed(2));
 
     textLayer = new pdfjs.TextLayer({
       textContentSource: content,
@@ -170,10 +162,6 @@ Selectable text can be rendered in one of two ways:
     });
   }
 
-  function onResize() {
-    numericScale = fitPage(width, height, container, scale);
-  }
-
   function onVisibilityChange() {
     if (
       window.document.visibilityState === "visible" &&
@@ -181,7 +169,7 @@ Selectable text can be rendered in one of two ways:
       !canvas.hidden
     ) {
       Promise.all([viewer.pdf, page]).then(([pdf, page]) => {
-        render(page, canvas, container, scale);
+        render(page, canvas);
       });
     }
   }
@@ -214,29 +202,16 @@ Selectable text can be rendered in one of two ways:
   });
   let aspect = $derived(height / width);
   let orientation = $derived(height > width ? "vertical" : "horizontal");
-  // Recomputed reactively when its inputs change; `onResize` also writes to
-  // it directly to pick up window resizes, which don't emit a reactive signal.
-  let numericScale = $derived(fitPage(width, height, container, scale));
   // The box this page occupies, at the zoom it will render at. Sizing it from
   // the intrinsic page width instead would lay every not-yet-rendered page out
   // at 100% while rendered ones sit at the real zoom, so boxes — and everything
-  // below them — jump as pdf.js works through the document (#1203). Only used
-  // for numeric zoom; fit-width and fit-height size the container in CSS.
-  let layoutWidth = $derived(Math.floor(width * numericScale));
+  // below them — jump as pdf.js works through the document (#1203).
+  let layoutWidth = $derived(Math.floor(width * scale));
   // we need to wait on both promises to render on initial load
   $effect(() => {
-    // Read `scale` synchronously so the effect tracks it as a dependency;
-    // reading it only inside the async `.then` below would not register it,
-    // and numeric zoom changes (which flow through `scale`) wouldn't re-render.
-    const currentScale = scale;
     Promise.all([viewer.pdf, page]).then(([pdf, page]) => {
-      render(page, canvas, container, currentScale);
-      textPromise = renderTextLayer(
-        page,
-        textContainer,
-        container,
-        currentScale,
-      );
+      render(page, canvas);
+      textPromise = renderTextLayer(page, textContainer);
     });
   });
   $effect(() => {
@@ -258,14 +233,10 @@ Selectable text can be rendered in one of two ways:
   );
 </script>
 
-<svelte:window onresize={onResize} />
-
 <svelte:document onvisibilitychange={onVisibilityChange} />
 
 <Page
   {page_number}
-  wide={scale === "width"}
-  tall={scale === "height"}
   track
   onvisible={() => {
     visible = true;
@@ -282,12 +253,10 @@ Selectable text can be rendered in one of two ways:
     {/if}
 
     <div
-      bind:this={container}
-      class="page-container scale-{scale} {orientation}"
+      class="page-container {orientation}"
       class:visible
       class:debug
       style:--aspect={aspect}
-      style:--scale-factor={numericScale.toFixed(2)}
       style:--width="{layoutWidth}px"
       style:--height="{height}px"
       data-loaded={loaded}
@@ -337,16 +306,6 @@ Selectable text can be rendered in one of two ways:
     background-color: var(--white, white);
     box-shadow: var(--shadow-1);
     width: var(--width, "100%");
-  }
-
-  .page-container.scale-width {
-    width: 100%;
-  }
-
-  .page-container.scale-height {
-    aspect-ratio: 1 / var(--aspect);
-    height: 90vh;
-    width: inherit;
   }
 
   .page-notes {

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -68,7 +68,7 @@ Selectable text can be rendered in one of two ways:
   let visible: boolean = $state(false);
 
   async function render(
-    page, // pdf.getPage
+    page: Maybe<PDFPageProxy>,
     canvas: Maybe<HTMLCanvasElement>,
     scale: number,
   ) {
@@ -84,7 +84,7 @@ Selectable text can be rendered in one of two ways:
     const viewport = page.getViewport({ scale });
     const dpr = window?.devicePixelRatio ?? 1;
 
-    const transform = dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : null;
+    const transform = dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : undefined;
 
     // set the pixel dimensions of the canvas
     canvas.width = Math.floor(viewport.width * dpr);
@@ -96,7 +96,7 @@ Selectable text can be rendered in one of two ways:
 
     // store the task, return the promise
     renderTask = page.render({
-      canvasContext: context,
+      canvasContext: context!,
       viewport,
       transform,
     });
@@ -105,7 +105,7 @@ Selectable text can be rendered in one of two ways:
   }
 
   async function renderTextLayer(
-    page, // PdfPageProxy
+    page: Maybe<PDFPageProxy>,
     textContainer: Maybe<HTMLElement>,
     scale: number,
   ) {

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -69,6 +69,7 @@ Selectable text can be rendered in one of two ways:
   async function render(
     page, // pdf.getPage
     canvas: Maybe<HTMLCanvasElement>,
+    scale: number,
   ) {
     // only one render task at a time;
     if (renderTask) {
@@ -105,6 +106,7 @@ Selectable text can be rendered in one of two ways:
   async function renderTextLayer(
     page, // PdfPageProxy
     textContainer: Maybe<HTMLElement>,
+    scale: number,
   ) {
     if (text.length > 0) return;
     if (!textContainer) return;
@@ -174,7 +176,7 @@ Selectable text can be rendered in one of two ways:
       !canvas.hidden
     ) {
       Promise.all([viewer.pdf, page]).then(([pdf, page]) => {
-        render(page, canvas);
+        render(page, canvas, scale);
       });
     }
   }
@@ -219,8 +221,8 @@ Selectable text can be rendered in one of two ways:
     // and numeric zoom changes (which flow through `scale`) wouldn't re-render.
     scale;
     Promise.all([viewer.pdf, page]).then(([pdf, page]) => {
-      render(page, canvas);
-      textPromise = renderTextLayer(page, textContainer);
+      render(page, canvas, scale);
+      textPromise = renderTextLayer(page, textContainer, scale);
     });
   });
   $effect(() => {

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -326,6 +326,7 @@ Selectable text can be rendered in one of two ways:
     gap: 1rem;
     width: 100%;
     margin-bottom: 1rem;
+    transform: translateX(var(--scroll-left));
   }
 
   .selectable-text {

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -271,6 +271,7 @@ Selectable text can be rendered in one of two ways:
       style:--aspect={aspect}
       style:--width="{layoutWidth}px"
       style:--height="{height}px"
+      style:--scale-factor={scale}
       data-loaded={loaded}
       onclick={checkForHighlightClick}
       onkeydown={checkForHighlightClick}

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -311,7 +311,6 @@ Selectable text can be rendered in one of two ways:
     aspect-ratio: 1 / var(--aspect);
     margin: 0;
     position: relative;
-    content-visibility: auto;
 
     background-color: var(--white, white);
     box-shadow: var(--shadow-1);

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -256,7 +256,7 @@ Selectable text can be rendered in one of two ways:
 >
   {#snippet children({ visible })}
     {#if page_level_notes.length}
-      <div class="page-notes">
+      <div class="page-notes pin-x">
         {#each page_level_notes as note}
           <Note {note} />
         {/each}
@@ -326,7 +326,6 @@ Selectable text can be rendered in one of two ways:
     gap: 1rem;
     width: 100%;
     margin-bottom: 1rem;
-    transform: translateX(var(--scroll-left));
   }
 
   .selectable-text {

--- a/src/lib/components/viewer/PDFPage.svelte
+++ b/src/lib/components/viewer/PDFPage.svelte
@@ -11,6 +11,7 @@ Selectable text can be rendered in one of two ways:
 -->
 <script lang="ts">
   import type { Maybe, TextPosition } from "$lib/api/types";
+  import type { PDFPageProxy } from "pdfjs-dist/types/web/interfaces";
 
   import { page as pageState } from "$app/state";
 
@@ -186,14 +187,15 @@ Selectable text can be rendered in one of two ways:
     query = getQuery(pageState.url, "q");
   });
   let document = $derived(viewer.document!);
+  let page = $state<Promise<PDFPageProxy>>();
   // render when anything changes
   // (PDFPage normally only renders when the viewer loads a PDF, but guard `pdf`
   // in case this component ends up in a viewer that never loads a PDF)
-  let page = $derived(
-    visible && viewer.pdf
-      ? Promise.resolve(viewer.pdf).then((pdf) => pdf.getPage(page_number))
-      : undefined,
-  );
+  $effect(() => {
+    if (!visible || !viewer.pdf || page) return;
+    page = Promise.resolve(viewer.pdf).then((pdf) => pdf.getPage(page_number));
+  });
+
   // handle 0 sizing when page_spec is unavailable
   $effect(() => {
     // Capture the derived value in a local so TS can narrow it; reading the
@@ -220,6 +222,7 @@ Selectable text can be rendered in one of two ways:
     // reading it only inside the async `.then` below would not register it,
     // and numeric zoom changes (which flow through `scale`) wouldn't re-render.
     scale;
+    if (!visible) return;
     Promise.all([viewer.pdf, page]).then(([pdf, page]) => {
       render(page, canvas, scale);
       textPromise = renderTextLayer(page, textContainer, scale);
@@ -246,14 +249,7 @@ Selectable text can be rendered in one of two ways:
 
 <svelte:document onvisibilitychange={onVisibilityChange} />
 
-<Page
-  {page_number}
-  track
-  onvisible={() => {
-    visible = true;
-  }}
-  bind:width={pageWidth}
->
+<Page {page_number} track bind:width={pageWidth} bind:visible>
   {#snippet children({ visible })}
     {#if page_level_notes.length}
       <div class="page-notes pin-x">
@@ -315,6 +311,7 @@ Selectable text can be rendered in one of two ways:
     aspect-ratio: 1 / var(--aspect);
     margin: 0;
     position: relative;
+    content-visibility: auto;
 
     background-color: var(--white, white);
     box-shadow: var(--shadow-1);

--- a/src/lib/components/viewer/Page.svelte
+++ b/src/lib/components/viewer/Page.svelte
@@ -155,6 +155,7 @@ Must be a child of a ViewerContext
     align-items: center;
     align-self: stretch;
     transform: translateX(var(--scroll-left));
+    z-index: 1;
   }
 
   .pageNumber {

--- a/src/lib/components/viewer/Page.svelte
+++ b/src/lib/components/viewer/Page.svelte
@@ -21,8 +21,6 @@ Must be a child of a ViewerContext
 
   interface Props {
     page_number: number;
-    wide?: boolean;
-    tall?: boolean;
     track?: boolean | "once";
     width?: number | undefined;
     title?: Snippet;
@@ -32,8 +30,6 @@ Must be a child of a ViewerContext
 
   let {
     page_number,
-    wide = false,
-    tall = false,
     track = false,
     width = $bindable(undefined),
     title,
@@ -123,14 +119,7 @@ Must be a child of a ViewerContext
   });
 </script>
 
-<div
-  {id}
-  bind:this={container}
-  bind:clientWidth={width}
-  class="page"
-  class:wide
-  class:tall
->
+<div {id} bind:this={container} bind:clientWidth={width} class="page">
   <div class="title">{@render title?.()}</div>
   <header>
     <h4 class="pageNumber">
@@ -156,10 +145,6 @@ Must be a child of a ViewerContext
     position: relative;
     max-width: 100%;
     scroll-margin-top: 6rem;
-  }
-
-  .page.wide {
-    width: 100%;
   }
 
   header {

--- a/src/lib/components/viewer/Page.svelte
+++ b/src/lib/components/viewer/Page.svelte
@@ -25,7 +25,7 @@ Must be a child of a ViewerContext
     width?: number | undefined;
     title?: Snippet;
     children?: Snippet<[any]>;
-    onvisible?: () => void;
+    visible?: boolean;
   }
 
   let {
@@ -34,14 +34,13 @@ Must be a child of a ViewerContext
     width = $bindable(undefined),
     title,
     children,
-    onvisible,
+    visible = $bindable(false),
   }: Props = $props();
 
   const viewer = getViewerState();
 
   let io: IntersectionObserver;
   let container: Maybe<HTMLElement> = $state();
-  let visible = $state(false);
 
   let document = $derived(viewer.document!);
   let id = $derived(pageHashUrl(page_number).replace("#", ""));
@@ -70,7 +69,6 @@ Must be a child of a ViewerContext
           if (entry.isIntersecting) {
             // update state
             visible = true;
-            onvisible?.();
 
             if (once) {
               observer.unobserve(el);

--- a/src/lib/components/viewer/Page.svelte
+++ b/src/lib/components/viewer/Page.svelte
@@ -154,6 +154,7 @@ Must be a child of a ViewerContext
     justify-content: space-between;
     align-items: center;
     align-self: stretch;
+    transform: translateX(var(--scroll-left));
   }
 
   .pageNumber {

--- a/src/lib/components/viewer/Page.svelte
+++ b/src/lib/components/viewer/Page.svelte
@@ -121,7 +121,7 @@ Must be a child of a ViewerContext
 
 <div {id} bind:this={container} bind:clientWidth={width} class="page">
   <div class="title">{@render title?.()}</div>
-  <header>
+  <header class="pin-x">
     <h4 class="pageNumber">
       <a href={documentHref}>
         {$_("documents.pageAbbrev")}
@@ -154,7 +154,6 @@ Must be a child of a ViewerContext
     justify-content: space-between;
     align-items: center;
     align-self: stretch;
-    transform: translateX(var(--scroll-left));
     z-index: 1;
   }
 

--- a/src/lib/components/viewer/Page.svelte
+++ b/src/lib/components/viewer/Page.svelte
@@ -119,7 +119,7 @@ Must be a child of a ViewerContext
 
 <div {id} bind:this={container} bind:clientWidth={width} class="page">
   <div class="title">{@render title?.()}</div>
-  <header class="pin-x">
+  <header class={visible && "pin-x"}>
     <h4 class="pageNumber">
       <a href={documentHref}>
         {$_("documents.pageAbbrev")}

--- a/src/lib/components/viewer/Zoom.svelte
+++ b/src/lib/components/viewer/Zoom.svelte
@@ -24,7 +24,7 @@ Must be a child of a ViewerContext
   let initial = $derived(getInitialZoom(page.url, viewer.mode));
 
   let [zoomOut, zoomIn] = $derived(
-    getZoomInOut(viewer.mode, viewer.zoom, viewer.autoZoomScale),
+    getZoomInOut(viewer.mode, viewer.zoom, viewer.scale),
   );
 
   $effect(() => {

--- a/src/lib/components/viewer/Zoom.svelte
+++ b/src/lib/components/viewer/Zoom.svelte
@@ -32,7 +32,10 @@ Must be a child of a ViewerContext
     {/if}
     <select name="zoom" bind:value={viewer.zoom}>
       {#each zoomLevels as [value, label]}
-        <option {value}>{$_(label)}</option>
+        <option {value}>
+          {$_(label)}
+          {#if value === "auto"}({Math.round(viewer.autoZoomScale * 100)}%){/if}
+        </option>
       {/each}
     </select>
   </label>

--- a/src/lib/components/viewer/Zoom.svelte
+++ b/src/lib/components/viewer/Zoom.svelte
@@ -95,4 +95,10 @@ Must be a child of a ViewerContext
     box-shadow: none;
     margin-left: 0.25rem;
   }
+
+  @media (max-width: 40rem) {
+    select {
+      display: none;
+    }
+  }
 </style>

--- a/src/lib/components/viewer/Zoom.svelte
+++ b/src/lib/components/viewer/Zoom.svelte
@@ -11,54 +11,79 @@ Must be a child of a ViewerContext
     getDefaultZoom,
     getZoomLevels,
     getInitialZoom,
+    getZoomInOut,
   } from "$lib/utils/viewer";
   import { getViewerState } from "$lib/state/viewer.svelte";
+
+  import Button from "$lib/components/common/Button.svelte";
+  import { ZoomIn16, ZoomOut16 } from "svelte-octicons";
 
   const viewer = getViewerState();
 
   let zoomLevels = $derived(getZoomLevels(viewer.mode));
   let initial = $derived(getInitialZoom(page.url, viewer.mode));
+
+  let [zoomOut, zoomIn] = $derived(
+    getZoomInOut(viewer.mode, viewer.zoom, viewer.autoZoomScale),
+  );
+
   $effect(() => {
     viewer.zoom = initial || getDefaultZoom(viewer.mode);
   });
 </script>
 
-{#if zoomLevels.length}
-  <label class="zoom">
-    {#if viewer.mode === "grid"}
-      {$_("zoom.size")}
-    {:else}
-      {$_("zoom.zoom")}
-    {/if}
-    <select name="zoom" bind:value={viewer.zoom}>
-      {#each zoomLevels as [value, label]}
-        <option {value}>
-          {$_(label)}
-          {#if value === "auto"}({Math.round(viewer.autoZoomScale * 100)}%){/if}
-        </option>
-      {/each}
-    </select>
-  </label>
-{/if}
+<div class="zoom">
+  {#if zoomLevels.length}
+    <Button
+      mode="primary"
+      size="small"
+      ghost
+      minW={false}
+      aria-label={$_("zoom.zoomOut")}
+      disabled={zoomOut === null}
+      onclick={() => (viewer.zoom = zoomOut!)}
+    >
+      <ZoomOut16 />
+    </Button>
+    <Button
+      mode="primary"
+      size="small"
+      ghost
+      minW={false}
+      aria-label={$_("zoom.zoomIn")}
+      disabled={zoomIn === null}
+      onclick={() => (viewer.zoom = zoomIn!)}
+    >
+      <ZoomIn16 />
+    </Button>
+    <label>
+      <span class="sr-only">
+        {#if viewer.mode === "grid"}
+          {$_("zoom.size")}
+        {:else}
+          {$_("zoom.zoom")}
+        {/if}
+      </span>
+      <select name="zoom" bind:value={viewer.zoom}>
+        {#each zoomLevels as [value, label]}
+          <option {value}>
+            {$_(label)}
+            {#if value === "auto"}
+              ({Math.round(viewer.autoZoomScale * 100)}%)
+            {/if}
+          </option>
+        {/each}
+      </select>
+    </label>
+  {/if}
+</div>
 
 <style>
-  label {
-    visibility: hidden;
-  }
-
-  select {
-    visibility: visible;
-  }
-
-  label.zoom {
+  .zoom {
     display: flex;
+    flex-direction: row;
     align-items: center;
-    gap: 0.5rem;
-    font-size: var(--font-md);
-  }
-
-  label.zoom {
-    justify-content: right;
+    justify-content: end;
   }
 
   select {
@@ -68,5 +93,6 @@ Must be a child of a ViewerContext
     font-family: var(--font-sans);
     font-size: var(--font-md);
     box-shadow: none;
+    margin-left: 0.25rem;
   }
 </style>

--- a/src/lib/components/viewer/Zoom.svelte
+++ b/src/lib/components/viewer/Zoom.svelte
@@ -32,8 +32,8 @@ Must be a child of a ViewerContext
   });
 </script>
 
-<div class="zoom">
-  {#if zoomLevels.length}
+{#if zoomLevels.length}
+  <div class="zoom">
     <Button
       mode="primary"
       size="small"
@@ -75,8 +75,8 @@ Must be a child of a ViewerContext
         {/each}
       </select>
     </label>
-  {/if}
-</div>
+  </div>
+{/if}
 
 <style>
   .zoom {

--- a/src/lib/components/viewer/Zoom.svelte
+++ b/src/lib/components/viewer/Zoom.svelte
@@ -16,6 +16,7 @@ Must be a child of a ViewerContext
   import { getViewerState } from "$lib/state/viewer.svelte";
 
   import Button from "$lib/components/common/Button.svelte";
+  import ZoomFit16 from "$lib/components/icons/ZoomFit16.svelte";
   import { ZoomIn16, ZoomOut16 } from "svelte-octicons";
 
   const viewer = getViewerState();
@@ -45,6 +46,21 @@ Must be a child of a ViewerContext
     >
       <ZoomOut16 />
     </Button>
+    {#if viewer.mode === "document"}
+      <div class="auto">
+        <Button
+          mode="primary"
+          size="small"
+          ghost
+          minW={false}
+          hover={viewer.zoom === "auto"}
+          aria-label={$_("zoom.auto")}
+          onclick={() => (viewer.zoom = "auto")}
+        >
+          <ZoomFit16 />
+        </Button>
+      </div>
+    {/if}
     <Button
       mode="primary"
       size="small"
@@ -96,9 +112,17 @@ Must be a child of a ViewerContext
     margin-left: 0.25rem;
   }
 
+  .auto {
+    display: none;
+  }
+
   @media (max-width: 40rem) {
     select {
       display: none;
+    }
+
+    .auto {
+      display: block;
     }
   }
 </style>

--- a/src/lib/components/viewer/stories/PDF.stories.svelte
+++ b/src/lib/components/viewer/stories/PDF.stories.svelte
@@ -46,9 +46,9 @@
       mode: "document",
       asset_url: pdfUrl(document),
     },
-    props: {
-      scale: "width",
-    },
+    // PDF takes no props: zoom is read from the viewer state, so stories set
+    // it through ViewerContext's `zoom` instead.
+    props: {},
   };
 </script>
 
@@ -68,15 +68,15 @@
 />
 
 <Story
-  name="Fit width"
+  name="Auto zoom"
   parameters={{ layout: "fullscreen" }}
-  args={{ ...args, props: { scale: "width" } }}
+  args={{ ...args, context: { ...args.context, zoom: "auto" } }}
 />
 
 <Story
   name="Zoom 200%"
   parameters={{ layout: "fullscreen" }}
-  args={{ ...args, props: { scale: 2 } }}
+  args={{ ...args, context: { ...args.context, zoom: 2 } }}
 />
 
 <Story

--- a/src/lib/components/viewer/stories/PDFPage.stories.svelte
+++ b/src/lib/components/viewer/stories/PDFPage.stories.svelte
@@ -32,9 +32,11 @@
   const url = new URL(pdfFile, import.meta.url);
 </script>
 
-<Story name="fit width" parameters={{ layout: "fullscreen" }} asChild>
+<!-- PDFPage always renders at a numeric scale now; the viewer resolves "auto"
+     to one before passing it down. -->
+<Story name="full size" parameters={{ layout: "fullscreen" }} asChild>
   <ViewerContext {document} asset_url={url}>
-    <PdfPage page_number={1} scale="width" {width} {height} />
+    <PdfPage page_number={1} scale={1} {width} {height} />
   </ViewerContext>
 </Story>
 
@@ -82,6 +84,6 @@
 
 <Story name="long section start" parameters={{ layout: "fullscreen" }} asChild>
   <ViewerContext {document} asset_url={url}>
-    <PdfPage page_number={1} scale="width" {width} {height} />
+    <PdfPage page_number={1} scale={1} {width} {height} />
   </ViewerContext>
 </Story>

--- a/src/lib/components/viewer/tests/PDF.test.ts
+++ b/src/lib/components/viewer/tests/PDF.test.ts
@@ -57,6 +57,23 @@ describe("PDF", () => {
     );
   });
 
+  it("publishes the measurements that `pin-x` descendants read", () => {
+    const { container } = renderInViewer(PDF, {
+      context: { document, mode: "document" },
+    });
+
+    const pages = container.querySelector(".pages") as HTMLElement;
+
+    expect(pages.style.getPropertyValue("--scroll-range")).toMatch(/px$/);
+    expect(pages.style.getPropertyValue("--pin-width")).toMatch(/px$/);
+    // CSS.supports is stubbed false in vitest-setup, so this is the fallback
+    // path, which tracks scroll position as well
+    expect(pages.style.getPropertyValue("--scroll-left")).toMatch(/px$/);
+    expect(
+      container.querySelector(".section, .page-notes, header"),
+    ).toHaveClass("pin-x");
+  });
+
   it("shows an error view instead of pages when loading failed", () => {
     const { container } = renderInViewer(PDF, {
       context: {

--- a/src/lib/components/viewer/tests/PDF.test.ts
+++ b/src/lib/components/viewer/tests/PDF.test.ts
@@ -69,9 +69,6 @@ describe("PDF", () => {
     // CSS.supports is stubbed false in vitest-setup, so this is the fallback
     // path, which tracks scroll position as well
     expect(pages.style.getPropertyValue("--scroll-left")).toMatch(/px$/);
-    expect(
-      container.querySelector(".section, .page-notes, header"),
-    ).toHaveClass("pin-x");
   });
 
   it("shows an error view instead of pages when loading failed", () => {

--- a/src/lib/components/viewer/tests/Zoom.test.ts
+++ b/src/lib/components/viewer/tests/Zoom.test.ts
@@ -7,8 +7,9 @@
  * Only genuinely external dependencies are mocked: pdfjs (network) and the
  * SvelteKit router.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
 import { readable } from "svelte/store";
 
 // pdfjs would hit the network when ViewerContext mounts and loads the PDF.
@@ -20,11 +21,23 @@ vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
   })),
 }));
 
+const DOC_URL = "https://www.documentcloud.org/documents/2622-doc/";
+
+// Zoom reads `page.url` to pick up an initial zoom from the query string, so
+// keep it mutable: it's the only way a test can seed a starting zoom (Zoom's
+// own effect overwrites whatever ViewerContext seeded).
+const { pageUrl } = vi.hoisted(() => ({ pageUrl: { current: "" } }));
+
 // ViewerContext reads the page store; Zoom reads it for the initial zoom.
 vi.mock("$app/stores", () => ({
-  page: readable({
-    url: new URL("https://www.documentcloud.org/documents/2622-doc/"),
-  }),
+  page: readable({ url: new URL(DOC_URL) }),
+}));
+vi.mock("$app/state", () => ({
+  page: {
+    get url() {
+      return new URL(pageUrl.current);
+    },
+  },
 }));
 vi.mock("$app/navigation", () => ({ afterNavigate: vi.fn() }));
 
@@ -41,13 +54,28 @@ function optionValues() {
   );
 }
 
+const zoomIn = () => screen.getByRole("button", { name: "Zoom In" });
+const zoomOut = () => screen.getByRole("button", { name: "Zoom Out" });
+
+/** Render Zoom with an optional `?zoom=` seeding the starting zoom level. */
+function renderZoom(mode: string, zoom?: string) {
+  const url = new URL(DOC_URL);
+  if (zoom !== undefined) url.searchParams.set("zoom", zoom);
+  pageUrl.current = url.href;
+
+  return renderInViewer(Zoom, { context: { document, mode: mode as any } });
+}
+
+beforeEach(() => {
+  pageUrl.current = DOC_URL;
+});
+
 describe("Zoom", () => {
-  it("offers width/height fit plus percentages in document mode", () => {
-    renderInViewer(Zoom, { context: { document, mode: "document" } });
+  it("offers auto fit plus percentages in document mode", () => {
+    renderZoom("document");
 
     expect(optionValues()).toEqual([
-      "width",
-      "height",
+      "auto",
       "0.5",
       "0.75",
       "1",
@@ -57,20 +85,106 @@ describe("Zoom", () => {
     ]);
   });
 
-  it("defaults to fit-width in document mode", () => {
-    renderInViewer(Zoom, { context: { document, mode: "document" } });
-    expect(screen.getByRole("combobox")).toHaveValue("width");
+  it("defaults to auto in document mode", () => {
+    renderZoom("document");
+    expect(screen.getByRole("combobox")).toHaveValue("auto");
+  });
+
+  it("shows the resolved percentage alongside the auto option", () => {
+    renderZoom("document");
+    // Zoom renders standalone here, so no width is measured and auto resolves
+    // to 100% — the point is that the option reports a concrete percentage.
+    expect(
+      screen.getByRole("option", { name: /Auto \(100%\)/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("labels the select for screen readers without showing the text", () => {
+    renderZoom("document");
+    expect(screen.getByLabelText("Zoom")).toBe(screen.getByRole("combobox"));
   });
 
   it("offers only size presets in grid mode and defaults to small", () => {
-    renderInViewer(Zoom, { context: { document, mode: "grid" } });
+    renderZoom("grid");
 
     expect(optionValues()).toEqual(["thumbnail", "small", "normal", "large"]);
     expect(screen.getByRole("combobox")).toHaveValue("small");
   });
 
   it("renders no control in notes mode (notes don't zoom)", () => {
-    renderInViewer(Zoom, { context: { document, mode: "notes" } });
+    renderZoom("notes");
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  describe("zoom in/out buttons", () => {
+    it("steps up to the next level and syncs the select", async () => {
+      const user = userEvent.setup();
+      renderZoom("document", "1");
+
+      await user.click(zoomIn());
+
+      expect(screen.getByRole("combobox")).toHaveValue("1.25");
+    });
+
+    it("steps down to the previous level and syncs the select", async () => {
+      const user = userEvent.setup();
+      renderZoom("document", "1");
+
+      await user.click(zoomOut());
+
+      expect(screen.getByRole("combobox")).toHaveValue("0.75");
+    });
+
+    it("steps away from auto using the resolved scale", async () => {
+      const user = userEvent.setup();
+      renderZoom("document");
+
+      // auto resolves to 100% here, so zooming in lands on 125%
+      expect(screen.getByRole("combobox")).toHaveValue("auto");
+      await user.click(zoomIn());
+
+      expect(screen.getByRole("combobox")).toHaveValue("1.25");
+    });
+
+    it("disables zoom out at the smallest level", () => {
+      renderZoom("document", "0.5");
+
+      expect(zoomOut()).toBeDisabled();
+      expect(zoomIn()).toBeEnabled();
+    });
+
+    it("disables zoom in at the largest level", () => {
+      renderZoom("document", "2");
+
+      expect(zoomIn()).toBeDisabled();
+      expect(zoomOut()).toBeEnabled();
+    });
+
+    it("steps through the size presets in grid mode", async () => {
+      const user = userEvent.setup();
+      renderZoom("grid");
+
+      expect(screen.getByRole("combobox")).toHaveValue("small");
+
+      await user.click(zoomIn());
+      expect(screen.getByRole("combobox")).toHaveValue("normal");
+
+      await user.click(zoomOut());
+      expect(screen.getByRole("combobox")).toHaveValue("small");
+    });
+
+    it("disables both ends of the grid presets", async () => {
+      const user = userEvent.setup();
+      renderZoom("grid", "thumbnail");
+
+      expect(zoomOut()).toBeDisabled();
+
+      await user.click(zoomIn());
+      await user.click(zoomIn());
+      await user.click(zoomIn());
+
+      expect(screen.getByRole("combobox")).toHaveValue("large");
+      expect(zoomIn()).toBeDisabled();
+    });
   });
 });

--- a/src/lib/state/tests/viewer.test.svelte.ts
+++ b/src/lib/state/tests/viewer.test.svelte.ts
@@ -30,6 +30,7 @@ vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => ({
 vi.mock("$lib/api/documents", () => ({ assetUrl }));
 
 import { ViewerState } from "$lib/state/viewer.svelte";
+import { PT_TO_PX } from "$lib/utils/viewer";
 import documentFixture from "@/test/fixtures/documents/document.json";
 
 const doc = documentFixture as unknown as Document;
@@ -163,7 +164,8 @@ describe("ViewerState", () => {
   // renders at one uniform scale. The fixture's page_spec is
   // "595.0x842.0:0-6" — seven A4 pages 595pt wide.
   describe("zoom", () => {
-    const PAGE_WIDTH = 595;
+    const PAGE_WIDTH = 595 * PT_TO_PX;
+    const PAGE_HEIGHT = 842 * PT_TO_PX;
 
     /** A viewer showing the fixture document, laid out at `width` px. */
     function viewerWithWidth(width?: number) {
@@ -176,9 +178,9 @@ describe("ViewerState", () => {
     it("derives pageSizes from the document's page_spec", () => {
       const v = viewerWithWidth();
       expect(v.pageSizes).toHaveLength(doc.page_count);
-      expect(v.pageSizes.every(([w, h]) => w === PAGE_WIDTH && h === 842)).toBe(
-        true,
-      );
+      expect(
+        v.pageSizes.every(([w, h]) => w === PAGE_WIDTH && h === PAGE_HEIGHT),
+      ).toBe(true);
     });
 
     it("derives empty pageSizes when the document has no page_spec", () => {
@@ -219,7 +221,7 @@ describe("ViewerState", () => {
       // one landscape page twice as wide as the rest drives the scale
       const v = new ViewerState();
       v.document = { ...doc, page_spec: "595x842:0-5;1190x842:6" } as Document;
-      v.width = 595;
+      v.width = PAGE_WIDTH;
       expect(v.autoZoomScale).toBe(0.5);
     });
 

--- a/src/lib/state/tests/viewer.test.svelte.ts
+++ b/src/lib/state/tests/viewer.test.svelte.ts
@@ -62,6 +62,9 @@ describe("ViewerState", () => {
     expect(v.currentNote).toBeNull();
     expect(v.newNote).toBeNull();
     expect(v.progress).toEqual({ loaded: 0, total: 0 });
+    // the viewport width is only known once the PDF pane has laid out
+    expect(v.width).toBeUndefined();
+    expect(v.pageSizes).toEqual([]);
   });
 
   it("loadingProgress guards against a zero total", () => {
@@ -154,5 +157,104 @@ describe("ViewerState", () => {
     // 1 initial + 5 retries
     await vi.waitFor(() => expect(getDocument).toHaveBeenCalledTimes(6));
     await vi.waitFor(() => expect(v.errors).toContain(err));
+  });
+
+  // Zoom is computed here rather than per-page so every page in the document
+  // renders at one uniform scale. The fixture's page_spec is
+  // "595.0x842.0:0-6" — seven A4 pages 595pt wide.
+  describe("zoom", () => {
+    const PAGE_WIDTH = 595;
+
+    /** A viewer showing the fixture document, laid out at `width` px. */
+    function viewerWithWidth(width?: number) {
+      const v = new ViewerState();
+      v.document = doc;
+      v.width = width;
+      return v;
+    }
+
+    it("derives pageSizes from the document's page_spec", () => {
+      const v = viewerWithWidth();
+      expect(v.pageSizes).toHaveLength(doc.page_count);
+      expect(v.pageSizes.every(([w, h]) => w === PAGE_WIDTH && h === 842)).toBe(
+        true,
+      );
+    });
+
+    it("derives empty pageSizes when the document has no page_spec", () => {
+      const v = new ViewerState();
+      v.document = { ...doc, page_spec: undefined } as Document;
+      expect(v.pageSizes).toEqual([]);
+    });
+
+    it("allows pageSizes to be overridden when page_spec is missing", () => {
+      // PDF.svelte falls back to placeholder sizes from the pdfjs page count
+      const v = new ViewerState();
+      v.document = { ...doc, page_spec: undefined } as Document;
+      v.pageSizes = Array(3).fill([0, 0]);
+      expect(v.pageSizes).toEqual([
+        [0, 0],
+        [0, 0],
+        [0, 0],
+      ]);
+    });
+
+    it("autoZoomScale is 1 until the viewport width is measured", () => {
+      expect(viewerWithWidth(undefined).autoZoomScale).toBe(1);
+      // a zero width means the pane hasn't laid out yet, not "infinitely small"
+      expect(viewerWithWidth(0).autoZoomScale).toBe(1);
+    });
+
+    it("autoZoomScale shrinks the document to fit a narrow viewport", () => {
+      expect(viewerWithWidth(PAGE_WIDTH / 2).autoZoomScale).toBe(0.5);
+      expect(viewerWithWidth(PAGE_WIDTH).autoZoomScale).toBe(1);
+    });
+
+    it("autoZoomScale never enlarges past the intrinsic page size", () => {
+      // a wide viewport caps at 100% rather than blowing the pages up
+      expect(viewerWithWidth(PAGE_WIDTH * 4).autoZoomScale).toBe(1);
+    });
+
+    it("autoZoomScale fits the widest page in a mixed-size document", () => {
+      // one landscape page twice as wide as the rest drives the scale
+      const v = new ViewerState();
+      v.document = { ...doc, page_spec: "595x842:0-5;1190x842:6" } as Document;
+      v.width = 595;
+      expect(v.autoZoomScale).toBe(0.5);
+    });
+
+    it("scale uses a numeric zoom verbatim", () => {
+      const v = viewerWithWidth(PAGE_WIDTH / 2);
+      v.zoom = 1.5;
+      expect(v.scale).toBe(1.5);
+      v.zoom = 0.75;
+      expect(v.scale).toBe(0.75);
+    });
+
+    it("scale follows autoZoomScale when zoom is 'auto'", () => {
+      const v = viewerWithWidth(PAGE_WIDTH / 2);
+      v.zoom = "auto";
+      expect(v.scale).toBe(0.5);
+    });
+
+    it("scale recomputes when the viewport is resized in 'auto'", () => {
+      const v = viewerWithWidth(PAGE_WIDTH / 2);
+      v.zoom = "auto";
+      expect(v.scale).toBe(0.5);
+
+      v.width = PAGE_WIDTH / 4;
+      expect(v.scale).toBe(0.25);
+
+      // ...but a fixed zoom ignores the viewport entirely
+      v.zoom = 1;
+      expect(v.scale).toBe(1);
+    });
+
+    it("scale falls back to 1 for a non-numeric, non-auto zoom", () => {
+      // grid mode uses size names ("small"), which don't map to a PDF scale
+      const v = viewerWithWidth(PAGE_WIDTH / 2);
+      v.zoom = "small";
+      expect(v.scale).toBe(1);
+    });
   });
 });

--- a/src/lib/state/viewer.svelte.ts
+++ b/src/lib/state/viewer.svelte.ts
@@ -21,6 +21,7 @@ import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
 import { createContext } from "svelte";
 
 import { assetUrl } from "$lib/api/documents";
+import { pageSizes } from "$lib/utils/viewer";
 
 if (!pdfjs.GlobalWorkerOptions.workerSrc) {
   pdfjs.GlobalWorkerOptions.workerSrc = new URL(
@@ -54,6 +55,23 @@ export class ViewerState {
   // internal PDF loading state
   #task: Nullable<pdfjs.PDFDocumentLoadingTask> = null;
   #retriesOn403Error = 0;
+
+  // state and deriveds for zoom calculations
+  // regardless of zoom mode, we always calculate auto zoom scale to display in select menu
+  width = $state<number>();
+  pageSizes = $derived(
+    this.document?.page_spec ? pageSizes(this.document.page_spec) : [],
+  );
+  autoZoomScale = $derived.by(() => {
+    if (!this.width) return 1;
+    const maxPageWidth = Math.max(...this.pageSizes.map(([w]) => w));
+    return Math.min(1, this.width / maxPageWidth);
+  });
+  scale = $derived.by(() => {
+    if (typeof this.zoom === "number") return this.zoom;
+    if (this.zoom === "auto") return this.autoZoomScale;
+    return 1;
+  });
 
   get loadingProgress(): number {
     if (this.progress.total === 0) return 0;

--- a/src/lib/utils/pinX.svelte.ts
+++ b/src/lib/utils/pinX.svelte.ts
@@ -1,0 +1,56 @@
+import { getViewerState } from "$lib/state/viewer.svelte";
+
+/**
+ * Attachment that handles custom CSS properties for the pin-x class,
+ * which pins UI elements horizontally within the PDF viewer.
+ */
+
+const PROPERTIES = ["--scroll-range", "--pin-width", "--scroll-left"] as const;
+
+export function pinX(element: HTMLElement) {
+  const viewer = getViewerState();
+
+  // Scroll-driven animations: Chrome 115+, Safari 26+, Firefox 144+.
+  const animate = CSS.supports("animation-timeline: scroll()");
+
+  function measure(): void {
+    const { paddingLeft, paddingRight } = getComputedStyle(element);
+    const padding = parseFloat(paddingLeft) + parseFloat(paddingRight);
+
+    element.style.setProperty(
+      "--scroll-range",
+      `${element.scrollWidth - element.clientWidth}px`,
+    );
+    element.style.setProperty(
+      "--pin-width",
+      `${element.clientWidth - padding}px`,
+    );
+  }
+
+  function onScroll(): void {
+    element.style.setProperty("--scroll-left", `${element.scrollLeft}px`);
+  }
+
+  $effect(() => {
+    void viewer.scale;
+    void viewer.pageSizes;
+
+    measure();
+  });
+
+  const observer = new ResizeObserver(measure);
+  observer.observe(element);
+
+  if (!animate) {
+    onScroll();
+    element.addEventListener("scroll", onScroll, { passive: true });
+  }
+
+  return () => {
+    observer.disconnect();
+    element.removeEventListener("scroll", onScroll);
+    for (const property of PROPERTIES) {
+      element.style.removeProperty(property);
+    }
+  };
+}

--- a/src/lib/utils/tests/__snapshots__/viewer.test.ts.snap
+++ b/src/lib/utils/tests/__snapshots__/viewer.test.ts.snap
@@ -3,12 +3,8 @@
 exports[`zoom > getZoomLevels 1`] = `
 [
   [
-    "width",
-    "zoom.fitWidth",
-  ],
-  [
-    "height",
-    "zoom.fitHeight",
+    "auto",
+    "zoom.auto",
   ],
   [
     0.5,
@@ -92,12 +88,8 @@ exports[`zoom > getZoomLevels 4`] = `[]`;
 exports[`zoom > getZoomLevels 5`] = `
 [
   [
-    "width",
-    "zoom.fitWidth",
-  ],
-  [
-    "height",
-    "zoom.fitHeight",
+    "auto",
+    "zoom.auto",
   ],
   [
     0.5,
@@ -129,12 +121,8 @@ exports[`zoom > getZoomLevels 5`] = `
 exports[`zoom > getZoomLevels 6`] = `
 [
   [
-    "width",
-    "zoom.fitWidth",
-  ],
-  [
-    "height",
-    "zoom.fitHeight",
+    "auto",
+    "zoom.auto",
   ],
   [
     0.5,

--- a/src/lib/utils/tests/viewer.test.ts
+++ b/src/lib/utils/tests/viewer.test.ts
@@ -14,6 +14,7 @@ import {
   getDefaultZoom,
   getInitialZoom,
   getZoomInOut,
+  PT_TO_PX,
 } from "../viewer";
 import {
   canonicalUrl,
@@ -78,10 +79,10 @@ describe("pageSizes", () => {
   });
   it("checks each part for a comma-delimited value", () => {
     expect(pageSizes("1x1:0;2x2:1-3")).toEqual([
-      [1, 1],
-      [2, 2],
-      [2, 2],
-      [2, 2],
+      [1 * PT_TO_PX, 1 * PT_TO_PX],
+      [2 * PT_TO_PX, 2 * PT_TO_PX],
+      [2 * PT_TO_PX, 2 * PT_TO_PX],
+      [2 * PT_TO_PX, 2 * PT_TO_PX],
     ]);
   });
 });

--- a/src/lib/utils/tests/viewer.test.ts
+++ b/src/lib/utils/tests/viewer.test.ts
@@ -13,6 +13,7 @@ import {
   getZoomLevels,
   getDefaultZoom,
   getInitialZoom,
+  getZoomInOut,
 } from "../viewer";
 import {
   canonicalUrl,
@@ -114,12 +115,24 @@ describe("zoom", () => {
   });
 
   test("getDefaultZoom", () => {
-    expect(getDefaultZoom("document")).toEqual("width");
+    expect(getDefaultZoom("document")).toEqual("auto");
     expect(getDefaultZoom("text")).toEqual(1);
     expect(getDefaultZoom("grid")).toEqual("small");
     expect(getDefaultZoom("notes")).toEqual(1);
-    expect(getDefaultZoom("annotating")).toEqual("width");
-    expect(getDefaultZoom("redacting")).toEqual("width");
+    expect(getDefaultZoom("annotating")).toEqual("auto");
+    expect(getDefaultZoom("redacting")).toEqual("auto");
+  });
+
+  test("getZoomLevels offers auto plus percentages in page modes", () => {
+    // "auto" replaced the old fit-width/fit-height options
+    (["document", "annotating", "redacting"] as ViewerMode[]).forEach(
+      (mode) => {
+        const values = getZoomLevels(mode).map(([value]) => value);
+        expect(values).toEqual(["auto", 0.5, 0.75, 1, 1.25, 1.5, 2]);
+        expect(values).not.toContain("width");
+        expect(values).not.toContain("height");
+      },
+    );
   });
 
   test("getZoomLevels", () => {
@@ -201,6 +214,70 @@ describe("zoom", () => {
 
       expect(result).toBeUndefined();
     });
+  });
+});
+
+describe("getZoomInOut", () => {
+  // The zoom in/out buttons step through the mode's zoom levels. For page
+  // modes the step is chosen by comparing against the *rendered* scale, so
+  // that stepping away from "auto" lands on a neighbouring percentage rather
+  // than on a fixed index.
+  describe("page modes", () => {
+    const modes: ViewerMode[] = ["document", "annotating", "redacting", "text"];
+
+    it("steps to the neighbouring levels of the current scale", () => {
+      modes.forEach((mode) => {
+        expect(getZoomInOut(mode, 1, 1)).toEqual([0.75, 1.25]);
+        expect(getZoomInOut(mode, 0.75, 0.75)).toEqual([0.5, 1]);
+        expect(getZoomInOut(mode, 1.5, 1.5)).toEqual([1.25, 2]);
+      });
+    });
+
+    it("returns null at the bottom and top of the range", () => {
+      modes.forEach((mode) => {
+        // nothing below 50%
+        expect(getZoomInOut(mode, 0.5, 0.5)).toEqual([null, 0.75]);
+        // nothing above 200%
+        expect(getZoomInOut(mode, 2, 2)).toEqual([1.5, null]);
+      });
+    });
+
+    it("uses the computed scale, not the literal zoom, for 'auto'", () => {
+      // "auto" is not a number, so the neighbours come from the scale it
+      // resolved to — a document rendered at 42% steps up to 50%.
+      expect(getZoomInOut("document", "auto", 0.42)).toEqual([null, 0.5]);
+      expect(getZoomInOut("document", "auto", 0.8)).toEqual([0.75, 1]);
+      expect(getZoomInOut("document", "auto", 1)).toEqual([0.75, 1.25]);
+    });
+
+    it("never offers 'auto' itself as a step", () => {
+      // "auto" is in the zoom levels list but must be skipped when stepping,
+      // since comparing a string to a number is never true.
+      const steps = [0.42, 0.5, 1, 2].flatMap((scale) =>
+        getZoomInOut("document", "auto", scale),
+      );
+      expect(steps).not.toContain("auto");
+    });
+
+    it("snaps to the surrounding levels for an off-grid scale", () => {
+      expect(getZoomInOut("document", 1.1, 1.1)).toEqual([1, 1.25]);
+    });
+  });
+
+  describe("grid mode", () => {
+    it("steps through the size presets by index", () => {
+      expect(getZoomInOut("grid", "small", 1)).toEqual(["thumbnail", "normal"]);
+      expect(getZoomInOut("grid", "normal", 1)).toEqual(["small", "large"]);
+    });
+
+    it("returns null at each end of the presets", () => {
+      expect(getZoomInOut("grid", "thumbnail", 1)).toEqual([null, "small"]);
+      expect(getZoomInOut("grid", "large", 1)).toEqual(["normal", null]);
+    });
+  });
+
+  it("returns no steps in notes mode, which has no zoom levels", () => {
+    expect(getZoomInOut("notes", 1, 1)).toEqual([null, null]);
   });
 });
 

--- a/src/lib/utils/viewer.ts
+++ b/src/lib/utils/viewer.ts
@@ -23,6 +23,11 @@ interface ViewerHrefOptions {
   query?: string;
 }
 
+/**
+ * Multiplier to convert PDF points (1/72 inch) to CSS pixels (1/96 inch)
+ */
+export const PT_TO_PX = 96 / 72;
+
 export function getViewerHref(options: ViewerHrefOptions = {}) {
   const {
     document,
@@ -90,7 +95,8 @@ export function pageSizes(pageSpec: string): [width: number, height: number][] {
   const parts = pageSpec.split(";");
   return parts.reduce((sizes, part) => {
     const [size, range] = part?.split(":");
-    const [width, height] = size?.split("x").map(parseFloat) ?? [];
+    const [width, height] =
+      size?.split("x").map((d) => parseFloat(d) * PT_TO_PX) ?? [];
 
     range?.split(",").forEach((rangePart) => {
       if (rangePart.includes("-")) {

--- a/src/lib/utils/viewer.ts
+++ b/src/lib/utils/viewer.ts
@@ -56,6 +56,28 @@ export function getViewerHref(options: ViewerHrefOptions = {}) {
 }
 
 /**
+ * Return a numeric scale based on intrinsic page size and container size
+ * @param width Original document width
+ * @param height Original document height
+ * @param container
+ * @param scale
+ */
+export function fitPage(
+  width: number,
+  height: number,
+  container: HTMLElement | undefined,
+  scale: number | "width" | "height",
+): number {
+  if (typeof scale === "number") return scale;
+  if (!container) return 1;
+
+  // const [x1, y1, width, height] = page.view;
+  const { clientWidth, clientHeight } = container;
+
+  return scale === "width" ? clientWidth / width : clientHeight / height;
+}
+
+/**
  * Parse page_spec into width and height of each page
  *
  * @param pageSpec A string encoding page dimensions in a compact format
@@ -118,6 +140,15 @@ export function sortedSections(document: Document): Section[] {
   return [...(document.sections ?? [])].sort(
     (a, b) => a.page_number - b.page_number,
   );
+}
+
+// for typescript
+export function zoomToScale(zoom: any): number | "width" | "height" {
+  if (zoom === "width" || zoom === "height") {
+    return zoom;
+  }
+
+  return +zoom || 1;
 }
 
 export function zoomToSize(zoom: any): Sizes {
@@ -220,7 +251,7 @@ export function getInitialZoom(url: Maybe<URL>, mode: ViewerMode): Maybe<Zoom> {
 export function getZoomInOut(
   mode: ViewerMode,
   zoom: Zoom,
-  autoZoomScale: number,
+  scale: number,
 ): [Nullable<Zoom>, Nullable<Zoom>] {
   const zoomValues = getZoomLevels(mode).map(([value]) => value);
 
@@ -235,9 +266,8 @@ export function getZoomInOut(
     // Other modes use numeric zoom levels.
     // If zoom is 'auto', use the calculated auto zoom scale.
     // Otherwise, use the numeric value of zoom.
-    const zoomLevel = zoom === "auto" ? autoZoomScale : (zoom as number);
-    zoomOut = (zoomValues as number[]).findLast((val) => val < zoomLevel);
-    zoomIn = (zoomValues as number[]).find((val) => val > zoomLevel);
+    zoomOut = (zoomValues as number[]).findLast((val) => val < scale);
+    zoomIn = (zoomValues as number[]).find((val) => val > scale);
   }
 
   return [zoomOut || null, zoomIn || null];

--- a/src/lib/utils/viewer.ts
+++ b/src/lib/utils/viewer.ts
@@ -2,6 +2,7 @@ import type {
   Document,
   Maybe,
   Note,
+  Nullable,
   Section,
   Sizes,
   ViewerMode,
@@ -214,4 +215,30 @@ export function getInitialZoom(url: Maybe<URL>, mode: ViewerMode): Maybe<Zoom> {
 
   // fallback
   return undefined;
+}
+
+export function getZoomInOut(
+  mode: ViewerMode,
+  zoom: Zoom,
+  autoZoomScale: number,
+): [Nullable<Zoom>, Nullable<Zoom>] {
+  const zoomValues = getZoomLevels(mode).map(([value]) => value);
+
+  let zoomOut: Maybe<Zoom>, zoomIn: Maybe<Zoom>;
+
+  // If the viewer is in grid mode, look up the string index
+  if (mode === "grid") {
+    const index = zoomValues.indexOf(zoom as Sizes);
+    zoomOut = zoomValues[index - 1];
+    zoomIn = zoomValues[index + 1];
+  } else {
+    // Other modes use numeric zoom levels.
+    // If zoom is 'auto', use the calculated auto zoom scale.
+    // Otherwise, use the numeric value of zoom.
+    const zoomLevel = zoom === "auto" ? autoZoomScale : (zoom as number);
+    zoomOut = (zoomValues as number[]).findLast((val) => val < zoomLevel);
+    zoomIn = (zoomValues as number[]).find((val) => val > zoomLevel);
+  }
+
+  return [zoomOut || null, zoomIn || null];
 }

--- a/src/lib/utils/viewer.ts
+++ b/src/lib/utils/viewer.ts
@@ -55,28 +55,6 @@ export function getViewerHref(options: ViewerHrefOptions = {}) {
 }
 
 /**
- * Return a numeric scale based on intrinsic page size and container size
- * @param width Original document width
- * @param height Original document height
- * @param container
- * @param scale
- */
-export function fitPage(
-  width: number,
-  height: number,
-  container: HTMLElement | undefined,
-  scale: number | "width" | "height",
-): number {
-  if (typeof scale === "number") return scale;
-  if (!container) return 1;
-
-  // const [x1, y1, width, height] = page.view;
-  const { clientWidth, clientHeight } = container;
-
-  return scale === "width" ? clientWidth / width : clientHeight / height;
-}
-
-/**
  * Parse page_spec into width and height of each page
  *
  * @param pageSpec A string encoding page dimensions in a compact format
@@ -141,15 +119,6 @@ export function sortedSections(document: Document): Section[] {
   );
 }
 
-// for typescript
-export function zoomToScale(zoom: any): number | "width" | "height" {
-  if (zoom === "width" || zoom === "height") {
-    return zoom;
-  }
-
-  return +zoom || 1;
-}
-
 export function zoomToSize(zoom: any): Sizes {
   if (IMAGE_WIDTHS_MAP.has(zoom)) {
     return zoom;
@@ -165,13 +134,13 @@ export function zoomToSize(zoom: any): Sizes {
 export function getDefaultZoom(mode: ViewerMode): Zoom {
   switch (mode) {
     case "document":
-      return "width";
+      return "auto";
 
     case "annotating":
-      return "width";
+      return "auto";
 
     case "redacting":
-      return "width";
+      return "auto";
 
     case "grid":
       return "small";
@@ -190,8 +159,7 @@ export function getZoomLevels(mode: ViewerMode): ZoomLevels {
     case "annotating":
     case "redacting":
       return [
-        ["width", "zoom.fitWidth"],
-        ["height", "zoom.fitHeight"],
+        ["auto", "zoom.auto"],
         [0.5, "50%"],
         [0.75, "75%"],
         [1, "100%"],

--- a/src/lib/utils/viewer.ts
+++ b/src/lib/utils/viewer.ts
@@ -270,5 +270,5 @@ export function getZoomInOut(
     zoomIn = (zoomValues as number[]).find((val) => val > scale);
   }
 
-  return [zoomOut || null, zoomIn || null];
+  return [zoomOut ?? null, zoomIn ?? null];
 }

--- a/src/style/kit.css
+++ b/src/style/kit.css
@@ -237,6 +237,26 @@ hr.divider {
   }
 }
 
+/* Horizontal pinning for sticky UI inside of PDF viewer */
+@keyframes pin-x {
+  to {
+    translate: var(--scroll-range, 0px) 0;
+  }
+}
+
+@supports (animation-timeline: scroll()) {
+  .pin-x {
+    animation: pin-x linear both;
+    animation-timeline: scroll(nearest inline);
+  }
+}
+
+/* Fallback for browsers that don't support animation-timeline */
+.pin-x {
+  max-width: var(--pin-width, none);
+  translate: var(--scroll-left, 0px) 0;
+}
+
 /* svelecte styles */
 .svelecte .indicator {
   fill: var(--gray-5, #233944);

--- a/tests/viewer-deep-link.spec.ts
+++ b/tests/viewer-deep-link.spec.ts
@@ -87,15 +87,19 @@ test.describe("deep linking to a page", () => {
     page,
     multiPageDoc,
   }) => {
-    // Sample `.pages` spacing every frame. Any change means pages were laid out
+    // Sample the page spacing every frame. Any change means pages were laid out
     // at one size and then resized — which moves every page below the change.
+    // Padding is on the scroll container (`.pages`) and the gap is on the flex
+    // column inside it (`.inner`), so both have to be read.
     await page.addInitScript(() => {
       const seen: string[] = ((window as any).__spacing = []);
       (function sample() {
         requestAnimationFrame(sample);
         const pages = document.querySelector(".pages");
-        if (!pages) return;
-        const { paddingLeft, rowGap } = getComputedStyle(pages);
+        const inner = pages?.querySelector(".inner");
+        if (!pages || !inner) return;
+        const { paddingLeft } = getComputedStyle(pages);
+        const { rowGap } = getComputedStyle(inner);
         const spacing = `${paddingLeft}/${rowGap}`;
         if (seen.at(-1) !== spacing) seen.push(spacing);
       })();
@@ -162,9 +166,9 @@ test.describe("deep linking on a wide screen", () => {
 });
 
 test.describe("deep linking at a numeric zoom", () => {
-  // Fit-width is the default, and it sizes pages in CSS. A numeric zoom sizes
-  // them from the page dimensions instead, which is where the two could — and
-  // did — disagree about how big a page is.
+  // "auto" is the default: the viewer measures its own width and derives one
+  // scale for the whole document. An explicit `?zoom=` pins that scale instead,
+  // so these cover the other side of the branch that sizes a page.
   test.use({ viewport: { width: 1280, height: 900 } });
 
   for (const zoom of ["0.5", "2"]) {


### PR DESCRIPTION
Closes #1084 and #1389. Introduces a new default zoom mode for documents, `Auto`, and zoom in/zoom out buttons to step between zoom levels.

Key changes:
- `Auto` zoom mode is added as the new default. This mode sizes the document so that its widest page fills 100% of the viewer. When the viewer width changes (from a window resize or toggling a sidebar), the zoom level changes too.
- `Fit width` and `Fit height` zoom modes are removed. Both of these sized pages individually to fill the viewer; removing them means that every page of the document is presented at a uniform zoom level.
- Zoom in and zoom out buttons accompany the zoom level select menu. These step through the same preset values available in the menu, in any mode. When auto zoom is active, the buttons will snap to the next lowest or highest preset zoom level.
- Also fixed #1389, where a page's text layer content was duplicated rather than replaced on re-rendering.

Update:
- Adds a compact mobile toolbar layout that removes the zoom select menu, the word "Page" from the pagination controls, and the label from the sections menu. Also adds an "auto zoom" button, though this might be unclear/unnecessary.
<img width="414" height="42" alt="image" src="https://github.com/user-attachments/assets/4e265cb9-2c3e-4b81-a892-c7a55d5746dc" />

- ~Implements pinch-to-zoom on mobile devices~
- Viewer UIs (section headers, page numbers/actions/notes, and annotations) are horizontally sticky in the viewport when the document overflows.
<img width="410" height="809" alt="image" src="https://github.com/user-attachments/assets/d5d9fd87-9d89-47f9-9e57-f45df6d08b4c" />
