### PR TITLE
Create projects from within the upload form

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,9 +27,6 @@ jobs:
     steps:
       - uses: nev7n/wait_for_response@v1.2.0
         with:
-          # `/` redirects (307) to `/home/`; poll the page that returns 200.
-          # The preview deploy runs in parallel, so allow time for it to finish
-          # and for the Cloudflare custom domain to come up.
           url: ${{ env.URL }}/home/
           responseCode: "200"
           timeout: 300000
@@ -85,11 +82,18 @@ jobs:
               "${DC_API_URL}/accounts/login/squarelet"
           )"
           echo "Login chain ended at HTTP ${status}: ${final}"
-          grep -i '^cf-ray:' "$headers" | tr -d '\r' || true
+
+          # One header block per hop, so the last CF-Ray belongs to the final
+          # (challenged) response. Earlier hops are other zones, and looking
+          # those up finds their own unrelated events.
+          rays="$(grep -i '^cf-ray:' "$headers" | tr -d '\r' | awk '{print $2}')"
+          echo "CF-Ray per hop: $(echo "$rays" | tr '\n' ' ')"
+          final_ray="$(echo "$rays" | tail -1)"
+          final_ray="${final_ray:-unknown}"
 
           # Fail if we hit a bot challenge
           if grep -qiE 'challenge-platform|Performing security verification|Just a moment' "$body"; then
-            echo "::error::Cloudflare is serving a bot challenge at ${final}, so the Playwright auth setup cannot log in. Ask infra for a WAF skip rule covering this runner (quote the CF-Ray above)."
+            echo "::error::Cloudflare is serving a bot challenge at ${final}, so the Playwright auth setup cannot log in. Look up CF-Ray ${final_ray} in the zone serving that host (not the earlier hops) to find what acted."
             exit 1
           fi
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -93,14 +93,15 @@ jobs:
           final_ray="$(echo "$rays" | tail -1 | cut -d- -f1)"
           final_ray="${final_ray:-unknown}"
 
-          # Fail if we hit a bot challenge
-          if grep -qiE 'challenge-platform|Performing security verification|Just a moment' "$body"; then
-            echo "::error::Cloudflare is serving a bot challenge at ${final}, so the Playwright auth setup cannot log in. Look up CF-Ray ${final_ray} in the zone serving that host (not the earlier hops) to find what acted."
-            exit 1
-          fi
-
+          # Interstitials answer 403 or 503, never 200 — and a served page carries
+          # an injected `challenge-platform/scripts/jsd` tag whenever JavaScript
+          # Detections is on, so body markers alone flag a healthy login page.
           if [ "$status" != "200" ]; then
-            echo "::error::Expected the Squarelet login page (HTTP 200); got HTTP ${status} at ${final}."
+            if grep -qiE 'challenge-platform/h/|Performing security verification|Just a moment' "$body"; then
+              echo "::error::Cloudflare is serving a bot challenge at ${final}, so the Playwright auth setup cannot log in. Look up CF-Ray ${final_ray} in the zone serving that host (not the earlier hops) to find what acted."
+            else
+              echo "::error::Expected the Squarelet login page (HTTP 200); got HTTP ${status} at ${final}."
+            fi
             exit 1
           fi
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -134,11 +134,12 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
+      # Bail out after three failures.
       - name: Run Playwright tests
-        run: npm run test:e2e
+        run: npm run test:e2e -- --max-failures=3
 
       - name: Upload report
