### PR TITLE
Only show username if document.organization is an individual org

### DIFF
--- a/src/lib/api/accounts.ts
+++ b/src/lib/api/accounts.ts
@@ -8,7 +8,7 @@ import {
   MAX_PER_PAGE,
   SQUARELET_BASE,
 } from "@/config/config.js";
-import { getAll, getApiResponse } from "../utils";
+import { getAll, getApiResponse } from "../utils/api";
 
 /** Get the logged-in user */
 export async function getMe(fetch = globalThis.fetch): Promise<Maybe<User>> {

--- a/src/lib/api/documents.ts
+++ b/src/lib/api/documents.ts
@@ -25,7 +25,7 @@ import type {
 } from "./types";
 
 import { writable, type Writable } from "svelte/store";
-import { getUserName, isOrg } from "./accounts";
+import { getUserName, isOrg, isUser } from "./accounts";
 import {
   APP_URL,
   BASE_API_URL,
@@ -701,13 +701,22 @@ export function pdfUrl(document: Document): URL {
  * @export
  */
 export function userOrgString(document: Document): string {
+  // we have a user and an individual org
+  if (
+    isOrg(document.organization) &&
+    isUser(document.user) &&
+    document.organization.individual
+  ) {
+    return getUserName(document.user);
+  }
+
   // we have an org and user
-  if (isOrg(document.organization) && typeof document.user === "object") {
+  if (isOrg(document.organization) && isUser(document.user)) {
     return `${getUserName(document.user)} (${document.organization.name})`;
   }
 
   // just a user
-  if (typeof document.user === "object") {
+  if (isUser(document.user)) {
     return getUserName(document.user);
   }
 

--- a/src/lib/components/documents/stories/Metadata.stories.svelte
+++ b/src/lib/components/documents/stories/Metadata.stories.svelte
@@ -1,7 +1,8 @@
 <script module lang="ts">
+  import type { Document, Org } from "$lib/api/types";
   import { defineMeta } from "@storybook/addon-svelte-csf";
+
   import MetadataComponent from "../Metadata.svelte";
-  import type { Document } from "$lib/api/types";
 
   import doc from "@/test/fixtures/documents/document-expanded.json";
   const document = doc as Document;
@@ -22,9 +23,26 @@
         "https://www.nytimes.com/live/2024/12/10/nyregion/unitedhealthcare-ceo-luigi-mangione",
     },
   };
+
+  const individual: Document = {
+    ...document,
+    organization: {
+      ...(document.organization as Org),
+      individual: true,
+    },
+  };
 </script>
 
 <Story name="Metadata" {args} />
+
+<Story
+  name="Individual org"
+  args={{
+    ...args,
+    document: individual,
+  }}
+/>
+
 <Story
   name="Signed out"
   {args}

--- a/src/lib/components/embeds/DocumentEmbed.svelte
+++ b/src/lib/components/embeds/DocumentEmbed.svelte
@@ -12,7 +12,7 @@
 
   import { defaultSettings, type EmbedSettings } from "$lib/utils/embed";
   import { getUserName, isOrg, isUser } from "$lib/api/accounts";
-  import { canonicalUrl } from "$lib/api/documents";
+  import { canonicalUrl, userOrgString } from "$lib/api/documents";
   import { getViewerState } from "$lib/state/viewer.svelte";
 
   interface Props {
@@ -30,13 +30,12 @@
 
   let document = $derived(viewer.document!);
 
-  let user = $derived(
-    isUser(document.user) ? getUserName(document.user) : undefined,
-  );
   let org = $derived(
     isOrg(document.organization) ? document.organization.name : undefined,
   );
-  let contributedBy = $derived(settings.onlyshoworg ? org : `${user} (${org})`);
+  let contributedBy = $derived(
+    settings.onlyshoworg ? org : userOrgString(document),
+  );
 </script>
 
 <div class="container">


### PR DESCRIPTION
Closes #873 

Does what it says on the tin.
<img width="434" height="339" alt="Screenshot 2026-08-17 at 12 35 17 PM" src="https://github.com/user-attachments/assets/1df0cfc3-420a-43a8-990b-dcbeb84b3110" />

Live example: https://preview-1392.staging.documentcloud.org/documents/20011000-english-20250408-roslindale-square-zoning-one-pager-2/