### PR TITLE
Remove document-info row wrap

### DIFF
--- a/src/lib/components/documents/DocumentListItem.svelte
+++ b/src/lib/components/documents/DocumentListItem.svelte
@@ -286,5 +286,6 @@ If we're in an embed, we want to open links to documents in new tabs and hide th
     gap: 0.25rem;
     max-width: 100%;
     overflow-x: auto;
+    flex: 1 1 100%;
   }
 </style>


### PR DESCRIPTION
Closes #1373. I can't see any situation where wrapping would be desirable here, but let me know if I missed something!