-        if: ${{ failure() }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -88,7 +88,9 @@ jobs:
           # those up finds their own unrelated events.
           rays="$(grep -i '^cf-ray:' "$headers" | tr -d '\r' | awk '{print $2}')"
           echo "CF-Ray per hop: $(echo "$rays" | tr '\n' ' ')"
-          final_ray="$(echo "$rays" | tail -1)"
+          # Strip the `-IAD` colo suffix: dashboard and GraphQL `rayName`
+          # lookups match the bare 16-character ray only.
+          final_ray="$(echo "$rays" | tail -1 | cut -d- -f1)"
           final_ray="${final_ray:-unknown}"
 
           # Fail if we hit a bot challenge

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -61,17 +61,47 @@ jobs:
             --write-out 'Squarelet responded: HTTP %{http_code} in %{time_total}s\n' \
             "${{ secrets.SQUARELET_STAGING_URL }}"
 
-      - name: Verify staging API login is not blocked by Cloudflare
+      - name: Verify the Squarelet login page is not blocked by Cloudflare
+        env:
+          # Approximates Playwright's UA, so a UA-based skip rule is tested too.
+          LOGIN_CHECK_USER_AGENT: >-
+            Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36
+            (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36
+            DocumentCloud-E2E (+https://github.com/MuckRock/documentcloud-frontend)
         run: |
-          # The auth flow starts here, then redirects to Squarelet. A normal
-          # response is a 3xx redirect; a Cloudflare WAF block is a 403. Don't
-          # follow redirects (-L would chase off to Squarelet); --fail turns a
-          # 403/block into a clear, fast failure before Playwright runs.
-          curl --fail --show-error --silent \
-            --retry 5 --retry-delay 5 --retry-all-errors \
-            --output /dev/null \
-            --write-out 'API login responded: HTTP %{http_code} in %{time_total}s\n' \
-            "${DC_API_URL}/accounts/login/squarelet"
+          # Follow the whole chain (api -> `/openid/authorize` -> `/accounts/login/`):
+          # The OIDC hops set state cookies.
+          headers="$(mktemp)"
+          body="$(mktemp)"
+          jar="$(mktemp)"
+          read -r status final <<<"$(
+            curl --silent --show-error --location \
+              --retry 3 --retry-delay 5 \
+              --cookie-jar "$jar" --cookie "$jar" \
+              --user-agent "$LOGIN_CHECK_USER_AGENT" \
+              --dump-header "$headers" --output "$body" \
+              --write-out '%{http_code} %{url_effective}' \
+              --get --data-urlencode "next=${URL}" \
+              "${DC_API_URL}/accounts/login/squarelet"
+          )"
+          echo "Login chain ended at HTTP ${status}: ${final}"
+          grep -i '^cf-ray:' "$headers" | tr -d '\r' || true
+
+          # Fail if we hit a bot challenge
+          if grep -qiE 'challenge-platform|Performing security verification|Just a moment' "$body"; then
+            echo "::error::Cloudflare is serving a bot challenge at ${final}, so the Playwright auth setup cannot log in. Ask infra for a WAF skip rule covering this runner (quote the CF-Ray above)."
+            exit 1
+          fi
+
+          if [ "$status" != "200" ]; then
+            echo "::error::Expected the Squarelet login page (HTTP 200); got HTTP ${status} at ${final}."
+            exit 1
+          fi
+
+          # Warn if the login form is missing
+          if ! grep -q 'name="login"' "$body"; then
+            echo "::warning::Reached the login page but found no input[name=login]; if the auth setup fails, check whether Squarelet's markup changed."
+          fi
 
       - name: Install dependencies
         run: npm ci

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To run the dev server locally against the staging API, take the following steps:
    npm run dev:remote
    ```
 
-Now, you should have a dev server accessible at `https://local.staging.documentcloud.org:5173` that connects to the staging DocumentCloud API (https://api.staging.documentcloud.org) and staging authentication service (https://squarelet-staging.herokuapp.com).
+Now, you should have a dev server accessible at `https://local.staging.documentcloud.org:5173` that connects to the staging DocumentCloud API (https://api.staging.documentcloud.org) and staging authentication service (https://staging-accounts.muckrock.com).
 
 ## Building for production
 

--- a/src/config/remote.js
+++ b/src/config/remote.js
@@ -1,6 +1,6 @@
 export const DC_BASE = "https://api.staging.documentcloud.org";
 export const APP_URL = "https://local.staging.documentcloud.org:5173";
 export const EMBED_URL = APP_URL;
-export const SQUARELET_BASE = "https://squarelet-staging.herokuapp.com";
+export const SQUARELET_BASE = "https://staging-accounts.muckrock.com";
 export const STAFF_ONLY_S3_URL =
   "https://s3.console.aws.amazon.com/s3/buckets/documentcloud-staging-files?region=us-east-1&prefix=documents/$$ID$$/&showversions=false";

--- a/src/config/staging.js
+++ b/src/config/staging.js
@@ -2,6 +2,6 @@ export const DC_BASE = "https://api.staging.documentcloud.org";
 export const APP_URL =
   process.env.APP_URL || "https://www.staging.documentcloud.org";
 export const EMBED_URL = APP_URL;
-export const SQUARELET_BASE = "https://squarelet-staging.herokuapp.com";
+export const SQUARELET_BASE = "https://staging-accounts.muckrock.com";
 export const STAFF_ONLY_S3_URL =
   "https://s3.console.aws.amazon.com/s3/buckets/documentcloud-staging-files?region=us-east-1&prefix=documents/$$ID$$/&showversions=false";

--- a/src/lib/components/forms/Upload.svelte
+++ b/src/lib/components/forms/Upload.svelte
@@ -59,8 +59,12 @@ progress through the three-part upload process.
   import Dropzone from "../inputs/Dropzone.svelte";
   import FileInput from "../inputs/File.svelte";
   import Language from "../inputs/Language.svelte";
-  import Select from "../inputs/Select.svelte";
+  import Select, { type CreateHandler } from "../inputs/Select.svelte";
   import Switch from "../inputs/Switch.svelte";
+
+  import Portal from "$lib/components/layouts/Portal.svelte";
+  import Modal from "$lib/components/layouts/Modal.svelte";
+  import EditProject from "$lib/components/forms/EditProject.svelte";
 
   import UploadListItem, { type UploadStatus } from "./UploadListItem.svelte";
 
@@ -128,6 +132,25 @@ progress through the three-part upload process.
   let add_to_projects: Project[] = $state(
     [getProjectToUpload()].filter(Boolean) as Project[],
   );
+
+  let newProjectTitle = $state<string>("");
+  let createProjectPromise = $state<PromiseWithResolvers<Project>>();
+
+  const createProjectHandler: CreateHandler = ({ inputValue }) => {
+    newProjectTitle = inputValue;
+    createProjectPromise = Promise.withResolvers<Project>();
+    return createProjectPromise.promise;
+  };
+
+  const onProjectCreated = (project: Project) => {
+    createProjectPromise?.resolve(project);
+    createProjectPromise = undefined;
+  };
+
+  const onProjectCancel = () => {
+    createProjectPromise?.reject(new Error("cancelled"));
+    createProjectPromise = undefined;
+  };
 
   onMount(() => {
     if (!csrf_token) {
@@ -397,6 +420,8 @@ progress through the three-part upload process.
               labelField="title"
               bind:value={add_to_projects}
               valueAsObject
+              creatable
+              createHandler={createProjectHandler}
             />
           </Field>
           <hr class="divider" />
@@ -451,6 +476,21 @@ progress through the three-part upload process.
     </Flex>
   </form>
 </Dropzone>
+
+{#if createProjectPromise}
+  <Portal>
+    <Modal onclose={onProjectCancel}>
+      {#snippet title()}
+        <h1>{$_("projects.create")}</h1>
+      {/snippet}
+      <EditProject
+        project={{ title: newProjectTitle }}
+        onsuccess={onProjectCreated}
+        onclose={onProjectCancel}
+      />
+    </Modal>
+  </Portal>
+{/if}
 
 <style>
   header {

--- a/src/lib/components/inputs/Select.svelte
+++ b/src/lib/components/inputs/Select.svelte
@@ -21,6 +21,8 @@ Wrapper for Svelecte: https://github.com/mskocik/svelecte
     disabled?: boolean;
   }
 
+  export type CreateHandler = Props["createHandler"];
+
   let {
     name,
     value = $bindable(null),

--- a/tests/README.md
+++ b/tests/README.md
@@ -46,6 +46,12 @@ DC_TEST_PASSWORD=...
 
 If these are unset, the auth setup is skipped and authenticated tests don't run. The Squarelet login selectors in `auth.setup.ts` may need adjusting if Squarelet's markup changes.
 
+### In CI: a Cloudflare challenge on the login page looks like a selector bug
+
+Staging Squarelet (`staging-accounts.muckrock.com`) sits behind Cloudflare. When its bot protection challenges the runner, `/accounts/login/` answers 403 with an interstitial ("Performing security verification") that headless Chromium can't clear — so the auth setup fails 30s later on `waiting for locator('input[name=login]')`, as if the selector were wrong. Only the aria snapshot in `error-context.md` (or the trace's network list) shows the real cause.
+
+The workflow's "Verify the Squarelet login page is not blocked by Cloudflare" step walks the whole redirect chain (api → `/openid/authorize` → `/accounts/login/`) before Playwright runs and names this failure directly, with the CF-Ray to quote to infra. Checking only the first hop doesn't catch it: that hop returns its 302 normally. The fix is a WAF skip rule for the runner, not a change here.
+
 ## Fixtures
 
 `fixtures/` holds sample PDFs for use in tests (e.g. file-upload flows). Prefer a small file (`Small pdf.pdf`) so processing finishes quickly.


### PR DESCRIPTION
Closes #832. The project picker select in the upload form is now `creatable` and triggers an `EditProject` modal.

<img width="329" height="125" alt="image" src="https://github.com/user-attachments/assets/d7fa3e08-7ad4-4e4d-a6b0-dd3d641c808e" />

I didn't add test coverage for this flow — the project creation logic all comes from `EditProject`, which also doesn't have unit tests, and it seems like we generally don't have a solution for testing forms that use SvelteKit's `use:enhance`.